### PR TITLE
remove redundant methods in Transport

### DIFF
--- a/src/Server/Transport/InMemoryTransport.php
+++ b/src/Server/Transport/InMemoryTransport.php
@@ -21,8 +21,6 @@ use Symfony\Component\Uid\Uuid;
  */
 class InMemoryTransport extends BaseTransport implements TransportInterface
 {
-    use ManagesTransportCallbacks;
-
     /**
      * @param list<string> $messages
      */
@@ -31,10 +29,6 @@ class InMemoryTransport extends BaseTransport implements TransportInterface
         ?LoggerInterface $logger = null,
     ) {
         parent::__construct($logger);
-    }
-
-    public function initialize(): void
-    {
     }
 
     public function onMessage(callable $listener): void

--- a/src/Server/Transport/StreamableHttpTransport.php
+++ b/src/Server/Transport/StreamableHttpTransport.php
@@ -60,10 +60,6 @@ class StreamableHttpTransport extends BaseTransport implements TransportInterfac
         ], $corsHeaders);
     }
 
-    public function initialize(): void
-    {
-    }
-
     public function send(string $data, array $context): void
     {
         $this->immediateResponse = $data;


### PR DESCRIPTION


## Motivation and Context
Im reading the code base and finding some redundant lines. 

`StreamableHttpTransport` and `InMemoryTransport` both extends `BaseTransport`. The `BaseTransport` already uses `ManagesTransportCallbacks` and implements an empty `initialize()` method. 

## How Has This Been Tested?
Not at all. 

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Minor code clean up

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
