### PR TITLE
refactor: integrate cache parameter into setDiscovery() method

### DIFF
--- a/docs/discovery-caching.md
+++ b/docs/discovery-caching.md
@@ -21,8 +21,7 @@ use Symfony\Component\Cache\Psr16Cache;
 
 $server = Server::make()
     ->setServerInfo('My Server', '1.0.0')
-    ->setDiscovery(__DIR__, ['.'])
-    ->setCache(new Psr16Cache(new ArrayAdapter())) // Enable caching
+    ->setDiscovery(__DIR__, ['.'], [], new Psr16Cache(new ArrayAdapter())) // Enable caching
     ->build();
 ```
 
@@ -69,8 +68,7 @@ $cache = DoctrineProvider::wrap(new ArrayCache());
 $cache = new Psr16Cache(new ArrayAdapter());
 
 $server = Server::make()
-    ->setDiscovery(__DIR__, ['.'])
-    ->setCache($cache)
+    ->setDiscovery(__DIR__, ['.'], [], $cache)
     ->build();
 ```
 
@@ -81,8 +79,7 @@ $server = Server::make()
 $cache = new Psr16Cache(new FilesystemAdapter('mcp-discovery', 0, '/var/cache'));
 
 $server = Server::make()
-    ->setDiscovery(__DIR__, ['.'])
-    ->setCache($cache)
+    ->setDiscovery(__DIR__, ['.'], [], $cache)
     ->build();
 ```
 

--- a/examples/09-cached-discovery-stdio/server.php
+++ b/examples/09-cached-discovery-stdio/server.php
@@ -26,8 +26,7 @@ $server = Server::make()
     ->setServerInfo('Cached Discovery Calculator', '1.0.0', 'Calculator with cached discovery for better performance.')
     ->setContainer(container())
     ->setLogger(logger())
-    ->setDiscovery(__DIR__, ['.'])
-    ->setCache(new Psr16Cache(new ArrayAdapter()))
+    ->setDiscovery(__DIR__, ['.'], [], new Psr16Cache(new ArrayAdapter()))
     ->build();
 
 $transport = new StdioTransport(logger: logger());

--- a/src/Server/ServerBuilder.php
+++ b/src/Server/ServerBuilder.php
@@ -58,7 +58,7 @@ final class ServerBuilder
 
     private ?LoggerInterface $logger = null;
 
-    private ?CacheInterface $cache = null;
+    private ?CacheInterface $discoveryCache = null;
 
     private ?ToolCallerInterface $toolCaller = null;
 
@@ -220,20 +220,12 @@ final class ServerBuilder
         string $basePath,
         array $scanDirs = ['.', 'src'],
         array $excludeDirs = [],
+        ?CacheInterface $cache = null,
     ): self {
         $this->discoveryBasePath = $basePath;
         $this->discoveryScanDirs = $scanDirs;
         $this->discoveryExcludeDirs = $excludeDirs;
-
-        return $this;
-    }
-
-    /**
-     * Enables discovery caching with the provided cache implementation.
-     */
-    public function setCache(CacheInterface $cache): self
-    {
-        $this->cache = $cache;
+        $this->discoveryCache = $cache;
 
         return $this;
     }
@@ -323,8 +315,8 @@ final class ServerBuilder
         if (null !== $this->discoveryBasePath) {
             $discovery = new Discoverer($registry, $logger);
 
-            if (null !== $this->cache) {
-                $discovery = new CachedDiscoverer($discovery, $this->cache, $logger);
+            if (null !== $this->discoveryCache) {
+                $discovery = new CachedDiscoverer($discovery, $this->discoveryCache, $logger);
             }
 
             $discovery->discover($this->discoveryBasePath, $this->discoveryScanDirs, $this->discoveryExcludeDirs);


### PR DESCRIPTION
This PR implements the API improvement suggested by CodeWithKyrian in PR #39.

## Changes

- Integrate cache into setDiscovery(): Add cache as 4th parameter to setDiscovery() method
- Rename property: Change cache to discoveryCache for clarity  
- Remove separate method: Remove the standalone setCache() method
- Update example: Update the cached discovery example to use the new API

## Benefits

- Cleaner API: Cache is now clearly associated with discovery operations
- More intuitive: Users don't need to call two separate methods
- Self-documenting: The API makes it obvious that the cache is for discovery

## Before
```php
Server::make()
    ->setDiscovery(__DIR__, ['.'])
    ->setCache(new Psr16Cache(new ArrayAdapter()))
    ->build();
```

## After  
```php
Server::make()
    ->setDiscovery(__DIR__, ['.'], [], new Psr16Cache(new ArrayAdapter()))
    ->build();
```

This addresses the feedback from the original discovery caching PR to make the API more ergonomic and intuitive.