### PR TITLE
Add Makefile to export-ignore in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 /.php-cs-fixer.dist.php export-ignore
 /phpstan.dist.neon export-ignore
 /phpunit.xml.dist export-ignore
+/Makefile export-ignore


### PR DESCRIPTION
# Add Makefile to export-ignore in .gitattributes

<!-- Provide a brief summary of your changes -->
This PR adds the Makefile to the export-ignore list in .gitattributes to prevent it from being included in distribution packages.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The Makefile contains development-specific commands and shortcuts that are only useful for contributors working on the codebase. End users who install this package via Composer don't need the Makefile in their vendor directory, as it's purely a development tool. Adding it to export-ignore reduces the package size and keeps the distributed package clean by excluding development-only files.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
This change affects only the package distribution and doesn't impact runtime functionality. The change can be verified by:
- Creating a package archive and confirming the Makefile is excluded
- Ensuring the Makefile continues to work normally in the development environment

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes. This only affects package distribution and has no impact on the API or functionality.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
This follows the existing pattern in .gitattributes where other development files like .php-cs-fixer.dist.php, phpstan.dist.neon, and phpunit.xml.dist are already excluded from exports. The Makefile contains common development tasks like running tests, code style fixes, and static analysis, which are only relevant for contributors.