### PR TITLE
[Schema] Add _meta to CallToolResult

### DIFF
--- a/src/Schema/Result/CallToolResult.php
+++ b/src/Schema/Result/CallToolResult.php
@@ -38,14 +38,16 @@ class CallToolResult implements ResultInterface
     /**
      * Create a new CallToolResult.
      *
-     * @param Content[] $content           The content of the tool result
-     * @param bool      $isError           Whether the tool execution resulted in an error.  If not set, this is assumed to be false (the call was successful).
-     * @param mixed[]   $structuredContent JSON content for `structuredContent`
+     * @param Content[]                 $content           The content of the tool result
+     * @param bool                      $isError           Whether the tool execution resulted in an error.  If not set, this is assumed to be false (the call was successful).
+     * @param mixed[]                   $structuredContent JSON content for `structuredContent`
+     * @param array<string, mixed>|null $meta              Optional metadata
      */
     public function __construct(
         public readonly array $content,
         public readonly bool $isError = false,
         public readonly ?array $structuredContent = null,
+        public readonly ?array $meta = null,
     ) {
         foreach ($this->content as $item) {
             if (!$item instanceof Content) {
@@ -57,27 +59,30 @@ class CallToolResult implements ResultInterface
     /**
      * Create a new CallToolResult with success status.
      *
-     * @param Content[] $content The content of the tool result
+     * @param Content[]                 $content The content of the tool result
+     * @param array<string, mixed>|null $meta    Optional metadata
      */
-    public static function success(array $content): self
+    public static function success(array $content, ?array $meta = null): self
     {
-        return new self($content, false);
+        return new self($content, false, null, $meta);
     }
 
     /**
      * Create a new CallToolResult with error status.
      *
-     * @param Content[] $content The content of the tool result
+     * @param Content[]                 $content The content of the tool result
+     * @param array<string, mixed>|null $meta    Optional metadata
      */
-    public static function error(array $content): self
+    public static function error(array $content, ?array $meta = null): self
     {
-        return new self($content, true);
+        return new self($content, true, null, $meta);
     }
 
     /**
      * @param array{
      *     content: array<mixed>,
      *     isError?: bool,
+     *     _meta?: array<string, mixed>,
      * } $data
      */
     public static function fromArray(array $data): self
@@ -98,13 +103,20 @@ class CallToolResult implements ResultInterface
             };
         }
 
-        return new self($contents, $data['isError'] ?? false);
+        return new self(
+            $contents,
+            $data['isError'] ?? false,
+            $data['structuredContent'] ?? null,
+            $data['_meta'] ?? null
+        );
     }
 
     /**
      * @return array{
      *     content: array<mixed>,
      *     isError: bool,
+     *     structuredContent?: array<mixed>,
+     *     _meta?: array<string, mixed>,
      * }
      */
     public function jsonSerialize(): array
@@ -116,6 +128,10 @@ class CallToolResult implements ResultInterface
 
         if ($this->structuredContent) {
             $result['structuredContent'] = $this->structuredContent;
+        }
+
+        if ($this->meta) {
+            $result['_meta'] = $this->meta;
         }
 
         return $result;


### PR DESCRIPTION
## Summary

Add `_meta` field support to `CallToolResult` to allow passing metadata in tool call responses.

## Motivation and Context

The MCP specification supports a `_meta` field for passing additional metadata in responses. This field was missing from the `CallToolResult` class, preventing servers from including metadata such as execution time, cache status, version information, or other contextual data in tool call responses.

This change brings `CallToolResult` in line with other schema classes that already support the `_meta` field (like `Tool`, `Resource`, etc.), providing a consistent API across the SDK.

## How Has This Been Tested?

- Verified that the `meta` parameter is properly added to the constructor
- Confirmed that `success()` and `error()` static methods accept and pass the `meta` parameter
- Checked that `fromArray()` correctly deserializes the `_meta` field
- Verified that `jsonSerialize()` includes `_meta` in the output when present
- Ensured backward compatibility - all parameters are optional with null defaults

## Breaking Changes

None. This is a backward-compatible change:
- The `meta` parameter is optional with a default value of `null`
- Existing code will continue to work without modifications
- The `_meta` field is only included in JSON output when explicitly provided

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Changes made:**
1. Added `meta` parameter to constructor with PHPDoc
2. Updated `success()` static method to accept and pass `meta`
3. Updated `error()` static method to accept and pass `meta`
4. Updated `fromArray()` to deserialize `_meta` from input
5. Updated `jsonSerialize()` to include `_meta` in output when present
6. Updated all PHPDoc type annotations to reflect the new field

The `_meta` field follows the MCP convention of using an underscore prefix to distinguish it from standard protocol fields.