### PR TITLE
[Server] Decouple Protocol from TransportInterface for reusability

### DIFF
--- a/src/Server/Transport/BaseTransport.php
+++ b/src/Server/Transport/BaseTransport.php
@@ -26,9 +26,13 @@ use Symfony\Component\Uid\Uuid;
  * @phpstan-import-type FiberSuspend from TransportInterface
  * @phpstan-import-type McpFiber from TransportInterface
  *
+ * @template TResult
+ *
+ * @implements TransportInterface<TResult>
+ *
  * @author Kyrian Obikwelu <koshnawaza@gmail.com>
  */
-abstract class BaseTransport
+abstract class BaseTransport implements TransportInterface
 {
     use ManagesTransportCallbacks;
 
@@ -126,7 +130,7 @@ abstract class BaseTransport
     protected function handleMessage(string $payload, ?Uuid $sessionId): void
     {
         if (\is_callable($this->messageListener)) {
-            ($this->messageListener)($payload, $sessionId);
+            ($this->messageListener)($this, $payload, $sessionId);
         }
     }
 

--- a/src/Server/Transport/InMemoryTransport.php
+++ b/src/Server/Transport/InMemoryTransport.php
@@ -15,11 +15,11 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
- * @implements TransportInterface<null>
+ * @extends BaseTransport<null>
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class InMemoryTransport extends BaseTransport implements TransportInterface
+class InMemoryTransport extends BaseTransport
 {
     use ManagesTransportCallbacks;
 

--- a/src/Server/Transport/ManagesTransportCallbacks.php
+++ b/src/Server/Transport/ManagesTransportCallbacks.php
@@ -26,7 +26,7 @@ use Symfony\Component\Uid\Uuid;
  * */
 trait ManagesTransportCallbacks
 {
-    /** @var callable(string, ?Uuid): void */
+    /** @var callable(TransportInterface<mixed>, string, ?Uuid): void */
     protected $messageListener;
 
     /** @var callable(Uuid): void */

--- a/src/Server/Transport/StdioTransport.php
+++ b/src/Server/Transport/StdioTransport.php
@@ -15,11 +15,11 @@ use Mcp\Schema\JsonRpc\Error;
 use Psr\Log\LoggerInterface;
 
 /**
- * @implements TransportInterface<int>
+ * @extends BaseTransport<int>
  *
  * @author Kyrian Obikwelu <koshnawaza@gmail.com>
- * */
-class StdioTransport extends BaseTransport implements TransportInterface
+ */
+class StdioTransport extends BaseTransport
 {
     /**
      * @param resource $input

--- a/src/Server/Transport/StreamableHttpTransport.php
+++ b/src/Server/Transport/StreamableHttpTransport.php
@@ -21,11 +21,11 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Uid\Uuid;
 
 /**
- * @implements TransportInterface<ResponseInterface>
+ * @extends BaseTransport<ResponseInterface>
  *
  * @author Kyrian Obikwelu <koshnawaza@gmail.com>
- * */
-class StreamableHttpTransport extends BaseTransport implements TransportInterface
+ */
+class StreamableHttpTransport extends BaseTransport
 {
     private ResponseFactoryInterface $responseFactory;
     private StreamFactoryInterface $streamFactory;

--- a/src/Server/Transport/TransportInterface.php
+++ b/src/Server/Transport/TransportInterface.php
@@ -70,7 +70,7 @@ interface TransportInterface
      *
      * The transport calls this whenever ANY message arrives, regardless of source.
      *
-     * @param callable(string $message, ?Uuid $sessionId): void $listener
+     * @param callable(TransportInterface<TResult> $transport, string $message, ?Uuid $sessionId): void $listener
      */
     public function onMessage(callable $listener): void;
 

--- a/tests/Unit/Server/ProtocolTest.php
+++ b/tests/Unit/Server/ProtocolTest.php
@@ -68,10 +68,9 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $sessionId = Uuid::v4();
         $protocol->processInput(
+            $this->transport,
             '{"jsonrpc": "2.0", "method": "notifications/initialized"}',
             $sessionId
         );
@@ -127,10 +126,9 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $sessionId = Uuid::v4();
         $protocol->processInput(
+            $this->transport,
             '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}',
             $sessionId
         );
@@ -166,10 +164,9 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $sessionId = Uuid::v4();
         $protocol->processInput(
+            $this->transport,
             '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"}}}',
             $sessionId
         );
@@ -198,9 +195,8 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $protocol->processInput(
+            $this->transport,
             '[{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"}}}, {"jsonrpc": "2.0", "method": "ping", "id": 2}]',
             null
         );
@@ -231,9 +227,8 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $protocol->processInput(
+            $this->transport,
             '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}',
             null
         );
@@ -266,10 +261,9 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $sessionId = Uuid::v4();
         $protocol->processInput(
+            $this->transport,
             '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}',
             $sessionId
         );
@@ -298,9 +292,8 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $protocol->processInput(
+            $this->transport,
             'invalid json',
             null
         );
@@ -343,10 +336,9 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $sessionId = Uuid::v4();
         $protocol->processInput(
+            $this->transport,
             '{"jsonrpc": "2.0", "params": {}}',
             $sessionId
         );
@@ -397,10 +389,9 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $sessionId = Uuid::v4();
         $protocol->processInput(
+            $this->transport,
             '{"jsonrpc": "2.0", "id": 1, "method": "ping"}',
             $sessionId
         );
@@ -456,10 +447,9 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $sessionId = Uuid::v4();
         $protocol->processInput(
+            $this->transport,
             '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "test"}}',
             $sessionId
         );
@@ -515,10 +505,9 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $sessionId = Uuid::v4();
         $protocol->processInput(
+            $this->transport,
             '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "test"}}',
             $sessionId
         );
@@ -553,10 +542,9 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $sessionId = Uuid::v4();
         $protocol->processInput(
+            $this->transport,
             '{"jsonrpc": "2.0", "method": "notifications/initialized"}',
             $sessionId
         );
@@ -607,9 +595,8 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $protocol->processInput(
+            $this->transport,
             '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}',
             $sessionId
         );
@@ -670,10 +657,9 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $sessionId = Uuid::v4();
         $protocol->processInput(
+            $this->transport,
             '[{"jsonrpc": "2.0", "method": "tools/list", "id": 1}, {"jsonrpc": "2.0", "method": "prompts/list", "id": 2}]',
             $sessionId
         );
@@ -706,10 +692,9 @@ final class ProtocolTest extends TestCase
             sessionStore: $this->sessionStore,
         );
 
-        $protocol->connect($this->transport);
-
         $sessionId = Uuid::v4();
         $protocol->processInput(
+            $this->transport,
             '{"jsonrpc": "2.0", "method": "notifications/initialized"}',
             $sessionId
         );


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Decouple the Protocol class from direct dependency on TransportInterface to support server instance reuse across multiple transport mechanisms.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Currently, the Protocol class can only be connected to a single transport instance due to internal state management and restrictions. Once connected, it cannot be reused with another transport. This change removes that limitation to allow a single Protocol instance to be used with multiple transports.The same issue exists in the TypeScript SDK: https://github.com/modelcontextprotocol/typescript-sdk/issues/961

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the repository's style guidelines
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

