### PR TITLE
[Server] Extend changelog for covering 0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Changelog
 
 All notable changes to `mcp/sdk` will be documented in this file.
+
+0.1
+---
+
+* First tagged release of package
+* Support for implementing MCP server


### PR DESCRIPTION
Basically kicking of the version structure - we need to collect for 0.2 in case of breaking changes or new features.