### PR TITLE
[Server] Add meta parameter to addTool and addResource methods

### DIFF
--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -315,6 +315,7 @@ final class Builder
      *
      * @param Handler                   $handler
      * @param array<string, mixed>|null $inputSchema
+     * @param array<string, mixed>|null $meta
      */
     public function addTool(
         callable|array|string $handler,
@@ -322,8 +323,9 @@ final class Builder
         ?string $description = null,
         ?ToolAnnotations $annotations = null,
         ?array $inputSchema = null,
+        ?array $meta = null,
     ): self {
-        $this->tools[] = compact('handler', 'name', 'description', 'annotations', 'inputSchema');
+        $this->tools[] = compact('handler', 'name', 'description', 'annotations', 'inputSchema', 'meta');
 
         return $this;
     }
@@ -331,7 +333,8 @@ final class Builder
     /**
      * Manually registers a resource handler.
      *
-     * @param Handler $handler
+     * @param Handler                   $handler
+     * @param array<string, mixed>|null $meta
      */
     public function addResource(
         \Closure|array|string $handler,
@@ -341,8 +344,9 @@ final class Builder
         ?string $mimeType = null,
         ?int $size = null,
         ?Annotations $annotations = null,
+        ?array $meta = null,
     ): self {
-        $this->resources[] = compact('handler', 'uri', 'name', 'description', 'mimeType', 'size', 'annotations');
+        $this->resources[] = compact('handler', 'uri', 'name', 'description', 'mimeType', 'size', 'annotations', 'meta');
 
         return $this;
     }


### PR DESCRIPTION
## Summary

Added `meta` parameter to `addTool()` and `addResource()` methods in the Server Builder to allow passing arbitrary metadata when manually registering tools and resources.

## Motivation and Context

The internal array definitions for `$tools` and `$resources` already included `meta: ?array<string, mixed>` in their type definitions, but the corresponding `addTool()` and `addResource()` methods did not expose this parameter. This inconsistency meant that users could not pass metadata when manually registering tools and resources, even though the infrastructure to support it was already in place.

This change brings the public API in line with the internal data structures and provides feature parity with the discovery-based registration system.

## How Has This Been Tested?

- Verified that the parameter is properly added to both methods
- Confirmed that the `compact()` calls include the new `meta` parameter
- Checked that PHPDoc annotations are correctly updated

## Breaking Changes

None. This is a backward-compatible change as the `meta` parameter is optional and defaults to `null`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This change only affects the `addTool()` and `addResource()` methods. The `addResourceTemplate()` and `addPrompt()` methods also have `meta` in their array definitions but were not modified in this PR. These could be addressed in a follow-up PR if needed for consistency.