### PR TITLE
Tell clients that they are allowed to use Mcp-Session-Id header

### DIFF
--- a/src/Server/Transport/StreamableHttpTransport.php
+++ b/src/Server/Transport/StreamableHttpTransport.php
@@ -57,6 +57,7 @@ class StreamableHttpTransport extends BaseTransport implements TransportInterfac
             'Access-Control-Allow-Origin' => '*',
             'Access-Control-Allow-Methods' => 'GET, POST, DELETE, OPTIONS',
             'Access-Control-Allow-Headers' => 'Content-Type, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID, Authorization, Accept',
+            'Access-Control-Expose-Headers' => 'Mcp-Session-Id',
         ], $corsHeaders);
     }
 


### PR DESCRIPTION
Add an extra cors header. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Expose-Headers

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
I had issues running HTTP server with `modelcontextprotocol/inspector`. It would never connect. 

After some debugging I found that after initialization the client sent an "initialized" notification without session id. 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes, With `modelcontextprotocol/inspector`

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
