### PR TITLE
[Server] align addLoaders with addRequestHandlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `mcp/sdk` will be documented in this file.
 -----
 
 * Make `Protocol` stateless by decouple if from `TransportInterface`. Removed `Protocol::getTransport()`.
+* Change signature of `Builder::addLoaders(...$loaders)` to `Builder::addLoaders(iterable $loaders)`.
 
 0.1.0
 -----

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -434,11 +434,23 @@ final class Builder
     }
 
     /**
-     * @param LoaderInterface[] $loaders
+     * Register a single custom loader.
      */
-    public function addLoaders(...$loaders): self
+    public function addLoader(LoaderInterface $loader): self
     {
-        $this->loaders = [...$this->loaders, ...$loaders];
+        $this->loaders[] = $loader;
+
+        return $this;
+    }
+
+    /**
+     * @param iterable<LoaderInterface> $loaders
+     */
+    public function addLoaders(iterable $loaders): self
+    {
+        foreach ($loaders as $loader) {
+            $this->loaders = [$loader];
+        }
 
         return $this;
     }


### PR DESCRIPTION
Use `iterable` as we did in `addRequestHandlers` and others.

This helps with framework integration and unifies code source.