### PR TITLE
[Server] Fix: extract and pass URI template variables to resource handlers

### DIFF
--- a/examples/http-discovery-userprofile/McpElements.php
+++ b/examples/http-discovery-userprofile/McpElements.php
@@ -16,6 +16,7 @@ use Mcp\Capability\Attribute\McpPrompt;
 use Mcp\Capability\Attribute\McpResource;
 use Mcp\Capability\Attribute\McpResourceTemplate;
 use Mcp\Capability\Attribute\McpTool;
+use Mcp\Exception\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -47,7 +48,7 @@ final class McpElements
      *
      * @return User user profile data
      *
-     * @throws McpServerException if the user is not found
+     * @throws InvalidArgumentException if the user is not found
      */
     #[McpResourceTemplate(
         uriTemplate: 'user://{userId}/profile',
@@ -61,8 +62,7 @@ final class McpElements
     ): array {
         $this->logger->info('Reading resource: user profile', ['userId' => $userId]);
         if (!isset($this->users[$userId])) {
-            // Throwing an exception that Processor can turn into an error response
-            throw McpServerException::invalidParams("User profile not found for ID: {$userId}");
+            throw new InvalidArgumentException("User profile not found for ID: {$userId}");
         }
 
         return $this->users[$userId];
@@ -130,7 +130,7 @@ final class McpElements
      *
      * @return array<string, string>[] prompt messages
      *
-     * @throws McpServerException if user not found
+     * @throws InvalidArgumentException if user not found
      */
     #[McpPrompt(name: 'generate_bio_prompt')]
     public function generateBio(
@@ -140,7 +140,7 @@ final class McpElements
     ): array {
         $this->logger->info('Executing prompt: generate_bio', ['userId' => $userId, 'tone' => $tone]);
         if (!isset($this->users[$userId])) {
-            throw McpServerException::invalidParams("User not found for bio prompt: {$userId}");
+            throw new InvalidArgumentException("User not found for bio prompt: {$userId}");
         }
         $user = $this->users[$userId];
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,18 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to static method invalidParams\(\) on an unknown class Mcp\\Example\\HttpDiscoveryUserProfile\\McpServerException\.$#'
-			identifier: class.notFound
-			count: 2
-			path: examples/http-discovery-userprofile/McpElements.php
-
-		-
-			message: '#^PHPDoc tag @throws with type Mcp\\Example\\HttpDiscoveryUserProfile\\McpServerException is not subtype of Throwable$#'
-			identifier: throws.notThrowable
-			count: 2
-			path: examples/http-discovery-userprofile/McpElements.php
-
-		-
 			message: '#^Method Mcp\\Schema\\Result\\ReadResourceResult\:\:jsonSerialize\(\) should return array\{contents\: array\<Mcp\\Schema\\Content\\BlobResourceContents\|Mcp\\Schema\\Content\\TextResourceContents\>\} but returns array\{contents\: array\<Mcp\\Schema\\Content\\ResourceContents\>\}\.$#'
 			identifier: return.type
 			count: 1

--- a/src/Capability/Registry/ResourceTemplateReference.php
+++ b/src/Capability/Registry/ResourceTemplateReference.php
@@ -57,18 +57,17 @@ class ResourceTemplateReference extends ElementReference
 
     public function matches(string $uri): bool
     {
-        if (preg_match($this->uriTemplateRegex, $uri, $matches)) {
-            $variables = [];
-            foreach ($this->variableNames as $varName) {
-                if (isset($matches[$varName])) {
-                    $variables[$varName] = $matches[$varName];
-                }
-            }
+        return 1 === preg_match($this->uriTemplateRegex, $uri);
+    }
 
-            return true;
-        }
+    /** @return array<string, mixed> */
+    public function extractVariables(string $uri): array
+    {
+        $matches = [];
 
-        return false;
+        preg_match($this->uriTemplateRegex, $uri, $matches);
+
+        return array_filter($matches, fn ($key) => \in_array($key, $this->variableNames), \ARRAY_FILTER_USE_KEY);
     }
 
     /**

--- a/src/Server/Handler/Request/ReadResourceHandler.php
+++ b/src/Server/Handler/Request/ReadResourceHandler.php
@@ -65,11 +65,14 @@ final class ReadResourceHandler implements RequestHandlerInterface
                 '_session' => $session,
             ];
 
-            $result = $this->referenceHandler->handle($reference, $arguments);
-
             if ($reference instanceof ResourceTemplateReference) {
+                $variables = $reference->extractVariables($uri);
+                $arguments = array_merge($arguments, $variables);
+
+                $result = $this->referenceHandler->handle($reference, $arguments);
                 $formatted = $reference->formatResult($result, $uri, $reference->resourceTemplate->mimeType);
             } else {
+                $result = $this->referenceHandler->handle($reference, $arguments);
                 $formatted = $reference->formatResult($result, $uri, $reference->schema->mimeType);
             }
 


### PR DESCRIPTION
This PR fixes resource template functionality by properly extracting URI template variables and passing them to resource handler methods.

## Motivation & Context
Resource templates have never worked correctly since their implementation. While the URI matching logic was functional, the extracted variables from URI patterns (like `userId` from `user://{userId}/profile`) were not being passed to handler methods, making it impossible for handlers to receive the expected parameters and rendering resource templates completely non-functional.

## What's Changed
- Added method to `ResourceTemplateReference` to extract variables from URIs using regex matches
- Modified `ReadResourceHandler` to detect template references and merge extracted variables into handler arguments

## Breaking Changes
None