### PR TITLE
Add ToolExecutionExceptionInterface for custom tool error handling

### DIFF
--- a/src/Capability/Registry/ReferenceHandlerInterface.php
+++ b/src/Capability/Registry/ReferenceHandlerInterface.php
@@ -27,8 +27,9 @@ interface ReferenceHandlerInterface
      *
      * @return mixed the result of the element execution
      *
-     * @throws \Mcp\Exception\InvalidArgumentException if the handler is invalid
-     * @throws \Mcp\Exception\RegistryException        if execution fails
+     * @throws \Mcp\Exception\InvalidArgumentException        if the handler is invalid
+     * @throws \Mcp\Exception\ToolExecutionExceptionInterface if the tool reports an error during its execution
+     * @throws \Mcp\Exception\RegistryException               if execution fails
      */
     public function handle(ElementReference $reference, array $arguments): mixed;
 }

--- a/src/Capability/Tool/ToolCaller.php
+++ b/src/Capability/Tool/ToolCaller.php
@@ -14,6 +14,7 @@ namespace Mcp\Capability\Tool;
 use Mcp\Capability\Registry\ReferenceHandlerInterface;
 use Mcp\Capability\Registry\ReferenceProviderInterface;
 use Mcp\Exception\ToolCallException;
+use Mcp\Exception\ToolExecutionExceptionInterface;
 use Mcp\Exception\ToolNotFoundException;
 use Mcp\Schema\Content\AudioContent;
 use Mcp\Schema\Content\EmbeddedResource;
@@ -68,6 +69,11 @@ final class ToolCaller implements ToolCallerInterface
             ]);
 
             return new CallToolResult($formattedResult);
+        } catch (ToolExecutionExceptionInterface $e) {
+            return CallToolResult::error(array_map(
+                fn (string $message): TextContent => new TextContent($message),
+                $e->getErrorMessages(),
+            ));
         } catch (\Throwable $e) {
             $this->logger->error('Tool execution failed', [
                 'name' => $toolName,

--- a/src/Capability/Tool/ToolCallerInterface.php
+++ b/src/Capability/Tool/ToolCallerInterface.php
@@ -12,6 +12,7 @@
 namespace Mcp\Capability\Tool;
 
 use Mcp\Exception\ToolCallException;
+use Mcp\Exception\ToolExecutionExceptionInterface;
 use Mcp\Exception\ToolNotFoundException;
 use Mcp\Schema\Request\CallToolRequest;
 use Mcp\Schema\Result\CallToolResult;
@@ -22,8 +23,9 @@ use Mcp\Schema\Result\CallToolResult;
 interface ToolCallerInterface
 {
     /**
-     * @throws ToolCallException     if the tool execution fails
-     * @throws ToolNotFoundException if the tool is not found
+     * @throws ToolCallException               if the tool execution fails
+     * @throws ToolNotFoundException           if the tool is not found
+     * @throws ToolExecutionExceptionInterface if the tool reports an error during its execution
      */
     public function call(CallToolRequest $request): CallToolResult;
 }

--- a/src/Capability/ToolChain.php
+++ b/src/Capability/ToolChain.php
@@ -17,6 +17,7 @@ use Mcp\Capability\Tool\MetadataInterface;
 use Mcp\Capability\Tool\ToolCallerInterface;
 use Mcp\Exception\InvalidCursorException;
 use Mcp\Exception\ToolCallException;
+use Mcp\Exception\ToolExecutionExceptionInterface;
 use Mcp\Exception\ToolNotFoundException;
 use Mcp\Schema\Request\CallToolRequest;
 use Mcp\Schema\Result\CallToolResult;
@@ -67,6 +68,10 @@ class ToolChain implements ToolCallerInterface, CollectionInterface
                 try {
                     return $item->call($request);
                 } catch (\Throwable $e) {
+                    if ($e instanceof ToolExecutionExceptionInterface) {
+                        throw $e;
+                    }
+
                     throw new ToolCallException($request, $e);
                 }
             }

--- a/src/Exception/ToolExecutionExceptionInterface.php
+++ b/src/Exception/ToolExecutionExceptionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Exception;
+
+interface ToolExecutionExceptionInterface extends \Throwable
+{
+    /**
+     * @return non-empty-list<non-empty-string>
+     */
+    public function getErrorMessages(): array;
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
The current tool execution system lacks a standardized way for handling tool-specific errors. This change provides a consistent way for tools to report errors.

## How Has This Been Tested?
Added unit tests in ToolCallerTest.php

## Breaking Changes
No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
The implementation includes modifications to:
- ToolCaller and ToolCallerInterface for exception handling integration
- ToolChain for proper error propagation
- New ToolExecutionExceptionInterface defining the contract for custom tool error handling

## Usage
```php
class McpElementsException extends RuntimException implements ToolExecutionExceptionInterface { ... }

class McpElements
{
	#[McpTool(name: 'calculate')]
	public function calculate(float $a, float $b, string $operation): float|string
	{
		$op = strtolower($operation);

		switch ($op) {
			case 'add':
				$result = $a + $b;
				break;
			case 'subtract':
				$result = $a - $b;
				break;
			case 'multiply':
				$result = $a * $b;
				break;
			case 'divide':
				if (0 == $b) {
					throw new McpElementsException(['Division by zero.']);
				}
				$result = $a / $b;
				break;
			default:
				throw new McpElementsException(["Unknown operation '{$operation}'. Supported: add, subtract, multiply, divide."]);
		}

		if (!$this->config['allow_negative'] && $result < 0) {
			throw new McpElementsException(['Negative results are disabled.']);
		}

		return round($result, $this->config['precision']);
	}
}
```

