### PR TITLE
[Server] Add meta to addPrompt and addResourceTemplate  methods

### DIFF
--- a/src/Capability/Registry/Loader/ArrayLoader.php
+++ b/src/Capability/Registry/Loader/ArrayLoader.php
@@ -149,14 +149,14 @@ final class ArrayLoader implements LoaderInterface
                 }
 
                 $resource = new Resource(
-                    $data['uri'],
-                    $name,
-                    $description,
-                    $data['mimeType'],
-                    $data['annotations'],
-                    $data['size'],
-                    $data['icons'],
-                    $data['meta'],
+                    uri: $data['uri'],
+                    name: $name,
+                    description: $description,
+                    mimeType: $data['mimeType'] ?? null,
+                    annotations: $data['annotations'] ?? null,
+                    size: $data['size'] ?? null,
+                    icons: $data['icons'] ?? null,
+                    meta: $data['meta'] ?? null,
                 );
                 $registry->registerResource($resource, $data['handler'], true);
 
@@ -189,12 +189,12 @@ final class ArrayLoader implements LoaderInterface
                 }
 
                 $template = new ResourceTemplate(
-                    $data['uriTemplate'],
-                    $name,
-                    $description,
-                    $data['mimeType'],
-                    $data['annotations'],
-                    $data['meta'],
+                    uriTemplate: $data['uriTemplate'],
+                    name: $name,
+                    description: $description,
+                    mimeType: $data['mimeType'] ?? null,
+                    annotations: $data['annotations'] ?? null,
+                    meta: $data['meta'] ?? null,
                 );
                 $completionProviders = $this->getCompletionProviders($reflection);
                 $registry->registerResourceTemplate($template, $data['handler'], $completionProviders, true);
@@ -246,7 +246,13 @@ final class ArrayLoader implements LoaderInterface
                         !$param->isOptional() && !$param->isDefaultValueAvailable(),
                     );
                 }
-                $prompt = new Prompt($name, $description, $arguments, $data['icons'], $data['meta']);
+                $prompt = new Prompt(
+                    name: $name,
+                    description: $description,
+                    arguments: $arguments,
+                    icons: $data['icons'] ?? null,
+                    meta: $data['meta'] ?? null
+                );
                 $completionProviders = $this->getCompletionProviders($reflection);
                 $registry->registerPrompt($prompt, $data['handler'], $completionProviders, true);
 

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -379,7 +379,8 @@ final class Builder
     /**
      * Manually registers a resource template handler.
      *
-     * @param Handler $handler
+     * @param Handler                   $handler
+     * @param array<string, mixed>|null $meta
      */
     public function addResourceTemplate(
         \Closure|array|string $handler,
@@ -388,6 +389,7 @@ final class Builder
         ?string $description = null,
         ?string $mimeType = null,
         ?Annotations $annotations = null,
+        ?array $meta = null,
     ): self {
         $this->resourceTemplates[] = compact(
             'handler',
@@ -396,6 +398,7 @@ final class Builder
             'description',
             'mimeType',
             'annotations',
+            'meta',
         );
 
         return $this;
@@ -404,16 +407,18 @@ final class Builder
     /**
      * Manually registers a prompt handler.
      *
-     * @param Handler $handler
-     * @param ?Icon[] $icons
+     * @param Handler                   $handler
+     * @param ?Icon[]                   $icons
+     * @param array<string, mixed>|null $meta
      */
     public function addPrompt(
         \Closure|array|string $handler,
         ?string $name = null,
         ?string $description = null,
         ?array $icons = null,
+        ?array $meta = null,
     ): self {
-        $this->prompts[] = compact('handler', 'name', 'description', 'icons');
+        $this->prompts[] = compact('handler', 'name', 'description', 'icons', 'meta');
 
         return $this;
     }


### PR DESCRIPTION
## Summary

Add missing `meta` parameter to `Builder::addResourceTemplate()` and `Builder::addPrompt()` methods to complete the metadata support across all registration methods.

## Motivation and Context

The `ResourceTemplate` and `Prompt` schemas support a `_meta` field for passing additional metadata. However, the `Builder::addResourceTemplate()` and `Builder::addPrompt()` methods didn't expose this parameter, creating an inconsistency with other registration methods like `addTool()` and `addResource()` which already support `meta`.

This change completes the metadata support across all manual registration methods, providing a consistent API for users to attach arbitrary metadata to any MCP element.

## How Has This Been Tested?

- Verified that the `meta` parameter is properly added to both methods
- Confirmed that the `compact()` calls include the new `meta` parameter
- Checked that the parameters are optional with null defaults for backward compatibility
- Ensured consistency with existing `addTool()` and `addResource()` implementations

## Breaking Changes

None. This is a backward-compatible change:
- The `meta` parameter is optional with a default value of `null`
- Existing code will continue to work without modifications
- The `meta` field is only included when explicitly provided

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Changes made:**
1. Added `meta` parameter to `Builder::addResourceTemplate()` method
2. Added `meta` parameter to `Builder::addPrompt()` method  
3. Updated `compact()` calls to include `meta` in both methods

This completes the metadata support that was previously added to `addTool()` and `addResource()` in PR #144, ensuring all manual registration methods have feature parity with the underlying schema classes.

**Note:** The corresponding PHPDoc type definitions and ArrayLoader changes will need to be updated separately to fully support these fields throughout the registration pipeline.