### PR TITLE
[Server] Change visibility of StreamableHttpTransport methods to protected

### DIFF
--- a/src/Server/Transport/StreamableHttpTransport.php
+++ b/src/Server/Transport/StreamableHttpTransport.php
@@ -208,7 +208,7 @@ class StreamableHttpTransport extends BaseTransport implements TransportInterfac
         return $this->withCorsHeaders($response);
     }
 
-    private function handleFiberTermination(): void
+    protected function handleFiberTermination(): void
     {
         $finalResult = $this->sessionFiber->getReturn();
 
@@ -227,7 +227,7 @@ class StreamableHttpTransport extends BaseTransport implements TransportInterfac
         $this->sessionFiber = null;
     }
 
-    private function flushOutgoingMessages(?Uuid $sessionId): void
+    protected function flushOutgoingMessages(?Uuid $sessionId): void
     {
         $messages = $this->getOutgoingMessages($sessionId);
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
<!-- Why is this change needed? What problem does it solve? -->
hi, I am integrating this SDK with `webman` framework. When using `ClientGateway` to send logs, I noticed that the messages are being output to the console, because webman framework starts multiple processes through the console and creates httpserver via socket, so it outputs to the console. Now I need to extend `StreamableHttpTransport` to send the results to the stream instead.
<img width="1678" height="378" alt="image" src="https://github.com/user-attachments/assets/a00c0222-9146-422f-a3ef-4c79fee1c8ca" />


## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
