### PR TITLE
[Server] Ability to set custom protocol version

### DIFF
--- a/src/Schema/Enum/ProtocolVersion.php
+++ b/src/Schema/Enum/ProtocolVersion.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Schema\Enum;
+
+/**
+ * Available protocol versions for MCP.
+ */
+enum ProtocolVersion: string
+{
+    case V2024_11_05 = '2024-11-05';
+
+    case V2025_03_26 = '2025-03-26';
+
+    case V2025_06_18 = '2025-06-18';
+}

--- a/src/Schema/JsonRpc/MessageInterface.php
+++ b/src/Schema/JsonRpc/MessageInterface.php
@@ -11,6 +11,8 @@
 
 namespace Mcp\Schema\JsonRpc;
 
+use Mcp\Schema\Enum\ProtocolVersion;
+
 /**
  * Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent.
  *
@@ -19,5 +21,5 @@ namespace Mcp\Schema\JsonRpc;
 interface MessageInterface extends \JsonSerializable
 {
     public const JSONRPC_VERSION = '2.0';
-    public const PROTOCOL_VERSION = '2025-06-18';
+    public const PROTOCOL_VERSION = ProtocolVersion::V2025_06_18;
 }

--- a/src/Schema/Result/InitializeResult.php
+++ b/src/Schema/Result/InitializeResult.php
@@ -12,6 +12,7 @@
 namespace Mcp\Schema\Result;
 
 use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\Enum\ProtocolVersion;
 use Mcp\Schema\Implementation;
 use Mcp\Schema\JsonRpc\MessageInterface;
 use Mcp\Schema\JsonRpc\Response;
@@ -38,6 +39,7 @@ class InitializeResult implements ResultInterface
         public readonly Implementation $serverInfo,
         public readonly ?string $instructions = null,
         public readonly ?array $_meta = null,
+        public readonly ?ProtocolVersion $protocolVersion = null,
     ) {
     }
 
@@ -66,7 +68,8 @@ class InitializeResult implements ResultInterface
             ServerCapabilities::fromArray($data['capabilities']),
             Implementation::fromArray($data['serverInfo']),
             $data['instructions'] ?? null,
-            $data['_meta'] ?? null
+            $data['_meta'] ?? null,
+            ProtocolVersion::tryFrom($data['protocolVersion']),
         );
     }
 
@@ -81,8 +84,9 @@ class InitializeResult implements ResultInterface
      */
     public function jsonSerialize(): array
     {
+        $protocolVersion = $this->protocolVersion ?? MessageInterface::PROTOCOL_VERSION;
         $data = [
-            'protocolVersion' => MessageInterface::PROTOCOL_VERSION,
+            'protocolVersion' => $protocolVersion->value,
             'capabilities' => $this->capabilities,
             'serverInfo' => $this->serverInfo,
         ];

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -27,6 +27,7 @@ use Mcp\Capability\Registry\ReferenceHandler;
 use Mcp\Exception\ConfigurationException;
 use Mcp\JsonRpc\MessageFactory;
 use Mcp\Schema\Annotations;
+use Mcp\Schema\Enum\ProtocolVersion;
 use Mcp\Schema\Implementation;
 use Mcp\Schema\Prompt;
 use Mcp\Schema\PromptArgument;
@@ -74,6 +75,8 @@ final class Builder
     private int $paginationLimit = 50;
 
     private ?string $instructions = null;
+
+    private ?ProtocolVersion $protocolVersion = null;
 
     /**
      * @var array<int, RequestHandlerInterface>
@@ -293,6 +296,13 @@ final class Builder
         return $this;
     }
 
+    public function setProtocolVersion(?ProtocolVersion $protocolVersion): self
+    {
+        $this->protocolVersion = $protocolVersion;
+
+        return $this;
+    }
+
     /**
      * Manually registers a tool handler.
      *
@@ -391,7 +401,7 @@ final class Builder
         $messageFactory = MessageFactory::make();
 
         $capabilities = $registry->getCapabilities();
-        $configuration = new Configuration($this->serverInfo, $capabilities, $this->paginationLimit, $this->instructions);
+        $configuration = new Configuration($this->serverInfo, $capabilities, $this->paginationLimit, $this->instructions, $this->protocolVersion);
         $referenceHandler = new ReferenceHandler($container);
 
         $requestHandlers = array_merge($this->requestHandlers, [

--- a/src/Server/Configuration.php
+++ b/src/Server/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Mcp\Server;
 
+use Mcp\Schema\Enum\ProtocolVersion;
 use Mcp\Schema\Implementation;
 use Mcp\Schema\ServerCapabilities;
 
@@ -34,6 +35,7 @@ class Configuration
         public readonly ServerCapabilities $capabilities,
         public readonly int $paginationLimit = 50,
         public readonly ?string $instructions = null,
+        public readonly ?ProtocolVersion $protocolVersion = null,
     ) {
     }
 }

--- a/src/Server/Handler/Request/InitializeHandler.php
+++ b/src/Server/Handler/Request/InitializeHandler.php
@@ -47,6 +47,8 @@ final class InitializeHandler implements RequestHandlerInterface
                 $this->configuration->capabilities ?? new ServerCapabilities(),
                 $this->configuration->serverInfo ?? new Implementation(),
                 $this->configuration?->instructions,
+                null,
+                $this->configuration?->protocolVersion,
             ),
         );
     }

--- a/tests/Unit/Server/Handler/Request/InitializeHandlerTest.php
+++ b/tests/Unit/Server/Handler/Request/InitializeHandlerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Server\Handler\Request;
+
+use Mcp\Schema\Enum\ProtocolVersion;
+use Mcp\Schema\Implementation;
+use Mcp\Schema\JsonRpc\MessageInterface;
+use Mcp\Schema\Request\InitializeRequest;
+use Mcp\Schema\Result\InitializeResult;
+use Mcp\Schema\ServerCapabilities;
+use Mcp\Server\Configuration;
+use Mcp\Server\Handler\Request\InitializeHandler;
+use Mcp\Server\Session\SessionInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+class InitializeHandlerTest extends TestCase
+{
+    #[TestDox('uses configuration protocol version when provided')]
+    public function testHandleUsesConfigurationProtocolVersion(): void
+    {
+        $customProtocolVersion = ProtocolVersion::V2024_11_05;
+
+        $configuration = new Configuration(
+            serverInfo: new Implementation('server', '1.2.3'),
+            capabilities: new ServerCapabilities(),
+            protocolVersion: $customProtocolVersion,
+        );
+
+        $handler = new InitializeHandler($configuration);
+
+        $session = $this->createMock(SessionInterface::class);
+        $session->expects($this->once())
+            ->method('set')
+            ->with('client_info', [
+                'name' => 'client-app',
+                'version' => '1.0.0',
+            ]);
+
+        $request = InitializeRequest::fromArray([
+            'jsonrpc' => MessageInterface::JSONRPC_VERSION,
+            'id' => 'request-1',
+            'method' => InitializeRequest::getMethod(),
+            'params' => [
+                'protocolVersion' => ProtocolVersion::V2024_11_05->value,
+                'capabilities' => [],
+                'clientInfo' => [
+                    'name' => 'client-app',
+                    'version' => '1.0.0',
+                ],
+            ],
+        ]);
+
+        $response = $handler->handle($request, $session);
+
+        $this->assertInstanceOf(InitializeResult::class, $response->result);
+
+        /** @var InitializeResult $result */
+        $result = $response->result;
+
+        $this->assertSame($customProtocolVersion, $result->protocolVersion);
+        $this->assertSame(
+            $customProtocolVersion->value,
+            $result->jsonSerialize()['protocolVersion']
+        );
+    }
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Added ability to set custom protocol version.
This enables usage of clients which doesn't support newest MCP version and will allow to change schema version in future.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
<img width="1775" height="905" alt="image" src="https://github.com/user-attachments/assets/4ea11be7-81d9-4e75-830a-479aeb307499" />
Jetbrains AI Assistant uses oldest `2024-11-05` for example.  

Some clients doesn't support newest version but work perfectly fine with 90%+ of SDK functionality.  
This allows us at least for now use of those clients, at least while [Schema Versioning](https://github.com/modelcontextprotocol/php-sdk/issues/14) won't be resolved.


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Unit test.
Jetbrains AI Assistant
<img width="1787" height="1309" alt="image" src="https://github.com/user-attachments/assets/d130610f-156f-482e-ba07-8d1ccf44a8b6" />


## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
