### PR TITLE
Make static methods in Error final

### DIFF
--- a/src/Schema/JsonRpc/Error.php
+++ b/src/Schema/JsonRpc/Error.php
@@ -52,7 +52,7 @@ class Error implements MessageInterface
     /**
      * @param ErrorData $data
      */
-    public static function fromArray(array $data): self
+    final public static function fromArray(array $data): self
     {
         if (!isset($data['jsonrpc']) || MessageInterface::JSONRPC_VERSION !== $data['jsonrpc']) {
             throw new InvalidArgumentException('Invalid or missing "jsonrpc" in Error data.');
@@ -76,37 +76,37 @@ class Error implements MessageInterface
         return new self($data['id'], $data['error']['code'], $data['error']['message'], $data['error']['data'] ?? null);
     }
 
-    public static function forParseError(string $message, string|int $id = ''): self
+    final public static function forParseError(string $message, string|int $id = ''): self
     {
         return new self($id, self::PARSE_ERROR, $message);
     }
 
-    public static function forInvalidRequest(string $message, string|int $id = ''): self
+    final public static function forInvalidRequest(string $message, string|int $id = ''): self
     {
         return new self($id, self::INVALID_REQUEST, $message);
     }
 
-    public static function forMethodNotFound(string $message, string|int $id = ''): self
+    final public static function forMethodNotFound(string $message, string|int $id = ''): self
     {
         return new self($id, self::METHOD_NOT_FOUND, $message);
     }
 
-    public static function forInvalidParams(string $message, string|int $id = '', mixed $data = null): self
+    final public static function forInvalidParams(string $message, string|int $id = '', mixed $data = null): self
     {
         return new self($id, self::INVALID_PARAMS, $message, $data);
     }
 
-    public static function forInternalError(string $message, string|int $id = ''): self
+    final public static function forInternalError(string $message, string|int $id = ''): self
     {
         return new self($id, self::INTERNAL_ERROR, $message);
     }
 
-    public static function forServerError(string $message, string|int $id = ''): self
+    final public static function forServerError(string $message, string|int $id = ''): self
     {
         return new self($id, self::SERVER_ERROR, $message);
     }
 
-    public static function forResourceNotFound(string $message, string|int $id = ''): self
+    final public static function forResourceNotFound(string $message, string|int $id = ''): self
     {
         return new self($id, self::RESOURCE_NOT_FOUND, $message);
     }


### PR DESCRIPTION
## Motivation and Context

This will just make the API more strict. It allows us add parameters to these methods without breaking BC. 


## How Has This Been Tested?

I did not test it

## Breaking Changes

Yes, this is a breaking change and should be merged when preparing for 0.3.0

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
