### PR TITLE
[Server] Rename `Server::make()` to `Server::builder()` for better clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 use Mcp\Server;
 use Mcp\Server\Transport\StdioTransport;
 
-Server::make()
+Server::builder()
     ->setServerInfo('Stdio Calculator', '1.1.0', 'Basic Calculator over STDIO transport.')
     ->setDiscovery(__DIR__, ['.'])
     ->build()

--- a/docs/discovery-caching.md
+++ b/docs/discovery-caching.md
@@ -19,7 +19,7 @@ use Mcp\Server;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 
-$server = Server::make()
+$server = Server::builder()
     ->setServerInfo('My Server', '1.0.0')
     ->setDiscovery(__DIR__, ['.'], [], new Psr16Cache(new ArrayAdapter())) // Enable caching
     ->build();
@@ -67,7 +67,7 @@ $cache = DoctrineProvider::wrap(new ArrayCache());
 // Use in-memory cache for fast development cycles
 $cache = new Psr16Cache(new ArrayAdapter());
 
-$server = Server::make()
+$server = Server::builder()
     ->setDiscovery(__DIR__, ['.'], [], $cache)
     ->build();
 ```
@@ -78,7 +78,7 @@ $server = Server::make()
 // Use persistent cache
 $cache = new Psr16Cache(new FilesystemAdapter('mcp-discovery', 0, '/var/cache'));
 
-$server = Server::make()
+$server = Server::builder()
     ->setDiscovery(__DIR__, ['.'], [], $cache)
     ->build();
 ```

--- a/examples/01-discovery-stdio-calculator/server.php
+++ b/examples/01-discovery-stdio-calculator/server.php
@@ -18,7 +18,7 @@ use Mcp\Server\Transport\StdioTransport;
 
 logger()->info('Starting MCP Stdio Calculator Server...');
 
-$server = Server::make()
+$server = Server::builder()
     ->setServerInfo('Stdio Calculator', '1.1.0', 'Basic Calculator over STDIO transport.')
     ->setContainer(container())
     ->setLogger(logger())

--- a/examples/02-discovery-http-userprofile/server.php
+++ b/examples/02-discovery-http-userprofile/server.php
@@ -25,7 +25,7 @@ $creator = new ServerRequestCreator($psr17Factory, $psr17Factory, $psr17Factory,
 
 $request = $creator->fromGlobals();
 
-$server = Server::make()
+$server = Server::builder()
     ->setServerInfo('HTTP User Profiles', '1.0.0')
     ->setLogger(logger())
     ->setContainer(container())

--- a/examples/03-manual-registration-stdio/server.php
+++ b/examples/03-manual-registration-stdio/server.php
@@ -19,7 +19,7 @@ use Mcp\Server\Transport\StdioTransport;
 
 logger()->info('Starting MCP Manual Registration (Stdio) Server...');
 
-$server = Server::make()
+$server = Server::builder()
     ->setServerInfo('Manual Reg Server', '1.0.0')
     ->setLogger(logger())
     ->setContainer(container())

--- a/examples/04-combined-registration-http/server.php
+++ b/examples/04-combined-registration-http/server.php
@@ -26,7 +26,7 @@ $creator = new ServerRequestCreator($psr17Factory, $psr17Factory, $psr17Factory,
 
 $request = $creator->fromGlobals();
 
-$server = Server::make()
+$server = Server::builder()
     ->setServerInfo('Combined HTTP Server', '1.0.0')
     ->setLogger(logger())
     ->setContainer(container())

--- a/examples/05-stdio-env-variables/server.php
+++ b/examples/05-stdio-env-variables/server.php
@@ -49,7 +49,7 @@ use Mcp\Server\Transport\StdioTransport;
 
 logger()->info('Starting MCP Stdio Environment Variable Example Server...');
 
-$server = Server::make()
+$server = Server::builder()
     ->setServerInfo('Env Var Server', '1.0.0')
     ->setLogger(logger())
     ->setDiscovery(__DIR__, ['.'])

--- a/examples/06-custom-dependencies-stdio/server.php
+++ b/examples/06-custom-dependencies-stdio/server.php
@@ -30,7 +30,7 @@ $container->set(TaskRepositoryInterface::class, $taskRepo);
 $statsService = new SystemStatsService($taskRepo);
 $container->set(StatsServiceInterface::class, $statsService);
 
-$server = Server::make()
+$server = Server::builder()
     ->setServerInfo('Task Manager Server', '1.0.0')
     ->setLogger(logger())
     ->setContainer($container)

--- a/examples/07-complex-tool-schema-http/server.php
+++ b/examples/07-complex-tool-schema-http/server.php
@@ -25,7 +25,7 @@ $creator = new ServerRequestCreator($psr17Factory, $psr17Factory, $psr17Factory,
 
 $request = $creator->fromGlobals();
 
-$server = Server::make()
+$server = Server::builder()
     ->setServerInfo('Event Scheduler Server', '1.0.0')
     ->setLogger(logger())
     ->setContainer(container())

--- a/examples/08-schema-showcase-streamable/server.php
+++ b/examples/08-schema-showcase-streamable/server.php
@@ -25,7 +25,7 @@ $creator = new ServerRequestCreator($psr17Factory, $psr17Factory, $psr17Factory,
 
 $request = $creator->fromGlobals();
 
-$server = Server::make()
+$server = Server::builder()
     ->setServerInfo('Schema Showcase', '1.0.0')
     ->setContainer(container())
     ->setLogger(logger())

--- a/examples/09-cached-discovery-stdio/server.php
+++ b/examples/09-cached-discovery-stdio/server.php
@@ -22,7 +22,7 @@ use Symfony\Component\Cache\Psr16Cache;
 
 logger()->info('Starting MCP Cached Discovery Calculator Server...');
 
-$server = Server::make()
+$server = Server::builder()
     ->setServerInfo('Cached Discovery Calculator', '1.0.0', 'Calculator with cached discovery for better performance.')
     ->setContainer(container())
     ->setLogger(logger())

--- a/src/Server.php
+++ b/src/Server.php
@@ -30,7 +30,7 @@ final class Server
     ) {
     }
 
-    public static function make(): ServerBuilder
+    public static function builder(): ServerBuilder
     {
         return new ServerBuilder();
     }


### PR DESCRIPTION
This PR renames the static method `Server::make()` to `Server::builder()` for better semantic clarity.

**Why this change:**

The `make()` method is ambiguous and could imply creating a server directly, but `builder()` clearly indicates you're getting a builder object, not a server instance. Besides, it has a more intuitive flow as `Server::builder()->setLogger()->build()` reads naturally.

**Changes:**
- Renamed `Server::make()` to `Server::builder()`
- Updated all examples and documentation to use the new method name