### PR TITLE
[Server] Fix wrong parameter order when creating the tool from array

### DIFF
--- a/src/Capability/Registry/Loader/ArrayLoader.php
+++ b/src/Capability/Registry/Loader/ArrayLoader.php
@@ -45,6 +45,7 @@ final class ArrayLoader implements LoaderInterface
      *     name: ?string,
      *     description: ?string,
      *     annotations: ?ToolAnnotations,
+     *     icons: ?array<int, \Mcp\Schema\Icon>,
      *     meta: ?array<string, mixed>
      * }[] $tools
      * @param array{
@@ -106,7 +107,14 @@ final class ArrayLoader implements LoaderInterface
 
                 $inputSchema = $data['inputSchema'] ?? $schemaGenerator->generate($reflection);
 
-                $tool = new Tool($name, $inputSchema, $description, $data['annotations'], $data['meta'] ?? null);
+                $tool = new Tool(
+                    name: $name,
+                    inputSchema: $inputSchema,
+                    description: $description,
+                    annotations: $data['annotations'] ?? null,
+                    icons: $data['icons'] ?? null,
+                    meta: $data['meta'] ?? null,
+                );
                 $registry->registerTool($tool, $data['handler'], true);
 
                 $handlerDesc = $this->getHandlerDescription($data['handler']);

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -83,6 +83,7 @@ final class Builder
      *     name: ?string,
      *     description: ?string,
      *     annotations: ?ToolAnnotations,
+     *     icons: ?array<int, Icon>,
      *     meta: ?array<string, mixed>
      * }[]
      */
@@ -315,6 +316,7 @@ final class Builder
      *
      * @param Handler                   $handler
      * @param array<string, mixed>|null $inputSchema
+     * @param Icon[]|null               $icons
      * @param array<string, mixed>|null $meta
      */
     public function addTool(
@@ -323,9 +325,10 @@ final class Builder
         ?string $description = null,
         ?ToolAnnotations $annotations = null,
         ?array $inputSchema = null,
+        ?array $icons = null,
         ?array $meta = null,
     ): self {
-        $this->tools[] = compact('handler', 'name', 'description', 'annotations', 'inputSchema', 'meta');
+        $this->tools[] = compact('handler', 'name', 'description', 'annotations', 'inputSchema', 'icons', 'meta');
 
         return $this;
     }


### PR DESCRIPTION
## Summary

Fix Tool constructor call in ArrayLoader where the `meta` parameter was incorrectly passed to the `icons` position due to missing `icons` argument. Also adds `icons` support to `Builder::addTool()` for consistency with the Tool schema.

## Motivation and Context

The `Tool` class constructor expects 6 parameters: `name`, `inputSchema`, `description`, `annotations`, `icons`, and `meta`. However, `ArrayLoader` was only passing 5 arguments, causing the `meta` value to be assigned to the `icons` parameter instead. This bug would prevent metadata from being properly attached to manually registered tools.

Additionally, the `Builder::addTool()` method didn't support the `icons` parameter, even though the Tool schema includes it. This inconsistency meant users couldn't specify icons when manually registering tools.

## How Has This Been Tested?

- Verified that all parameters are now correctly mapped to their intended positions
- Confirmed that the `compact()` call in Builder includes all necessary keys
- Checked that null coalescing operators are used consistently for optional parameters

## Breaking Changes

**Potentially breaking:** The `Builder::addTool()` method signature has changed. A new `icons` parameter has been added between `inputSchema` and `meta`. 

**Impact:** If users were calling `addTool()` with positional arguments and passing `meta`, they will need to add `null` for the `icons` parameter or switch to named arguments.

**Before:**
->addTool($handler, 'name', 'desc', $annotations, $schema, $meta)**After (positional):**
->addTool($handler, 'name', 'desc', $annotations, $schema, null, $meta)**After (named - recommended):**
->addTool($handler, name: 'name', meta: $meta)## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Changes made:**
1. Fixed `ArrayLoader::load()` to pass all 6 parameters to Tool constructor using named arguments
2. Added null coalescing operator for `annotations` parameter to prevent undefined key warnings
3. Added `icons` parameter to `Builder::addTool()` method signature
4. Updated PHPDoc type definitions in both Builder and ArrayLoader to include `icons`
5. Used named arguments in Tool instantiation for better clarity and maintainability

The use of named arguments makes the code more maintainable and prevents similar parameter ordering bugs in the future.