### PR TITLE
[Server] Structured content return and tool error

### DIFF
--- a/src/Schema/Result/CallToolResult.php
+++ b/src/Schema/Result/CallToolResult.php
@@ -38,12 +38,14 @@ class CallToolResult implements ResultInterface
     /**
      * Create a new CallToolResult.
      *
-     * @param Content[] $content The content of the tool result
-     * @param bool      $isError Whether the tool execution resulted in an error.  If not set, this is assumed to be false (the call was successful).
+     * @param Content[] $content           The content of the tool result
+     * @param bool      $isError           Whether the tool execution resulted in an error.  If not set, this is assumed to be false (the call was successful).
+     * @param mixed[]   $structuredContent JSON content for `structuredContent`
      */
     public function __construct(
         public readonly array $content,
         public readonly bool $isError = false,
+        public readonly ?array $structuredContent = null,
     ) {
         foreach ($this->content as $item) {
             if (!$item instanceof Content) {
@@ -107,9 +109,15 @@ class CallToolResult implements ResultInterface
      */
     public function jsonSerialize(): array
     {
-        return [
+        $result = [
             'content' => $this->content,
             'isError' => $this->isError,
         ];
+
+        if ($this->structuredContent) {
+            $result['structuredContent'] = $this->structuredContent;
+        }
+
+        return $result;
     }
 }

--- a/src/Server/Handler/Request/CallToolHandler.php
+++ b/src/Server/Handler/Request/CallToolHandler.php
@@ -59,14 +59,17 @@ final class CallToolHandler implements RequestHandlerInterface
             }
 
             $result = $this->referenceHandler->handle($reference, $arguments);
-            $formatted = $reference->formatResult($result);
+
+            if (!$result instanceof CallToolResult) {
+                $result = new CallToolResult($reference->formatResult($result));
+            }
 
             $this->logger->debug('Tool executed successfully', [
                 'name' => $toolName,
                 'result_type' => \gettype($result),
             ]);
 
-            return new Response($request->getId(), new CallToolResult($formatted));
+            return new Response($request->getId(), $result);
         } catch (ToolNotFoundException $e) {
             $this->logger->error('Tool not found', ['name' => $toolName]);
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Added optional `structuredContent` for `CallToolResult` which enables return of structured content when we provide output schema for a tool.

Added ability to return `CallToolResult` from tool directly, which enables proper return of tool errors to allow LLM to self-correct tool call.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
While testing my MCP server I've noticed inconsistencies between output with Python MCP server.
1. There was no possibility and no implementation for `structuredContent`
2. There was no possibility to return `isError=true`

Also while `outputSchema` being added in https://github.com/modelcontextprotocol/php-sdk/pull/88 , with `outputSchema` MCP server **MUST** provide structured content alongside text representation.


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Tested on my MCP server to ensure same response between PHP and Python versions.
Added unit tests.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->


