### PR TITLE
Removed redundant Builder.setServerCapabilities duplicate method

### DIFF
--- a/examples/stdio-explicit-registration/server.php
+++ b/examples/stdio-explicit-registration/server.php
@@ -28,7 +28,7 @@ $server = Server::builder()
     ->addResource([SimpleHandlers::class, 'getAppVersion'], 'app://version', 'application_version', mimeType: 'text/plain')
     ->addPrompt([SimpleHandlers::class, 'greetingPrompt'], 'personalized_greeting')
     ->addResourceTemplate([SimpleHandlers::class, 'getItemDetails'], 'item://{itemId}/details', 'get_item_details', mimeType: 'application/json')
-    ->setServerCapabilities(new ServerCapabilities(
+    ->setCapabilities(new ServerCapabilities(
         tools: true,
         toolsListChanged: false,
         resources: true,

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -75,8 +75,6 @@ final class Builder
 
     private ?string $instructions = null;
 
-    private ?ServerCapabilities $explicitCapabilities = null;
-
     /**
      * @var array<int, MethodHandlerInterface>
      */
@@ -177,9 +175,9 @@ final class Builder
     /**
      * Explicitly set server capabilities. If set, this overrides automatic detection.
      */
-    public function setCapabilities(ServerCapabilities $capabilities): self
+    public function setCapabilities(ServerCapabilities $serverCapabilities): self
     {
-        $this->explicitCapabilities = $capabilities;
+        $this->serverCapabilities = $serverCapabilities;
 
         return $this;
     }
@@ -262,13 +260,6 @@ final class Builder
         $this->discoveryScanDirs = $scanDirs;
         $this->discoveryExcludeDirs = $excludeDirs;
         $this->discoveryCache = $cache;
-
-        return $this;
-    }
-
-    public function setServerCapabilities(ServerCapabilities $serverCapabilities): self
-    {
-        $this->serverCapabilities = $serverCapabilities;
 
         return $this;
     }
@@ -370,7 +361,7 @@ final class Builder
         $sessionStore = $this->sessionStore ?? new InMemorySessionStore($sessionTtl);
         $messageFactory = MessageFactory::make();
 
-        $capabilities = $this->explicitCapabilities ?? $registry->getCapabilities();
+        $capabilities = $registry->getCapabilities();
         $configuration = new Configuration($this->serverInfo, $capabilities, $this->paginationLimit, $this->instructions);
         $referenceHandler = new ReferenceHandler($container);
 
@@ -597,7 +588,8 @@ final class Builder
         }
 
         if (\is_array($handler)) {
-            return \sprintf('%s::%s',
+            return \sprintf(
+                '%s::%s',
                 \is_object($handler[0]) ? $handler[0]::class : $handler[0],
                 $handler[1],
             );


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
While trying to integrate logging with ServerCapabilities, I discovered that we have two methods and private properties on the Builder class that store ServerCapabilities. This PR removes the duplicate, so we maintain just one interface for setting ServerCapabilities
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes
## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
