### PR TITLE
[Server] Add PSR-17 factory auto-discovery to StreamableHttpTransport

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "php": "^8.1",
     "ext-fileinfo": "*",
     "opis/json-schema": "^2.4",
+    "php-http/discovery": "^1.20",
     "phpdocumentor/reflection-docblock": "^5.6",
     "psr/clock": "^1.0",
     "psr/container": "^2.0",
@@ -64,6 +65,9 @@
     }
   },
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "php-http/discovery": false
+    }
   }
 }

--- a/examples/http-combined-registration/server.php
+++ b/examples/http-combined-registration/server.php
@@ -13,18 +13,15 @@
 require_once dirname(__DIR__).'/bootstrap.php';
 chdir(__DIR__);
 
+use Http\Discovery\Psr17Factory;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Mcp\Example\HttpCombinedRegistration\ManualHandlers;
 use Mcp\Server;
 use Mcp\Server\Session\FileSessionStore;
 use Mcp\Server\Transport\StreamableHttpTransport;
-use Nyholm\Psr7\Factory\Psr17Factory;
-use Nyholm\Psr7Server\ServerRequestCreator;
 
 $psr17Factory = new Psr17Factory();
-$creator = new ServerRequestCreator($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
-
-$request = $creator->fromGlobals();
+$request = $psr17Factory->createServerRequestFromGlobals();
 
 $server = Server::builder()
     ->setServerInfo('Combined HTTP Server', '1.0.0')
@@ -40,7 +37,7 @@ $server = Server::builder()
     )
     ->build();
 
-$transport = new StreamableHttpTransport($request, $psr17Factory, $psr17Factory);
+$transport = new StreamableHttpTransport($request);
 
 $response = $server->run($transport);
 

--- a/examples/http-complex-tool-schema/server.php
+++ b/examples/http-complex-tool-schema/server.php
@@ -13,17 +13,14 @@
 require_once dirname(__DIR__).'/bootstrap.php';
 chdir(__DIR__);
 
+use Http\Discovery\Psr17Factory;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Mcp\Server;
 use Mcp\Server\Session\FileSessionStore;
 use Mcp\Server\Transport\StreamableHttpTransport;
-use Nyholm\Psr7\Factory\Psr17Factory;
-use Nyholm\Psr7Server\ServerRequestCreator;
 
 $psr17Factory = new Psr17Factory();
-$creator = new ServerRequestCreator($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
-
-$request = $creator->fromGlobals();
+$request = $psr17Factory->createServerRequestFromGlobals();
 
 $server = Server::builder()
     ->setServerInfo('Event Scheduler Server', '1.0.0')
@@ -33,7 +30,7 @@ $server = Server::builder()
     ->setDiscovery(__DIR__, ['.'])
     ->build();
 
-$transport = new StreamableHttpTransport($request, $psr17Factory, $psr17Factory);
+$transport = new StreamableHttpTransport($request);
 
 $response = $server->run($transport);
 

--- a/examples/http-discovery-userprofile/server.php
+++ b/examples/http-discovery-userprofile/server.php
@@ -13,17 +13,14 @@
 require_once dirname(__DIR__).'/bootstrap.php';
 chdir(__DIR__);
 
+use Http\Discovery\Psr17Factory;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Mcp\Server;
 use Mcp\Server\Session\FileSessionStore;
 use Mcp\Server\Transport\StreamableHttpTransport;
-use Nyholm\Psr7\Factory\Psr17Factory;
-use Nyholm\Psr7Server\ServerRequestCreator;
 
 $psr17Factory = new Psr17Factory();
-$creator = new ServerRequestCreator($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
-
-$request = $creator->fromGlobals();
+$request = $psr17Factory->createServerRequestFromGlobals();
 
 $server = Server::builder()
     ->setServerInfo('HTTP User Profiles', '1.0.0')
@@ -75,7 +72,7 @@ $server = Server::builder()
     )
     ->build();
 
-$transport = new StreamableHttpTransport($request, $psr17Factory, $psr17Factory);
+$transport = new StreamableHttpTransport($request);
 
 $response = $server->run($transport);
 

--- a/examples/http-schema-showcase/server.php
+++ b/examples/http-schema-showcase/server.php
@@ -13,17 +13,14 @@
 require_once dirname(__DIR__).'/bootstrap.php';
 chdir(__DIR__);
 
+use Http\Discovery\Psr17Factory;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Mcp\Server;
 use Mcp\Server\Session\FileSessionStore;
 use Mcp\Server\Transport\StreamableHttpTransport;
-use Nyholm\Psr7\Factory\Psr17Factory;
-use Nyholm\Psr7Server\ServerRequestCreator;
 
 $psr17Factory = new Psr17Factory();
-$creator = new ServerRequestCreator($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
-
-$request = $creator->fromGlobals();
+$request = $psr17Factory->createServerRequestFromGlobals();
 
 $server = Server::builder()
     ->setServerInfo('Schema Showcase', '1.0.0')
@@ -33,7 +30,7 @@ $server = Server::builder()
     ->setDiscovery(__DIR__, ['.'])
     ->build();
 
-$transport = new StreamableHttpTransport($request, $psr17Factory, $psr17Factory);
+$transport = new StreamableHttpTransport($request);
 
 $response = $server->run($transport);
 


### PR DESCRIPTION
This PR introduces PSR-17 factory auto-discovery to the `StreamableHttpTransport`, simplifying HTTP transport initialization by automatically discovering `ResponseFactory` and `StreamFactory` implementations.

## Motivation & Context
The original implementation required developers to manually create and pass PSR-17 factory instances, adding unnecessary boilerplate to every HTTP transport usage. This was particularly cumbersome in simple use cases and examples where the choice of PSR-7 implementation wasn't critical. By implementing auto-discovery, we can provide a much cleaner API while still allowing explicit factory injection when needed.

## What's Changed
- Added `php-http/discovery` dependency for PSR-17 factory discovery
- Made `ResponseFactory` and `StreamFactory` constructor parameters optional with fallback to auto discovery
- Updated all HTTP examples to use the simplified API with `Psr17Factory` (from `php-http/discovery`)
- Updated documentation to explain auto-discovery behavior and supported packages
- Disabled automatic plugin installation for `php-http/discovery`

## Breaking Changes
None. Existing code continues to work unchanged, and the simplified API is opt-in.