### PR TITLE
Normalize composer.json with ergebnis/composer-normalize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "name": "mcp/sdk",
-  "type": "library",
   "description": "Model Context Protocol SDK for Client and Server applications in PHP",
   "license": "MIT",
+  "type": "library",
   "authors": [
     {
       "name": "Christopher Hertel",
@@ -33,16 +33,16 @@
     "symfony/uid": "^5.4 || ^6.4 || ^7.3 || ^8.0"
   },
   "require-dev": {
+    "laminas/laminas-httphandlerrunner": "^2.12",
+    "nyholm/psr7": "^1.8",
+    "nyholm/psr7-server": "^1.1",
     "php-cs-fixer/shim": "^3.91",
     "phpstan/phpstan": "^2.1",
     "phpunit/phpunit": "^10.5",
     "psr/simple-cache": "^2.0 || ^3.0",
     "symfony/cache": "^5.4 || ^6.4 || ^7.3 || ^8.0",
     "symfony/console": "^5.4 || ^6.4 || ^7.3 || ^8.0",
-    "symfony/process": "^5.4 || ^6.4 || ^7.3 || ^8.0",
-    "nyholm/psr7": "^1.8",
-    "nyholm/psr7-server": "^1.1",
-    "laminas/laminas-httphandlerrunner": "^2.12"
+    "symfony/process": "^5.4 || ^6.4 || ^7.3 || ^8.0"
   },
   "autoload": {
     "psr-4": {
@@ -53,6 +53,7 @@
     "psr-4": {
       "Mcp\\Example\\Server\\CachedDiscovery\\": "examples/server/cached-discovery/",
       "Mcp\\Example\\Server\\ClientCommunication\\": "examples/server/client-communication/",
+      "Mcp\\Example\\Server\\ClientLogging\\": "examples/server/client-logging/",
       "Mcp\\Example\\Server\\CombinedRegistration\\": "examples/server/combined-registration/",
       "Mcp\\Example\\Server\\ComplexToolSchema\\": "examples/server/complex-tool-schema/",
       "Mcp\\Example\\Server\\CustomDependencies\\": "examples/server/custom-dependencies/",
@@ -62,14 +63,13 @@
       "Mcp\\Example\\Server\\EnvVariables\\": "examples/server/env-variables/",
       "Mcp\\Example\\Server\\ExplicitRegistration\\": "examples/server/explicit-registration/",
       "Mcp\\Example\\Server\\SchemaShowcase\\": "examples/server/schema-showcase/",
-      "Mcp\\Example\\Server\\ClientLogging\\": "examples/server/client-logging/",
       "Mcp\\Tests\\": "tests/"
     }
   },
   "config": {
-    "sort-packages": true,
     "allow-plugins": {
       "php-http/discovery": false
-    }
+    },
+    "sort-packages": true
   }
 }


### PR DESCRIPTION
Sort composer.json to some kind of standard

## Motivation and Context
The main issue is that we have `sort-packages: true` but not all packages are sorted. To fix this, I just ran `composer normalize`. 

## How Has This Been Tested?

Yes. I ran `composer update`

## Breaking Changes

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
