### PR TITLE
Make logger nullable in Transport constructors

### DIFF
--- a/src/Server/Transport/BaseTransport.php
+++ b/src/Server/Transport/BaseTransport.php
@@ -14,6 +14,7 @@ namespace Mcp\Server\Transport;
 use Mcp\Schema\JsonRpc\Error;
 use Mcp\Schema\JsonRpc\Response;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -38,9 +39,11 @@ abstract class BaseTransport
      */
     protected ?\Fiber $sessionFiber = null;
 
-    public function __construct(
-        protected readonly LoggerInterface $logger,
-    ) {
+    protected LoggerInterface $logger;
+
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function initialize(): void

--- a/src/Server/Transport/InMemoryTransport.php
+++ b/src/Server/Transport/InMemoryTransport.php
@@ -11,6 +11,7 @@
 
 namespace Mcp\Server\Transport;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -27,7 +28,9 @@ class InMemoryTransport extends BaseTransport implements TransportInterface
      */
     public function __construct(
         private readonly array $messages = [],
+        ?LoggerInterface $logger = null,
     ) {
+        parent::__construct($logger);
     }
 
     public function initialize(): void
@@ -51,10 +54,13 @@ class InMemoryTransport extends BaseTransport implements TransportInterface
      */
     public function listen(): mixed
     {
+        $this->logger->info('InMemoryTransport is processing messages...');
+
         foreach ($this->messages as $message) {
             $this->handleMessage($message, $this->sessionId);
         }
 
+        $this->logger->info('InMemoryTransport finished processing.');
         $this->handleSessionEnd($this->sessionId);
 
         $this->sessionId = null;

--- a/src/Server/Transport/StdioTransport.php
+++ b/src/Server/Transport/StdioTransport.php
@@ -13,7 +13,6 @@ namespace Mcp\Server\Transport;
 
 use Mcp\Schema\JsonRpc\Error;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 /**
  * @implements TransportInterface<int>
@@ -29,7 +28,7 @@ class StdioTransport extends BaseTransport implements TransportInterface
     public function __construct(
         private $input = \STDIN,
         private $output = \STDOUT,
-        LoggerInterface $logger = new NullLogger(),
+        ?LoggerInterface $logger = null,
     ) {
         parent::__construct($logger);
     }

--- a/src/Server/Transport/StreamableHttpTransport.php
+++ b/src/Server/Transport/StreamableHttpTransport.php
@@ -18,7 +18,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -45,7 +44,7 @@ class StreamableHttpTransport extends BaseTransport implements TransportInterfac
         ?ResponseFactoryInterface $responseFactory = null,
         ?StreamFactoryInterface $streamFactory = null,
         array $corsHeaders = [],
-        LoggerInterface $logger = new NullLogger(),
+        ?LoggerInterface $logger = null,
     ) {
         parent::__construct($logger);
         $sessionIdString = $this->request->getHeaderLine('Mcp-Session-Id');


### PR DESCRIPTION
- BaseTransport: Accept ?LoggerInterface parameter and convert null to NullLogger
- StdioTransport: Change logger parameter to nullable
- StreamableHttpTransport: Change logger parameter to nullable
- InMemoryTransport: Fix missing parent::__construct() call and add logging

<!-- Provide a brief summary of your changes -->

## Motivation and Context

 Allow passing `null` as logger parameter to avoid verbose ternary operators when the logger is optional.

## How Has This Been Tested?

  - PHPUnit: All unit tests pass
  - PHP-CS-Fixer: Clean
  - PHPStan: No errors

## Breaking Changes

No 

## Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update

## Checklist

  - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
  - [x] My code follows the repository's style guidelines
  - [x] New and existing tests pass locally
  - [x] I have added appropriate error handling
  - [x] I have added or updated documentation as needed
  
## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
https://github.com/camilleislasse/ai/blob/ecea6d676b4ea9e35ade883bda281ef1d113879d/src/mcp-bundle/src/Controller/McpController.php