### PR TITLE
Allow users to not specify server info

### DIFF
--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -482,7 +482,7 @@ final class Builder
             completions: true,
         );
 
-        $serverInfo = $this->serverInfo ?? new Implementation('MCP SDK for PHP');
+        $serverInfo = $this->serverInfo ?? new Implementation();
         $configuration = new Configuration($serverInfo, $capabilities, $this->paginationLimit, $this->instructions, $this->protocolVersion);
         $referenceHandler = new ReferenceHandler($container);
 


### PR DESCRIPTION
I want to allow users to build their servers like: 

```php
$server = Server::builder()
    //->setServerInfo('My demo', '1.1.0', 'Basic demo')
    ->setSession(new FileSessionStore(__DIR__.'/sessions'))
    ->setDiscovery(__DIR__)
    ->build();
```

## Motivation and Context
This comes from a pure DX perspective. If I forget to specify my server info, I dont want everything to crash with: 

```
PHP Fatal error:  Uncaught TypeError: Mcp\Server\Configuration::__construct(): Argument #1 ($serverInfo) must be of type Mcp\Schema\Implementation, null given, called in...
```

With this PR it "just works".

## How Has This Been Tested?
I ran the script locally a few times. Also tested with `@modelcontextprotocol/inspector`

## Breaking Changes
Nope. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Small DX improvment

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
