### PR TITLE
Add getRegistry() method to Server class for debugging access

### DIFF
--- a/examples/09-standalone-cli/index.php
+++ b/examples/09-standalone-cli/index.php
@@ -13,12 +13,16 @@ require __DIR__.'/vendor/autoload.php';
 
 use Symfony\Component\Console as SymfonyConsole;
 use Symfony\Component\Console\Output\OutputInterface;
+use Mcp\Capability\Registry;
 
 $debug = (bool) ($_SERVER['DEBUG'] ?? false);
 
 // Setup input, output and logger
 $output = new SymfonyConsole\Output\ConsoleOutput($debug ? OutputInterface::VERBOSITY_VERY_VERBOSE : OutputInterface::VERBOSITY_NORMAL);
 $logger = new SymfonyConsole\Logger\ConsoleLogger($output);
+
+// Configure the registry (empty for this standalone example)
+$registry = new Registry();
 
 // Configure the JsonRpcHandler and build the functionality
 $jsonRpcHandler = new Mcp\JsonRpc\Handler(
@@ -28,7 +32,7 @@ $jsonRpcHandler = new Mcp\JsonRpc\Handler(
 );
 
 // Set up the server
-$sever = new Mcp\Server($jsonRpcHandler, $logger);
+$sever = new Mcp\Server($jsonRpcHandler, $registry, $logger);
 
 // Create the transport layer using Stdio
 $transport = new Mcp\Server\Transport\StdioTransport(logger: $logger);

--- a/src/Server.php
+++ b/src/Server.php
@@ -11,6 +11,7 @@
 
 namespace Mcp;
 
+use Mcp\Capability\Registry\ReferenceProviderInterface;
 use Mcp\JsonRpc\Handler;
 use Mcp\Server\ServerBuilder;
 use Mcp\Server\TransportInterface;
@@ -24,6 +25,7 @@ final class Server
 {
     public function __construct(
         private readonly Handler $jsonRpcHandler,
+        private readonly ReferenceProviderInterface $registry,
         private readonly LoggerInterface $logger = new NullLogger(),
     ) {
     }
@@ -31,6 +33,11 @@ final class Server
     public static function make(): ServerBuilder
     {
         return new ServerBuilder();
+    }
+
+    public function getRegistry(): ReferenceProviderInterface
+    {
+        return $this->registry;
     }
 
     public function connect(TransportInterface $transport): void

--- a/src/Server/ServerBuilder.php
+++ b/src/Server/ServerBuilder.php
@@ -302,6 +302,7 @@ final class ServerBuilder
                 promptGetter: $promptGetter,
                 logger: $logger,
             ),
+            registry: $registry,
             logger: $logger,
         );
     }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -11,6 +11,7 @@
 
 namespace Mcp\Tests;
 
+use Mcp\Capability\Registry\ReferenceProviderInterface;
 use Mcp\JsonRpc\Handler;
 use Mcp\Server;
 use Mcp\Server\Transport\InMemoryTransport;
@@ -41,7 +42,20 @@ class ServerTest extends TestCase
             ->getMock();
         $transport->expects($this->once())->method('send')->with('success');
 
-        $server = new Server($handler, $logger);
+        $registry = $this->createMock(ReferenceProviderInterface::class);
+
+        $server = new Server($handler, $registry, $logger);
         $server->connect($transport);
+    }
+
+    public function testGetRegistry()
+    {
+        $handler = $this->createMock(Handler::class);
+        $registry = $this->createMock(ReferenceProviderInterface::class);
+        $logger = new NullLogger();
+
+        $server = new Server($handler, $registry, $logger);
+
+        $this->assertSame($registry, $server->getRegistry());
     }
 }


### PR DESCRIPTION
## Summary
Expose the Registry through the Server class to enable debugging and monitoring tools like Symfony Web Profiler to access discovered capabilities.

## Changes
- Add `ReferenceProviderInterface $registry` parameter to `Server` constructor
- Add `getRegistry(): ReferenceProviderInterface` method to `Server` class  
- Update `ServerBuilder` to pass registry to `Server` constructor
- Update standalone example to use new `Server` constructor signature
- Add test coverage for `getRegistry()` method

## Use Case
This enables integration with debugging tools like Symfony Web Profiler by providing access to:
- `getTools()` - All registered tools
- `getResources()` - All registered resources  
- `getPrompts()` - All registered prompts
- `getResourceTemplates()` - All registered resource templates

## Test Plan
- [x] All existing tests pass
- [x] New test added for `getRegistry()` method
- [x] PHP CS Fixer validation passes
- [x] PHPStan static analysis passes
- [x] Manual testing with various MCP capabilities confirmed working

Resolves #74