### PR TITLE
Be more generous with PSR versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
     "php-http/discovery": "^1.20",
     "phpdocumentor/reflection-docblock": "^5.6",
     "psr/clock": "^1.0",
-    "psr/container": "^2.0",
+    "psr/container": "^1.0 || ^2.0",
     "psr/event-dispatcher": "^1.0",
     "psr/http-factory": "^1.1",
-    "psr/http-message": "^2.0",
+    "psr/http-message": "^1.1 || ^2.0",
     "psr/log": "^1.0 || ^2.0 || ^3.0",
     "symfony/finder": "^5.4 || ^6.4 || ^7.3 || ^8.0",
     "symfony/uid": "^5.4 || ^6.4 || ^7.3 || ^8.0"


### PR DESCRIPTION
The only difference is return types. Since we dont implement these interfaces, it does not matter for us. There is no need to restrict one version or another. 

