### PR TITLE
Remove unused development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,6 @@
         "phpunit/phpunit": "^10.5",
         "psr/cache": "^3.0",
         "symfony/console": "^6.4 || ^7.0",
-        "symfony/dependency-injection": "^6.4 || ^7.0",
-        "symfony/event-dispatcher": "^6.4 || ^7.0",
         "symfony/process": "^6.4 || ^7.0"
     },
     "suggest": {


### PR DESCRIPTION
Remove symfony/dependency-injection and symfony/event-dispatcher from require-dev as they are not used in the codebase. The project uses psr/event-dispatcher interface instead of Symfony's implementation.