### PR TITLE
[Server] Handle empty message queue in CachePoolStore::pop()

### DIFF
--- a/src/Server/Transport/Sse/Store/CachePoolStore.php
+++ b/src/Server/Transport/Sse/Store/CachePoolStore.php
@@ -45,6 +45,11 @@ final class CachePoolStore implements StoreInterface
         }
 
         $messages = $item->get();
+
+        if ([] === $messages) {
+            return null;
+        }
+
         $message = array_shift($messages);
 
         $item->set($messages);


### PR DESCRIPTION
Previously, pop() would call array_shift() even if the cached queue was empty,
leading to unnecessary operations (caching an empty array repeatedly). This change ensures that pop() returns null
early when no messages are available.