### PR TITLE
Fix README namespace imports for Quick Start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ Create `src/CalculatorElements.php`:
 
 namespace App;
 
-use PhpMcp\Server\Attributes\McpTool;
-use PhpMcp\Server\Attributes\Schema;
+use Mcp\Capability\Attribute\McpTool;
 
 class CalculatorElements
 {


### PR DESCRIPTION
## Motivation and Context
The README's Quick Start example contained incorrect namespace and import paths that didn't match the actual codebase structure.

## Solution
- Updated `use PhpMcp\Server\Attributes\McpTool;` to `use Mcp\Capability\Attribute\McpTool;`
- Removed unused `Schema` import

