### PR TITLE
Address issue with pagination limit on builder

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -79,25 +79,7 @@ parameters:
 			path: src/Server/ServerBuilder.php
 
 		-
-			message: '#^Property Mcp\\Server\\ServerBuilder\:\:\$discoveryExcludeDirs type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Server/ServerBuilder.php
-
-		-
 			message: '#^Property Mcp\\Server\\ServerBuilder\:\:\$instructions is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: src/Server/ServerBuilder.php
-
-		-
-			message: '#^Property Mcp\\Server\\ServerBuilder\:\:\$paginationLimit \(int\|null\) is never assigned null so it can be removed from the property type\.$#'
-			identifier: property.unusedType
-			count: 1
-			path: src/Server/ServerBuilder.php
-
-		-
-			message: '#^Property Mcp\\Server\\ServerBuilder\:\:\$paginationLimit is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: src/Server/ServerBuilder.php

--- a/src/JsonRpc/Handler.php
+++ b/src/JsonRpc/Handler.php
@@ -73,6 +73,7 @@ class Handler
         SessionStoreInterface $sessionStore,
         SessionFactoryInterface $sessionFactory,
         LoggerInterface $logger = new NullLogger(),
+        int $paginationLimit = 50,
     ): self {
         return new self(
             messageFactory: MessageFactory::make(),
@@ -82,12 +83,12 @@ class Handler
                 new NotificationHandler\InitializedHandler(),
                 new RequestHandler\InitializeHandler($registry->getCapabilities(), $implementation),
                 new RequestHandler\PingHandler(),
-                new RequestHandler\ListPromptsHandler($referenceProvider),
+                new RequestHandler\ListPromptsHandler($referenceProvider, $paginationLimit),
                 new RequestHandler\GetPromptHandler($promptGetter),
-                new RequestHandler\ListResourcesHandler($referenceProvider),
+                new RequestHandler\ListResourcesHandler($referenceProvider, $paginationLimit),
                 new RequestHandler\ReadResourceHandler($resourceReader),
                 new RequestHandler\CallToolHandler($toolCaller, $logger),
-                new RequestHandler\ListToolsHandler($referenceProvider),
+                new RequestHandler\ListToolsHandler($referenceProvider, $paginationLimit),
             ],
             logger: $logger,
         );

--- a/src/Server/RequestHandler/Reference/Page.php
+++ b/src/Server/RequestHandler/Reference/Page.php
@@ -12,9 +12,9 @@
 namespace Mcp\Server\RequestHandler\Reference;
 
 /**
- * @implements \ArrayAccess<int|string, mixed>
+ * @extends \ArrayObject<int|string, mixed>
  */
-final class Page implements \Countable, \ArrayAccess
+final class Page extends \ArrayObject
 {
     /**
      * @param array<int|string, mixed> $references Items can be Tool, Prompt, ResourceTemplate, or Resource
@@ -23,30 +23,11 @@ final class Page implements \Countable, \ArrayAccess
         public readonly array $references,
         public readonly ?string $nextCursor,
     ) {
+        parent::__construct($references, \ArrayObject::ARRAY_AS_PROPS);
     }
 
     public function count(): int
     {
         return \count($this->references);
-    }
-
-    public function offsetExists(mixed $offset): bool
-    {
-        return isset($this->references[$offset]);
-    }
-
-    public function offsetGet(mixed $offset): mixed
-    {
-        return $this->references[$offset] ?? null;
-    }
-
-    public function offsetSet(mixed $offset, mixed $value): void
-    {
-        return;
-    }
-
-    public function offsetUnset(mixed $offset): void
-    {
-        return;
     }
 }

--- a/src/Server/ServerBuilder.php
+++ b/src/Server/ServerBuilder.php
@@ -76,7 +76,7 @@ final class ServerBuilder
 
     private int $sessionTtl = 3600;
 
-    private ?int $paginationLimit = 50;
+    private int $paginationLimit = 50;
 
     private ?string $instructions = null;
 
@@ -119,6 +119,9 @@ final class ServerBuilder
      * @var array|string[]
      */
     private array $discoveryScanDirs = [];
+    /**
+     * @var array|string[]
+     */
     private array $discoveryExcludeDirs = [];
 
     /**
@@ -337,6 +340,7 @@ final class ServerBuilder
                 sessionStore: $sessionStore,
                 sessionFactory: $sessionFactory,
                 logger: $logger,
+                paginationLimit: $this->paginationLimit,
             ),
             logger: $logger,
         );


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

This is a follow-up to the work done here: https://github.com/modelcontextprotocol/php-sdk/pull/55, to now support pagination limits on the builder. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
