### PR TITLE
fix bug with Builder::addLoders()

### DIFF
--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -449,7 +449,7 @@ final class Builder
     public function addLoaders(iterable $loaders): self
     {
         foreach ($loaders as $loader) {
-            $this->loaders = [$loader];
+            $this->loaders[] = $loader;
         }
 
         return $this;


### PR DESCRIPTION
Follow up from https://github.com/modelcontextprotocol/php-sdk/pull/183

I think the logic was a bit flawed. 

Ping @soyuka 