### PR TITLE
BugFix - Pagination of List requests

### DIFF
--- a/src/Capability/Registry.php
+++ b/src/Capability/Registry.php
@@ -22,6 +22,7 @@ use Mcp\Event\ResourceListChangedEvent;
 use Mcp\Event\ResourceTemplateListChangedEvent;
 use Mcp\Event\ToolListChangedEvent;
 use Mcp\Exception\InvalidArgumentException;
+use Mcp\Exception\InvalidCursorException;
 use Mcp\Schema\Content\PromptMessage;
 use Mcp\Schema\Content\ResourceContents;
 use Mcp\Schema\Prompt;
@@ -306,30 +307,137 @@ class Registry
     /**
      * @return array<string, Tool>
      */
-    public function getTools(): array
+    public function getTools(?int $limit = null, ?string $cursor = null): array
     {
-        return array_map(fn (ToolReference $tool) => $tool->tool, $this->tools);
+        $tools = [];
+        foreach ($this->tools as $toolReference) {
+            $tools[] = $toolReference->tool;
+        }
+        
+        if ($limit === null) {
+            return $tools;
+        }
+        
+        return $this->paginateResults($tools, $limit, $cursor);
     }
 
     /**
      * @return array<string, resource>
      */
-    public function getResources(): array
+    public function getResources(?int $limit = null, ?string $cursor = null): array
     {
-        return array_map(fn (ResourceReference $resource) => $resource->schema, $this->resources);
+        $resources = [];
+        foreach ($this->resources as $resource) {
+            $resources[] = $resource->schema;
+        }
+        
+        if ($limit === null) {
+            return $resources;
+        }
+        
+        return $this->paginateResults($resources, $limit, $cursor);
     }
 
     /**
      * @return array<string, Prompt>
      */
-    public function getPrompts(): array
+    public function getPrompts(?int $limit = null, ?string $cursor = null): array
     {
-        return array_map(fn (PromptReference $prompt) => $prompt->prompt, $this->prompts);
+        $prompts = [];
+        foreach ($this->prompts as $promptReference) {
+            $prompts[] = $promptReference->prompt;
+        }
+        
+        if ($limit === null) {
+            return $prompts;
+        }
+        
+        return $this->paginateResults($prompts, $limit, $cursor);
     }
 
-    /** @return array<string, ResourceTemplate> */
-    public function getResourceTemplates(): array
+    /**
+     * Get total count of tools.
+     */
+    public function getToolsCount(): int
     {
-        return array_map(fn ($template) => $template->resourceTemplate, $this->resourceTemplates);
+        return count($this->tools);
+    }
+
+    /**
+     * Get total count of prompts.
+     */
+    public function getPromptsCount(): int
+    {
+        return count($this->prompts);
+    }
+
+    /**
+     * Get total count of resources.
+     */
+    public function getResourcesCount(): int
+    {
+        return count($this->resources);
+    }
+
+    /** 
+     * @return array<string, ResourceTemplate> 
+     */
+    public function getResourceTemplates(?int $limit = null, ?string $cursor = null): array
+    {
+        $templates = array_map(fn ($template) => $template->resourceTemplate, $this->resourceTemplates);
+        
+        if ($limit === null) {
+            return $templates;
+        }
+        
+        return $this->paginateResults($templates, $limit, $cursor);
+    }
+
+    /**
+     * @throws InvalidCursorException
+     */
+    private function paginateResults(array $items, int $limit, ?string $cursor = null): array
+    {
+        $offset = 0;
+        if ($cursor !== null) {
+            $decodedCursor = base64_decode($cursor, true);
+
+            if ($decodedCursor === false || !is_numeric($decodedCursor)) {
+                throw new InvalidCursorException($cursor);
+            }
+            
+            $offset = $decodedCursor;
+            
+            // Validate offset is within reasonable bounds
+            if ($offset < 0 || $offset > count($items)) {
+                throw new InvalidCursorException($cursor);
+            }
+        }
+
+        return array_slice($items, $offset, $limit);
+    }
+
+    /**
+     * Calculate next cursor for pagination.
+     */
+    public function calculateNextCursor(int $totalCount, ?string $currentCursor, int $returnedCount): ?string
+    {
+        $currentOffset = 0;
+
+        if ($currentCursor !== null) {
+            $decodedCursor = base64_decode($currentCursor, true);
+            if ($decodedCursor !== false && is_numeric($decodedCursor)) {
+                $currentOffset = $decodedCursor;
+            }
+        }
+        
+        $nextOffset = $currentOffset + $returnedCount;
+        
+        // If we have more items available, return next cursor
+        if ($nextOffset < $totalCount) {
+            return base64_encode((string) $nextOffset);
+        }
+        
+        return null;
     }
 }

--- a/src/Server/RequestHandler/ListPromptsHandler.php
+++ b/src/Server/RequestHandler/ListPromptsHandler.php
@@ -27,8 +27,7 @@ final class ListPromptsHandler implements MethodHandlerInterface
     public function __construct(
         private readonly Registry $registry,
         private readonly int $pageSize = 20,
-    ) {
-    }
+    ) {}
 
     public function supports(HasMethodInterface $message): bool
     {

--- a/src/Server/RequestHandler/ListPromptsHandler.php
+++ b/src/Server/RequestHandler/ListPromptsHandler.php
@@ -12,6 +12,7 @@
 namespace Mcp\Server\RequestHandler;
 
 use Mcp\Capability\Registry;
+use Mcp\Exception\InvalidCursorException;
 use Mcp\Schema\JsonRpc\HasMethodInterface;
 use Mcp\Schema\JsonRpc\Response;
 use Mcp\Schema\Request\ListPromptsRequest;
@@ -34,6 +35,9 @@ final class ListPromptsHandler implements MethodHandlerInterface
         return $message instanceof ListPromptsRequest;
     }
 
+    /**
+     * @throws InvalidCursorException
+     */
     public function handle(ListPromptsRequest|HasMethodInterface $message): Response
     {
         \assert($message instanceof ListPromptsRequest);

--- a/src/Server/RequestHandler/ListPromptsHandler.php
+++ b/src/Server/RequestHandler/ListPromptsHandler.php
@@ -38,9 +38,13 @@ final class ListPromptsHandler implements MethodHandlerInterface
     {
         \assert($message instanceof ListPromptsRequest);
 
-        $cursor = null;
         $prompts = $this->registry->getPrompts($this->pageSize, $message->cursor);
-        $nextCursor = (null !== $cursor && \count($prompts) === $this->pageSize) ? $cursor : null;
+
+        $nextCursor = $this->registry->calculateNextCursor(
+            $this->registry->getPromptsCount(),
+            $message->cursor,
+            \count($prompts)
+        );
 
         return new Response(
             $message->getId(),

--- a/src/Server/RequestHandler/ListResourcesHandler.php
+++ b/src/Server/RequestHandler/ListResourcesHandler.php
@@ -38,9 +38,13 @@ final class ListResourcesHandler implements MethodHandlerInterface
     {
         \assert($message instanceof ListResourcesRequest);
 
-        $cursor = null;
         $resources = $this->registry->getResources($this->pageSize, $message->cursor);
-        $nextCursor = (null !== $cursor && \count($resources) === $this->pageSize) ? $cursor : null;
+
+        $nextCursor = $this->registry->calculateNextCursor(
+            $this->registry->getResourcesCount(),
+            $message->cursor,
+            \count($resources)
+        );
 
         return new Response(
             $message->getId(),

--- a/src/Server/RequestHandler/ListResourcesHandler.php
+++ b/src/Server/RequestHandler/ListResourcesHandler.php
@@ -12,9 +12,11 @@
 namespace Mcp\Server\RequestHandler;
 
 use Mcp\Capability\Registry;
+use Mcp\Exception\InvalidCursorException;
 use Mcp\Schema\JsonRpc\HasMethodInterface;
 use Mcp\Schema\JsonRpc\Response;
 use Mcp\Schema\Request\ListResourcesRequest;
+use Mcp\Schema\Resource;
 use Mcp\Schema\Result\ListResourcesResult;
 use Mcp\Server\MethodHandlerInterface;
 
@@ -34,6 +36,9 @@ final class ListResourcesHandler implements MethodHandlerInterface
         return $message instanceof ListResourcesRequest;
     }
 
+    /**
+     * @throws InvalidCursorException
+     */
     public function handle(ListResourcesRequest|HasMethodInterface $message): Response
     {
         \assert($message instanceof ListResourcesRequest);

--- a/src/Server/RequestHandler/ListResourcesHandler.php
+++ b/src/Server/RequestHandler/ListResourcesHandler.php
@@ -28,8 +28,7 @@ final class ListResourcesHandler implements MethodHandlerInterface
     public function __construct(
         private readonly Registry $registry,
         private readonly int $pageSize = 20,
-    ) {
-    }
+    ) {}
 
     public function supports(HasMethodInterface $message): bool
     {

--- a/src/Server/RequestHandler/ListToolsHandler.php
+++ b/src/Server/RequestHandler/ListToolsHandler.php
@@ -12,6 +12,7 @@
 namespace Mcp\Server\RequestHandler;
 
 use Mcp\Capability\Registry;
+use Mcp\Exception\InvalidCursorException;
 use Mcp\Schema\JsonRpc\HasMethodInterface;
 use Mcp\Schema\JsonRpc\Response;
 use Mcp\Schema\Request\ListToolsRequest;
@@ -27,21 +28,27 @@ final class ListToolsHandler implements MethodHandlerInterface
     public function __construct(
         private readonly Registry $registry,
         private readonly int $pageSize = 20,
-    ) {
-    }
+    ) {}
 
     public function supports(HasMethodInterface $message): bool
     {
         return $message instanceof ListToolsRequest;
     }
 
+    /**
+     * @throws InvalidCursorException When the cursor is invalid
+     */
     public function handle(ListToolsRequest|HasMethodInterface $message): Response
     {
         \assert($message instanceof ListToolsRequest);
 
-        $cursor = null;
         $tools = $this->registry->getTools($this->pageSize, $message->cursor);
-        $nextCursor = (null !== $cursor && \count($tools) === $this->pageSize) ? $cursor : null;
+
+        $nextCursor = $this->registry->calculateNextCursor(
+            $this->registry->getToolsCount(),
+            $message->cursor,
+            \count($tools)
+        );
 
         return new Response(
             $message->getId(),

--- a/tests/Server/RequestHandler/ListPromptsHandlerTest.php
+++ b/tests/Server/RequestHandler/ListPromptsHandlerTest.php
@@ -1,0 +1,219 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Server\RequestHandler;
+
+use Mcp\Capability\Registry;
+use Mcp\Exception\InvalidCursorException;
+use Mcp\Schema\Prompt;
+use Mcp\Schema\Request\ListPromptsRequest;
+use Mcp\Schema\Result\ListPromptsResult;
+use Mcp\Server\RequestHandler\ListPromptsHandler;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class ListPromptsHandlerTest extends TestCase
+{
+    private Registry $registry;
+    private ListPromptsHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->registry = new Registry();
+        $this->handler = new ListPromptsHandler($this->registry, pageSize: 3); // Use small page size for testing
+    }
+
+    #[TestDox('Returns first page when no cursor provided')]
+    public function testReturnsFirstPageWhenNoCursorProvided(): void
+    {
+        // Arrange
+        $this->addPromptsToRegistry(5);
+        $request = $this->createListPromptsRequest();
+
+        // Act
+        $response = $this->handler->handle($request);
+
+        // Assert
+        $this->assertInstanceOf(ListPromptsResult::class, $response->result);
+        $this->assertCount(3, $response->result->prompts);
+        $this->assertNotNull($response->result->nextCursor);
+
+        $this->assertEquals('prompt_0', $response->result->prompts[0]->name);
+        $this->assertEquals('prompt_1', $response->result->prompts[1]->name);
+        $this->assertEquals('prompt_2', $response->result->prompts[2]->name);
+    }
+
+    #[TestDox('Returns paginated prompts with cursor')]
+    public function testReturnsPaginatedPromptsWithCursor(): void
+    {
+        // Arrange
+        $this->addPromptsToRegistry(10);
+        $request = $this->createListPromptsRequest(cursor: null);
+
+        // Act
+        $response = $this->handler->handle($request);
+
+        // Assert
+        $this->assertInstanceOf(ListPromptsResult::class, $response->result);
+        $this->assertCount(3, $response->result->prompts);
+        $this->assertNotNull($response->result->nextCursor);
+
+        $this->assertEquals('prompt_0', $response->result->prompts[0]->name);
+        $this->assertEquals('prompt_1', $response->result->prompts[1]->name);
+        $this->assertEquals('prompt_2', $response->result->prompts[2]->name);
+    }
+
+    #[TestDox('Returns second page with cursor')]
+    public function testReturnsSecondPageWithCursor(): void
+    {
+        // Arrange
+        $this->addPromptsToRegistry(10);
+        $firstPageRequest = $this->createListPromptsRequest();
+        $firstPageResponse = $this->handler->handle($firstPageRequest);
+        
+        $secondPageRequest = $this->createListPromptsRequest(cursor: $firstPageResponse->result->nextCursor);
+
+        // Act
+        $response = $this->handler->handle($secondPageRequest);
+
+        // Assert
+        $this->assertInstanceOf(ListPromptsResult::class, $response->result);
+        $this->assertCount(3, $response->result->prompts);
+        $this->assertNotNull($response->result->nextCursor);
+
+        $this->assertEquals('prompt_3', $response->result->prompts[0]->name);
+        $this->assertEquals('prompt_4', $response->result->prompts[1]->name);
+        $this->assertEquals('prompt_5', $response->result->prompts[2]->name);
+    }
+
+    #[TestDox('Returns last page with null cursor')]
+    public function testReturnsLastPageWithNullCursor(): void
+    {
+        // Arrange
+        $this->addPromptsToRegistry(5);
+        $firstPageRequest = $this->createListPromptsRequest();
+        $firstPageResponse = $this->handler->handle($firstPageRequest);
+        
+        $secondPageRequest = $this->createListPromptsRequest(cursor: $firstPageResponse->result->nextCursor);
+
+        // Act
+        $response = $this->handler->handle($secondPageRequest);
+
+        // Assert
+        $this->assertInstanceOf(ListPromptsResult::class, $response->result);
+        $this->assertCount(2, $response->result->prompts);
+        $this->assertNull($response->result->nextCursor);
+
+        $this->assertEquals('prompt_3', $response->result->prompts[0]->name);
+        $this->assertEquals('prompt_4', $response->result->prompts[1]->name);
+    }
+
+    #[TestDox('Handles empty registry')]
+    public function testHandlesEmptyRegistry(): void
+    {
+        // Arrange
+        $request = $this->createListPromptsRequest();
+
+        // Act
+        $response = $this->handler->handle($request);
+
+        // Assert
+        $this->assertInstanceOf(ListPromptsResult::class, $response->result);
+        $this->assertCount(0, $response->result->prompts);
+        $this->assertNull($response->result->nextCursor);
+    }
+
+    #[TestDox('Throws exception for invalid cursor')]
+    public function testThrowsExceptionForInvalidCursor(): void
+    {
+        // Arrange
+        $this->addPromptsToRegistry(5);
+        $request = $this->createListPromptsRequest(cursor: 'invalid-cursor');
+
+        // Assert
+        $this->expectException(InvalidCursorException::class);
+
+        // Act
+        $this->handler->handle($request);
+    }
+
+    #[TestDox('Throws exception for cursor beyond bounds')]
+    public function testThrowsExceptionForCursorBeyondBounds(): void
+    {
+        // Arrange
+        $this->addPromptsToRegistry(5);
+        $outOfBoundsCursor = base64_encode('1000');
+        $request = $this->createListPromptsRequest(cursor: $outOfBoundsCursor);
+
+        // Assert
+        $this->expectException(InvalidCursorException::class);
+
+        // Act
+        $this->handler->handle($request);
+    }
+
+    #[TestDox('Handles cursor at exact boundary')]
+    public function testHandlesCursorAtExactBoundary(): void
+    {
+        // Arrange
+        $this->addPromptsToRegistry(6);
+        $exactBoundaryCursor = base64_encode('6');
+        $request = $this->createListPromptsRequest(cursor: $exactBoundaryCursor);
+
+        // Act
+        $response = $this->handler->handle($request);
+
+        // Assert
+        $this->assertInstanceOf(ListPromptsResult::class, $response->result);
+        $this->assertCount(0, $response->result->prompts);
+        $this->assertNull($response->result->nextCursor);
+    }
+
+    #[TestDox('Maintains stable cursors across calls')]
+    public function testMaintainsStableCursorsAcrossCalls(): void
+    {
+        // Arrange
+        $this->addPromptsToRegistry(10);
+        
+        // Act
+        $request = $this->createListPromptsRequest();
+        $response1 = $this->handler->handle($request);
+        $response2 = $this->handler->handle($request);
+
+        // Assert
+        $this->assertEquals($response1->result->nextCursor, $response2->result->nextCursor);
+        $this->assertEquals($response1->result->prompts, $response2->result->prompts);
+    }
+
+    private function addPromptsToRegistry(int $count): void
+    {
+        for ($i = 0; $i < $count; $i++) {
+            $prompt = new Prompt(
+                name: "prompt_$i",
+                description: "Test prompt $i"
+            );
+
+            $this->registry->registerPrompt($prompt, fn() => null);
+        }
+    }
+
+    private function createListPromptsRequest(?string $cursor = null): ListPromptsRequest
+    {
+        $listPromptsRequest = new ListPromptsRequest(cursor: $cursor);
+
+        $reflection = new ReflectionClass($listPromptsRequest);
+        $idProperty = $reflection->getProperty('id');
+        $idProperty->setValue($listPromptsRequest, 'test-request-id');
+        
+        return $listPromptsRequest;
+    }
+}

--- a/tests/Server/RequestHandler/ListPromptsHandlerTest.php
+++ b/tests/Server/RequestHandler/ListPromptsHandlerTest.php
@@ -19,7 +19,6 @@ use Mcp\Schema\Result\ListPromptsResult;
 use Mcp\Server\RequestHandler\ListPromptsHandler;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 
 class ListPromptsHandlerTest extends TestCase
 {
@@ -166,7 +165,7 @@ class ListPromptsHandlerTest extends TestCase
     {
         // Arrange
         $this->addPromptsToRegistry(6);
-        $exactBoundaryCursor = base64_encode('6');
+        $exactBoundaryCursor = base64_encode('6'); // Exactly at the end
         $request = $this->createListPromptsRequest(cursor: $exactBoundaryCursor);
 
         // Act
@@ -208,12 +207,13 @@ class ListPromptsHandlerTest extends TestCase
 
     private function createListPromptsRequest(?string $cursor = null): ListPromptsRequest
     {
-        $listPromptsRequest = new ListPromptsRequest(cursor: $cursor);
-
-        $reflection = new ReflectionClass($listPromptsRequest);
-        $idProperty = $reflection->getProperty('id');
-        $idProperty->setValue($listPromptsRequest, 'test-request-id');
+        $mock = $this->getMockBuilder(ListPromptsRequest::class)
+            ->setConstructorArgs([$cursor])
+            ->onlyMethods(['getId'])
+            ->getMock();
         
-        return $listPromptsRequest;
+        $mock->method('getId')->willReturn('test-request-id');
+        
+        return $mock;
     }
 }

--- a/tests/Server/RequestHandler/ListPromptsHandlerTest.php
+++ b/tests/Server/RequestHandler/ListPromptsHandlerTest.php
@@ -42,13 +42,15 @@ class ListPromptsHandlerTest extends TestCase
         $response = $this->handler->handle($request);
 
         // Assert
-        $this->assertInstanceOf(ListPromptsResult::class, $response->result);
-        $this->assertCount(3, $response->result->prompts);
-        $this->assertNotNull($response->result->nextCursor);
+        /** @var ListPromptsResult $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListPromptsResult::class, $result);
+        $this->assertCount(3, $result->prompts);
+        $this->assertNotNull($result->nextCursor);
 
-        $this->assertEquals('prompt_0', $response->result->prompts[0]->name);
-        $this->assertEquals('prompt_1', $response->result->prompts[1]->name);
-        $this->assertEquals('prompt_2', $response->result->prompts[2]->name);
+        $this->assertEquals('prompt_0', $result->prompts[0]->name);
+        $this->assertEquals('prompt_1', $result->prompts[1]->name);
+        $this->assertEquals('prompt_2', $result->prompts[2]->name);
     }
 
     #[TestDox('Returns paginated prompts with cursor')]
@@ -62,13 +64,15 @@ class ListPromptsHandlerTest extends TestCase
         $response = $this->handler->handle($request);
 
         // Assert
-        $this->assertInstanceOf(ListPromptsResult::class, $response->result);
-        $this->assertCount(3, $response->result->prompts);
-        $this->assertNotNull($response->result->nextCursor);
+        /** @var ListPromptsResult $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListPromptsResult::class, $result);
+        $this->assertCount(3, $result->prompts);
+        $this->assertNotNull($result->nextCursor);
 
-        $this->assertEquals('prompt_0', $response->result->prompts[0]->name);
-        $this->assertEquals('prompt_1', $response->result->prompts[1]->name);
-        $this->assertEquals('prompt_2', $response->result->prompts[2]->name);
+        $this->assertEquals('prompt_0', $result->prompts[0]->name);
+        $this->assertEquals('prompt_1', $result->prompts[1]->name);
+        $this->assertEquals('prompt_2', $result->prompts[2]->name);
     }
 
     #[TestDox('Returns second page with cursor')]
@@ -85,13 +89,15 @@ class ListPromptsHandlerTest extends TestCase
         $response = $this->handler->handle($secondPageRequest);
 
         // Assert
-        $this->assertInstanceOf(ListPromptsResult::class, $response->result);
-        $this->assertCount(3, $response->result->prompts);
-        $this->assertNotNull($response->result->nextCursor);
+        /** @var ListPromptsResult $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListPromptsResult::class, $result);
+        $this->assertCount(3, $result->prompts);
+        $this->assertNotNull($result->nextCursor);
 
-        $this->assertEquals('prompt_3', $response->result->prompts[0]->name);
-        $this->assertEquals('prompt_4', $response->result->prompts[1]->name);
-        $this->assertEquals('prompt_5', $response->result->prompts[2]->name);
+        $this->assertEquals('prompt_3', $result->prompts[0]->name);
+        $this->assertEquals('prompt_4', $result->prompts[1]->name);
+        $this->assertEquals('prompt_5', $result->prompts[2]->name);
     }
 
     #[TestDox('Returns last page with null cursor')]
@@ -108,12 +114,14 @@ class ListPromptsHandlerTest extends TestCase
         $response = $this->handler->handle($secondPageRequest);
 
         // Assert
-        $this->assertInstanceOf(ListPromptsResult::class, $response->result);
-        $this->assertCount(2, $response->result->prompts);
-        $this->assertNull($response->result->nextCursor);
+        /** @var ListPromptsResult $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListPromptsResult::class, $result);
+        $this->assertCount(2, $result->prompts);
+        $this->assertNull($result->nextCursor);
 
-        $this->assertEquals('prompt_3', $response->result->prompts[0]->name);
-        $this->assertEquals('prompt_4', $response->result->prompts[1]->name);
+        $this->assertEquals('prompt_3', $result->prompts[0]->name);
+        $this->assertEquals('prompt_4', $result->prompts[1]->name);
     }
 
     #[TestDox('Handles empty registry')]
@@ -126,9 +134,11 @@ class ListPromptsHandlerTest extends TestCase
         $response = $this->handler->handle($request);
 
         // Assert
-        $this->assertInstanceOf(ListPromptsResult::class, $response->result);
-        $this->assertCount(0, $response->result->prompts);
-        $this->assertNull($response->result->nextCursor);
+        /** @var ListPromptsResult $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListPromptsResult::class, $result);
+        $this->assertCount(0, $result->prompts);
+        $this->assertNull($result->nextCursor);
     }
 
     #[TestDox('Throws exception for invalid cursor')]
@@ -172,9 +182,11 @@ class ListPromptsHandlerTest extends TestCase
         $response = $this->handler->handle($request);
 
         // Assert
-        $this->assertInstanceOf(ListPromptsResult::class, $response->result);
-        $this->assertCount(0, $response->result->prompts);
-        $this->assertNull($response->result->nextCursor);
+        /** @var ListPromptsResult $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListPromptsResult::class, $result);
+        $this->assertCount(0, $result->prompts);
+        $this->assertNull($result->nextCursor);
     }
 
     #[TestDox('Maintains stable cursors across calls')]

--- a/tests/Server/RequestHandler/ListResourcesHandlerTest.php
+++ b/tests/Server/RequestHandler/ListResourcesHandlerTest.php
@@ -42,13 +42,15 @@ class ListResourcesHandlerTest extends TestCase
         $response = $this->handler->handle($request);
 
         // Assert
-        $this->assertInstanceOf(ListResourcesResult::class, $response->result);
-        $this->assertCount(3, $response->result->resources);
-        $this->assertNotNull($response->result->nextCursor);
+        /** @var ListResourcesResult $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListResourcesResult::class, $result);
+        $this->assertCount(3, $result->resources);
+        $this->assertNotNull($result->nextCursor);
 
-        $this->assertEquals('resource://test/resource_0', $response->result->resources[0]->uri);
-        $this->assertEquals('resource://test/resource_1', $response->result->resources[1]->uri);
-        $this->assertEquals('resource://test/resource_2', $response->result->resources[2]->uri);
+        $this->assertEquals('resource://test/resource_0', $result->resources[0]->uri);
+        $this->assertEquals('resource://test/resource_1', $result->resources[1]->uri);
+        $this->assertEquals('resource://test/resource_2', $result->resources[2]->uri);
     }
 
     #[TestDox('Returns paginated resources with cursor')]
@@ -62,13 +64,15 @@ class ListResourcesHandlerTest extends TestCase
         $response = $this->handler->handle($request);
 
         // Assert
-        $this->assertInstanceOf(ListResourcesResult::class, $response->result);
-        $this->assertCount(3, $response->result->resources);
-        $this->assertNotNull($response->result->nextCursor);
+        /** @var ListResourcesResult $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListResourcesResult::class, $result);
+        $this->assertCount(3, $result->resources);
+        $this->assertNotNull($result->nextCursor);
 
-        $this->assertEquals('resource://test/resource_0', $response->result->resources[0]->uri);
-        $this->assertEquals('resource://test/resource_1', $response->result->resources[1]->uri);
-        $this->assertEquals('resource://test/resource_2', $response->result->resources[2]->uri);
+        $this->assertEquals('resource://test/resource_0', $result->resources[0]->uri);
+        $this->assertEquals('resource://test/resource_1', $result->resources[1]->uri);
+        $this->assertEquals('resource://test/resource_2', $result->resources[2]->uri);
     }
 
     #[TestDox('Returns second page with cursor')]
@@ -85,13 +89,15 @@ class ListResourcesHandlerTest extends TestCase
         $response = $this->handler->handle($secondPageRequest);
 
         // Assert
-        $this->assertInstanceOf(ListResourcesResult::class, $response->result);
-        $this->assertCount(3, $response->result->resources);
-        $this->assertNotNull($response->result->nextCursor);
+        /** @var ListResourcesResult $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListResourcesResult::class, $result);
+        $this->assertCount(3, $result->resources);
+        $this->assertNotNull($result->nextCursor);
 
-        $this->assertEquals('resource://test/resource_3', $response->result->resources[0]->uri);
-        $this->assertEquals('resource://test/resource_4', $response->result->resources[1]->uri);
-        $this->assertEquals('resource://test/resource_5', $response->result->resources[2]->uri);
+        $this->assertEquals('resource://test/resource_3', $result->resources[0]->uri);
+        $this->assertEquals('resource://test/resource_4', $result->resources[1]->uri);
+        $this->assertEquals('resource://test/resource_5', $result->resources[2]->uri);
     }
 
     #[TestDox('Returns last page with null cursor')]
@@ -108,12 +114,14 @@ class ListResourcesHandlerTest extends TestCase
         $response = $this->handler->handle($secondPageRequest);
 
         // Assert
-        $this->assertInstanceOf(ListResourcesResult::class, $response->result);
-        $this->assertCount(2, $response->result->resources);
-        $this->assertNull($response->result->nextCursor);
+        /** @var ListResourcesResult $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListResourcesResult::class, $result);
+        $this->assertCount(2, $result->resources);
+        $this->assertNull($result->nextCursor);
 
-        $this->assertEquals('resource://test/resource_3', $response->result->resources[0]->uri);
-        $this->assertEquals('resource://test/resource_4', $response->result->resources[1]->uri);
+        $this->assertEquals('resource://test/resource_3', $result->resources[0]->uri);
+        $this->assertEquals('resource://test/resource_4', $result->resources[1]->uri);
     }
 
     #[TestDox('Handles empty registry')]
@@ -126,9 +134,11 @@ class ListResourcesHandlerTest extends TestCase
         $response = $this->handler->handle($request);
 
         // Assert
-        $this->assertInstanceOf(ListResourcesResult::class, $response->result);
-        $this->assertCount(0, $response->result->resources);
-        $this->assertNull($response->result->nextCursor);
+        /** @var ListResourcesResult $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListResourcesResult::class, $result);
+        $this->assertCount(0, $result->resources);
+        $this->assertNull($result->nextCursor);
     }
 
     #[TestDox('Throws exception for invalid cursor')]

--- a/tests/Server/RequestHandler/ListResourcesHandlerTest.php
+++ b/tests/Server/RequestHandler/ListResourcesHandlerTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Server\RequestHandler;
+
+use Mcp\Capability\Registry;
+use Mcp\Exception\InvalidCursorException;
+use Mcp\Schema\Resource;
+use Mcp\Schema\Request\ListResourcesRequest;
+use Mcp\Schema\Result\ListResourcesResult;
+use Mcp\Server\RequestHandler\ListResourcesHandler;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+class ListResourcesHandlerTest extends TestCase
+{
+    private Registry $registry;
+    private ListResourcesHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->registry = new Registry();
+        $this->handler = new ListResourcesHandler($this->registry, pageSize: 3); // Use small page size for testing
+    }
+
+    #[TestDox('Returns first page when no cursor provided')]
+    public function testReturnsFirstPageWhenNoCursorProvided(): void
+    {
+        // Arrange
+        $this->addResourcesToRegistry(5);
+        $request = $this->createListResourcesRequest();
+
+        // Act
+        $response = $this->handler->handle($request);
+
+        // Assert
+        $this->assertInstanceOf(ListResourcesResult::class, $response->result);
+        $this->assertCount(3, $response->result->resources);
+        $this->assertNotNull($response->result->nextCursor);
+
+        $this->assertEquals('resource://test/resource_0', $response->result->resources[0]->uri);
+        $this->assertEquals('resource://test/resource_1', $response->result->resources[1]->uri);
+        $this->assertEquals('resource://test/resource_2', $response->result->resources[2]->uri);
+    }
+
+    #[TestDox('Returns paginated resources with cursor')]
+    public function testReturnsPaginatedResourcesWithCursor(): void
+    {
+        // Arrange
+        $this->addResourcesToRegistry(10);
+        $request = $this->createListResourcesRequest(cursor: null);
+
+        // Act
+        $response = $this->handler->handle($request);
+
+        // Assert
+        $this->assertInstanceOf(ListResourcesResult::class, $response->result);
+        $this->assertCount(3, $response->result->resources);
+        $this->assertNotNull($response->result->nextCursor);
+
+        $this->assertEquals('resource://test/resource_0', $response->result->resources[0]->uri);
+        $this->assertEquals('resource://test/resource_1', $response->result->resources[1]->uri);
+        $this->assertEquals('resource://test/resource_2', $response->result->resources[2]->uri);
+    }
+
+    #[TestDox('Returns second page with cursor')]
+    public function testReturnsSecondPageWithCursor(): void
+    {
+        // Arrange
+        $this->addResourcesToRegistry(10);
+        $firstPageRequest = $this->createListResourcesRequest();
+        $firstPageResponse = $this->handler->handle($firstPageRequest);
+        
+        $secondPageRequest = $this->createListResourcesRequest(cursor: $firstPageResponse->result->nextCursor);
+
+        // Act
+        $response = $this->handler->handle($secondPageRequest);
+
+        // Assert
+        $this->assertInstanceOf(ListResourcesResult::class, $response->result);
+        $this->assertCount(3, $response->result->resources);
+        $this->assertNotNull($response->result->nextCursor);
+
+        $this->assertEquals('resource://test/resource_3', $response->result->resources[0]->uri);
+        $this->assertEquals('resource://test/resource_4', $response->result->resources[1]->uri);
+        $this->assertEquals('resource://test/resource_5', $response->result->resources[2]->uri);
+    }
+
+    #[TestDox('Returns last page with null cursor')]
+    public function testReturnsLastPageWithNullCursor(): void
+    {
+        // Arrange
+        $this->addResourcesToRegistry(5);
+        $firstPageRequest = $this->createListResourcesRequest();
+        $firstPageResponse = $this->handler->handle($firstPageRequest);
+        
+        $secondPageRequest = $this->createListResourcesRequest(cursor: $firstPageResponse->result->nextCursor);
+
+        // Act
+        $response = $this->handler->handle($secondPageRequest);
+
+        // Assert
+        $this->assertInstanceOf(ListResourcesResult::class, $response->result);
+        $this->assertCount(2, $response->result->resources);
+        $this->assertNull($response->result->nextCursor);
+
+        $this->assertEquals('resource://test/resource_3', $response->result->resources[0]->uri);
+        $this->assertEquals('resource://test/resource_4', $response->result->resources[1]->uri);
+    }
+
+    #[TestDox('Handles empty registry')]
+    public function testHandlesEmptyRegistry(): void
+    {
+        // Arrange
+        $request = $this->createListResourcesRequest();
+
+        // Act
+        $response = $this->handler->handle($request);
+
+        // Assert
+        $this->assertInstanceOf(ListResourcesResult::class, $response->result);
+        $this->assertCount(0, $response->result->resources);
+        $this->assertNull($response->result->nextCursor);
+    }
+
+    #[TestDox('Throws exception for invalid cursor')]
+    public function testThrowsExceptionForInvalidCursor(): void
+    {
+        // Arrange
+        $this->addResourcesToRegistry(5);
+        $request = $this->createListResourcesRequest(cursor: 'invalid-cursor');
+
+        // Assert
+        $this->expectException(InvalidCursorException::class);
+
+        // Act
+        $this->handler->handle($request);
+    }
+
+    #[TestDox('Throws exception for cursor beyond bounds')]
+    public function testThrowsExceptionForCursorBeyondBounds(): void
+    {
+        // Arrange
+        $this->addResourcesToRegistry(5);
+        $outOfBoundsCursor = base64_encode('100');
+        $request = $this->createListResourcesRequest(cursor: $outOfBoundsCursor);
+
+        // Assert
+        $this->expectException(InvalidCursorException::class);
+
+        // Act
+        $this->handler->handle($request);
+    }
+
+    #[TestDox('Handles cursor at exact boundary')]
+    public function testHandlesCursorAtExactBoundary(): void
+    {
+        // Arrange
+        $this->addResourcesToRegistry(6);
+        $exactBoundaryCursor = base64_encode('6');
+        $request = $this->createListResourcesRequest(cursor: $exactBoundaryCursor);
+
+        // Act
+        $response = $this->handler->handle($request);
+
+        // Assert
+        $this->assertInstanceOf(ListResourcesResult::class, $response->result);
+        $this->assertCount(0, $response->result->resources);
+        $this->assertNull($response->result->nextCursor);
+    }
+
+    #[TestDox('Maintains stable cursors across calls')]
+    public function testMaintainsStableCursorsAcrossCalls(): void
+    {
+        // Arrange
+        $this->addResourcesToRegistry(10);
+        
+        // Act
+        $request = $this->createListResourcesRequest();
+        $response1 = $this->handler->handle($request);
+        $response2 = $this->handler->handle($request);
+
+        // Assert
+        $this->assertEquals($response1->result->nextCursor, $response2->result->nextCursor);
+        $this->assertEquals($response1->result->resources, $response2->result->resources);
+    }
+
+    private function addResourcesToRegistry(int $count): void
+    {
+        for ($i = 0; $i < $count; $i++) {
+            $resource = new Resource(
+                uri: "resource://test/resource_$i",
+                name: "resource_$i",
+                description: "Test resource $i"
+            );
+            // Use a simple callable as handler
+            $this->registry->registerResource($resource, fn() => null);
+        }
+    }
+
+    private function createListResourcesRequest(?string $cursor = null): ListResourcesRequest
+    {
+        $mock = $this->getMockBuilder(ListResourcesRequest::class)
+            ->setConstructorArgs([$cursor])
+            ->onlyMethods(['getId'])
+            ->getMock();
+        
+        $mock->method('getId')->willReturn('test-request-id');
+        
+        return $mock;
+    }
+}

--- a/tests/Server/RequestHandler/ListToolsHandlerTest.php
+++ b/tests/Server/RequestHandler/ListToolsHandlerTest.php
@@ -1,0 +1,254 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Server\RequestHandler;
+
+use Mcp\Capability\Registry;
+use Mcp\Exception\InvalidCursorException;
+use Mcp\Schema\Tool;
+use Mcp\Schema\Request\ListToolsRequest;
+use Mcp\Schema\Result\ListToolsResult;
+use Mcp\Server\RequestHandler\ListToolsHandler;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+class ListToolsHandlerTest extends TestCase
+{
+    private Registry $registry;
+    private ListToolsHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->registry = new Registry();
+        $this->handler = new ListToolsHandler($this->registry, pageSize: 3); // Use small page size for testing
+    }
+
+    #[TestDox('Returns first page when no cursor provided')]
+    public function testReturnsFirstPageWhenNoCursorProvided(): void
+    {
+        // Arrange
+        $this->addToolsToRegistry(5);
+        $request = $this->createListToolsRequest();
+
+        // Act
+        $response = $this->handler->handle($request);
+
+        // Assert
+        /** @var ListToolsHandler $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListToolsResult::class, $result);
+        $this->assertCount(3, $result->tools);
+        $this->assertNotNull($result->nextCursor);
+
+        $this->assertEquals('tool_0', $result->tools[0]->name);
+        $this->assertEquals('tool_1', $result->tools[1]->name);
+        $this->assertEquals('tool_2', $result->tools[2]->name);
+    }
+
+    #[TestDox('Returns paginated tools with cursor')]
+    public function testReturnsPaginatedToolsWithCursor(): void
+    {
+        // Arrange
+        $this->addToolsToRegistry(10);
+        $request = $this->createListToolsRequest(cursor: null);
+
+        // Act
+        $response = $this->handler->handle($request);
+
+        // Assert
+        /** @var ListToolsHandler $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListToolsResult::class, $result);
+        $this->assertCount(3, $result->tools);
+        $this->assertNotNull($result->nextCursor);
+
+        $this->assertEquals('tool_0', $result->tools[0]->name);
+        $this->assertEquals('tool_1', $result->tools[1]->name);
+        $this->assertEquals('tool_2', $result->tools[2]->name);
+    }
+
+    #[TestDox('Returns second page with cursor')]
+    public function testReturnsSecondPageWithCursor(): void
+    {
+        // Arrange
+        $this->addToolsToRegistry(10);
+        $firstPageRequest = $this->createListToolsRequest();
+        $firstPageResponse = $this->handler->handle($firstPageRequest);
+        
+        $secondPageRequest = $this->createListToolsRequest(cursor: $firstPageResponse->result->nextCursor);
+
+        // Act
+        $response = $this->handler->handle($secondPageRequest);
+
+        // Assert
+        /** @var ListToolsHandler $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListToolsResult::class, $result);
+        $this->assertCount(3, $result->tools);
+        $this->assertNotNull($result->nextCursor);
+
+        $this->assertEquals('tool_3', $result->tools[0]->name);
+        $this->assertEquals('tool_4', $result->tools[1]->name);
+        $this->assertEquals('tool_5', $result->tools[2]->name);
+    }
+
+    #[TestDox('Returns last page with null cursor')]
+    public function testReturnsLastPageWithNullCursor(): void
+    {
+        // Arrange
+        $this->addToolsToRegistry(5);
+        $firstPageRequest = $this->createListToolsRequest();
+        $firstPageResponse = $this->handler->handle($firstPageRequest);
+        
+        $secondPageRequest = $this->createListToolsRequest(cursor: $firstPageResponse->result->nextCursor);
+
+        // Act
+        $response = $this->handler->handle($secondPageRequest);
+
+        // Assert
+        /** @var ListToolsHandler $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListToolsResult::class, $result);
+        $this->assertCount(2, $result->tools);
+        $this->assertNull($result->nextCursor);
+
+        $this->assertEquals('tool_3', $result->tools[0]->name);
+        $this->assertEquals('tool_4', $result->tools[1]->name);
+    }
+
+    #[TestDox('Returns all tools when count is less than page size')]
+    public function testReturnsAllToolsWhenCountIsLessThanPageSize(): void
+    {
+        // Arrange
+        $this->addToolsToRegistry(2); // Less than page size (3)
+        $request = $this->createListToolsRequest();
+
+        // Act
+        $response = $this->handler->handle($request);
+
+        // Assert
+        /** @var ListToolsHandler $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListToolsResult::class, $result);
+        $this->assertCount(2, $result->tools);
+        $this->assertNull($result->nextCursor);
+
+        $this->assertEquals('tool_0', $result->tools[0]->name);
+        $this->assertEquals('tool_1', $result->tools[1]->name);
+    }
+
+    #[TestDox('Handles empty registry')]
+    public function testHandlesEmptyRegistry(): void
+    {
+        // Arrange
+        $request = $this->createListToolsRequest();
+
+        // Act
+        $response = $this->handler->handle($request);
+
+        // Assert
+        /** @var ListToolsHandler $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListToolsResult::class, $result);
+        $this->assertCount(0, $result->tools);
+        $this->assertNull($result->nextCursor);
+    }
+
+    #[TestDox('Throws exception for invalid cursor')]
+    public function testThrowsExceptionForInvalidCursor(): void
+    {
+        // Arrange
+        $this->addToolsToRegistry(5);
+        $request = $this->createListToolsRequest(cursor: 'invalid-cursor');
+
+        // Assert
+        $this->expectException(InvalidCursorException::class);
+
+        // Act
+        $this->handler->handle($request);
+    }
+
+    #[TestDox('Throws exception for cursor beyond bounds')]
+    public function testThrowsExceptionForCursorBeyondBounds(): void
+    {
+        // Arrange
+        $this->addToolsToRegistry(5);
+        $outOfBoundsCursor = base64_encode('100');
+        $request = $this->createListToolsRequest(cursor: $outOfBoundsCursor);
+
+        // Assert
+        $this->expectException(InvalidCursorException::class);
+
+        // Act
+        $this->handler->handle($request);
+    }
+
+    #[TestDox('Handles cursor at exact boundary')]
+    public function testHandlesCursorAtExactBoundary(): void
+    {
+        // Arrange
+        $this->addToolsToRegistry(6);
+        $exactBoundaryCursor = base64_encode('6');
+        $request = $this->createListToolsRequest(cursor: $exactBoundaryCursor);
+
+        // Act
+        $response = $this->handler->handle($request);
+
+        // Assert
+        /** @var ListToolsHandler $result */
+        $result = $response->result;
+        $this->assertInstanceOf(ListToolsResult::class, $result);
+        $this->assertCount(0, $result->tools);
+        $this->assertNull($result->nextCursor);
+    }
+
+    #[TestDox('Maintains stable cursors across calls')]
+    public function testMaintainsStableCursorsAcrossCalls(): void
+    {
+        // Arrange
+        $this->addToolsToRegistry(10);
+        
+        // Act
+        $request = $this->createListToolsRequest();
+        $response1 = $this->handler->handle($request);
+        $response2 = $this->handler->handle($request);
+
+        // Assert
+        $this->assertEquals($response1->result->nextCursor, $response2->result->nextCursor);
+        $this->assertEquals($response1->result->tools, $response2->result->tools);
+    }
+
+    private function addToolsToRegistry(int $count): void
+    {
+        for ($i = 0; $i < $count; $i++) {
+            $tool = new Tool(
+                name: "tool_$i",
+                inputSchema: ['type' => 'object'],
+                description: "Test tool $i",
+                annotations: null
+            );
+
+            $this->registry->registerTool($tool, fn() => null);
+        }
+    }
+
+    private function createListToolsRequest(?string $cursor = null): ListToolsRequest
+    {
+        $mock = $this->getMockBuilder(ListToolsRequest::class)
+            ->setConstructorArgs([$cursor])
+            ->onlyMethods(['getId'])
+            ->getMock();
+        
+        $mock->method('getId')->willReturn('test-request-id');
+        
+        return $mock;
+    }
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Implements MCP pagination for tools/list, prompts/list, and resources/list endpoints.

- Added pagination support to ListToolsHandler, ListPromptsHandler, ListResourcesHandler
- Enhanced Registry with pagination methods and cursor calculation
- Added comprehensive unit tests for all pagination scenarios
- Added proper exception handling with @throws annotations

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The change was raised as an issue to enable the list request to have pagination support.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes, this has been tested. 

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No, users don't need to make any updates

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
