### PR TITLE
[Server] bugfix: Cache discovery is unavailable #113

### DIFF
--- a/src/Capability/Discovery/Discoverer.php
+++ b/src/Capability/Discovery/Discoverer.php
@@ -20,7 +20,6 @@ use Mcp\Capability\Completion\EnumCompletionProvider;
 use Mcp\Capability\Completion\ListCompletionProvider;
 use Mcp\Capability\Completion\ProviderInterface;
 use Mcp\Capability\Registry\PromptReference;
-use Mcp\Capability\Registry\ReferenceRegistryInterface;
 use Mcp\Capability\Registry\ResourceReference;
 use Mcp\Capability\Registry\ResourceTemplateReference;
 use Mcp\Capability\Registry\ToolReference;
@@ -48,7 +47,6 @@ use Symfony\Component\Finder\SplFileInfo;
 class Discoverer
 {
     public function __construct(
-        private readonly ReferenceRegistryInterface $registry,
         private readonly LoggerInterface $logger = new NullLogger(),
         private ?DocBlockParser $docBlockParser = null,
         private ?SchemaGenerator $schemaGenerator = null,
@@ -95,10 +93,7 @@ class Discoverer
                     'base_path' => $basePath,
                 ]);
 
-                $emptyState = new DiscoveryState();
-                $this->registry->setDiscoveryState($emptyState);
-
-                return $emptyState;
+                return new DiscoveryState();
             }
 
             $finder->files()
@@ -125,11 +120,7 @@ class Discoverer
             'resourceTemplates' => $discoveredCount['resourceTemplates'],
         ]);
 
-        $discoveryState = new DiscoveryState($tools, $resources, $prompts, $resourceTemplates);
-
-        $this->registry->setDiscoveryState($discoveryState);
-
-        return $discoveryState;
+        return new DiscoveryState($tools, $resources, $prompts, $resourceTemplates);
     }
 
     /**

--- a/src/Capability/Registry/Loader/DiscoveryLoader.php
+++ b/src/Capability/Registry/Loader/DiscoveryLoader.php
@@ -38,12 +38,14 @@ final class DiscoveryLoader implements LoaderInterface
     public function load(ReferenceRegistryInterface $registry): void
     {
         // This now encapsulates the discovery process
-        $discoverer = new Discoverer($registry, $this->logger);
+        $discoverer = new Discoverer($this->logger);
 
         $cachedDiscoverer = $this->cache
             ? new CachedDiscoverer($discoverer, $this->cache, $this->logger)
             : $discoverer;
 
-        $cachedDiscoverer->discover($this->basePath, $this->scanDirs, $this->excludeDirs);
+        $discoveryState = $cachedDiscoverer->discover($this->basePath, $this->scanDirs, $this->excludeDirs);
+
+        $registry->setDiscoveryState($discoveryState);
     }
 }

--- a/tests/Unit/Capability/Discovery/CachedDiscovererTest.php
+++ b/tests/Unit/Capability/Discovery/CachedDiscovererTest.php
@@ -14,7 +14,6 @@ namespace Mcp\Tests\Unit\Capability\Discovery;
 use Mcp\Capability\Discovery\CachedDiscoverer;
 use Mcp\Capability\Discovery\Discoverer;
 use Mcp\Capability\Discovery\DiscoveryState;
-use Mcp\Capability\Registry;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Psr\SimpleCache\CacheInterface;
@@ -23,8 +22,7 @@ class CachedDiscovererTest extends TestCase
 {
     public function testCachedDiscovererUsesCacheOnSecondCall(): void
     {
-        $registry = new Registry(null, new NullLogger());
-        $discoverer = new Discoverer($registry, new NullLogger());
+        $discoverer = new Discoverer();
 
         $cache = $this->createMock(CacheInterface::class);
         $cache->expects($this->once())
@@ -47,8 +45,7 @@ class CachedDiscovererTest extends TestCase
 
     public function testCachedDiscovererReturnsCachedResults(): void
     {
-        $registry = new Registry(null, new NullLogger());
-        $discoverer = new Discoverer($registry, new NullLogger());
+        $discoverer = new Discoverer();
 
         $cache = $this->createMock(CacheInterface::class);
         $cachedState = new DiscoveryState();
@@ -71,8 +68,7 @@ class CachedDiscovererTest extends TestCase
 
     public function testCacheKeyGeneration(): void
     {
-        $registry = new Registry(null, new NullLogger());
-        $discoverer = new Discoverer($registry, new NullLogger());
+        $discoverer = new Discoverer();
 
         $cache = $this->createMock(CacheInterface::class);
 


### PR DESCRIPTION
## Problem Description

The cached discovery functionality was not working correctly because the `DiscoveryLoader` was not calling `$registry->setDiscoveryState($discoveryState)` when using cached results. This caused a critical issue where:

1. **Cache Hit Scenario**: When `CachedDiscoverer` returned cached `DiscoveryState` from the cache, the `DiscoveryLoader` would receive the cached state but never apply it to the registry via `setDiscoveryState()`.

2. **Registry State Mismatch**: The registry would remain empty or contain stale data, even though the discovery process had successfully retrieved cached results.

3. **Silent Failure**: This bug was particularly insidious because it would fail silently - the cache would appear to work (no errors thrown), but the discovered MCP elements (tools, resources, prompts, resource templates) would not be available in the registry.

## Root Cause Analysis

The issue occurred during the refactoring of the discovery process in PR #111. The original `Discoverer::discover()` method was responsible for both:
- Performing the discovery process
- Setting the discovery state on the registry via `$this->registry->setDiscoveryState($discoveryState)`

However, when the discovery logic was moved to `DiscoveryLoader`, the responsibility for setting the discovery state was not properly transferred. The `DiscoveryLoader` was calling the discoverer but not applying the returned `DiscoveryState` to the registry.

## Technical Details

**Before Fix:**
```php
// DiscoveryLoader.php - BROKEN
$cachedDiscoverer->discover($this->basePath, $this->scanDirs, $this->excludeDirs);
// Missing: $registry->setDiscoveryState($discoveryState);
```

**After Fix:**
```php
// DiscoveryLoader.php - FIXED
$discoveryState = $cachedDiscoverer->discover($this->basePath, $this->scanDirs, $this->excludeDirs);
$registry->setDiscoveryState($discoveryState);
```

## Impact

- **Performance**: Cached discovery was not providing the expected performance benefits
- **Functionality**: MCP servers using cached discovery would not expose their discovered capabilities
- **User Experience**: Tools, resources, and prompts would not be available to MCP clients

## Solution

This fix ensures that:
1. The `DiscoveryLoader` properly captures the `DiscoveryState` returned by the discoverer (whether cached or fresh)
2. The `DiscoveryState` is applied to the registry via `setDiscoveryState()`
3. Both cached and non-cached discovery paths work identically
4. The registry contains the correct discovered elements regardless of cache hit/miss

## Testing

The fix maintains backward compatibility and ensures that:
- Fresh discovery works as before
- Cached discovery now properly populates the registry
- All existing tests continue to pass
- The `stdio-cached-discovery` example now functions correctly

## Files Changed

- `src/Capability/Registry/Loader/DiscoveryLoader.php`: Added missing `setDiscoveryState()` call
- `src/Capability/Discovery/Discoverer.php`: Removed redundant `setDiscoveryState()` call (now handled by loader)

## Summary

This fix resolves the core issue where cached discovery results were not being applied to the registry, ensuring that MCP servers can properly utilize cached discovery for improved performance while maintaining full functionality.

---

**Type**: Bug Fix  
**Breaking Change**: No  
**Related Issue**: Fixes cached discovery functionality introduced in PR #111
