### PR TITLE
Rename `schema` to `resource` in Capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `mcp/sdk` will be documented in this file.
 
 * Add output schema support to MCP tools
 * Add validation of the input parameters given to a Tool.
+* Rename `Mcp\Capability\Registry\ResourceReference::$schema` to `Mcp\Capability\Registry\ResourceReference::$resource`.
 
 0.2.2
 -----

--- a/src/Capability/Registry.php
+++ b/src/Capability/Registry.php
@@ -234,7 +234,7 @@ final class Registry implements RegistryInterface
     {
         $resources = [];
         foreach ($this->resources as $resourceReference) {
-            $resources[$resourceReference->schema->uri] = $resourceReference->schema;
+            $resources[$resourceReference->resource->uri] = $resourceReference->resource;
         }
 
         if (null === $limit) {

--- a/src/Capability/Registry/ResourceReference.php
+++ b/src/Capability/Registry/ResourceReference.php
@@ -29,7 +29,7 @@ class ResourceReference extends ElementReference
      * @param Handler $handler
      */
     public function __construct(
-        public readonly Resource $schema,
+        public readonly Resource $resource,
         callable|array|string $handler,
         bool $isManual = false,
     ) {
@@ -68,7 +68,7 @@ class ResourceReference extends ElementReference
             return [$readResult->resource];
         }
 
-        $meta = $this->schema->meta;
+        $meta = $this->resource->meta;
 
         if (\is_array($readResult)) {
             if (empty($readResult)) {

--- a/src/Server/Handler/Request/ReadResourceHandler.php
+++ b/src/Server/Handler/Request/ReadResourceHandler.php
@@ -72,7 +72,7 @@ final class ReadResourceHandler implements RequestHandlerInterface
                 $formatted = $reference->formatResult($result, $uri, $reference->resourceTemplate->mimeType);
             } else {
                 $result = $this->referenceHandler->handle($reference, $arguments);
-                $formatted = $reference->formatResult($result, $uri, $reference->schema->mimeType);
+                $formatted = $reference->formatResult($result, $uri, $reference->resource->mimeType);
             }
 
             return new Response($request->getId(), new ReadResourceResult($formatted));

--- a/tests/Unit/Capability/Discovery/DiscoveryTest.php
+++ b/tests/Unit/Capability/Discovery/DiscoveryTest.php
@@ -65,8 +65,8 @@ class DiscoveryTest extends TestCase
 
         $this->assertArrayHasKey('app://info/version', $resources);
         $this->assertFalse($resources['app://info/version']->isManual);
-        $this->assertEquals('app_version', $resources['app://info/version']->schema->name);
-        $this->assertEquals('text/plain', $resources['app://info/version']->schema->mimeType);
+        $this->assertEquals('app_version', $resources['app://info/version']->resource->name);
+        $this->assertEquals('text/plain', $resources['app://info/version']->resource->mimeType);
 
         $this->assertArrayHasKey('invokable://config/status', $resources);
         $this->assertFalse($resources['invokable://config/status']->isManual);

--- a/tests/Unit/Capability/RegistryTest.php
+++ b/tests/Unit/Capability/RegistryTest.php
@@ -167,7 +167,7 @@ class RegistryTest extends TestCase
 
         $resourceRef = $this->registry->getResource('test://resource');
         $this->assertInstanceOf(ResourceReference::class, $resourceRef);
-        $this->assertEquals($resource->uri, $resourceRef->schema->uri);
+        $this->assertEquals($resource->uri, $resourceRef->resource->uri);
         $this->assertEquals($handler, $resourceRef->handler);
         $this->assertFalse($resourceRef->isManual);
     }
@@ -260,7 +260,7 @@ class RegistryTest extends TestCase
 
         $resourceRef = $this->registry->getResource('test://123');
         $this->assertInstanceOf(ResourceReference::class, $resourceRef);
-        $this->assertEquals($resource->uri, $resourceRef->schema->uri);
+        $this->assertEquals($resource->uri, $resourceRef->resource->uri);
     }
 
     public function testGetResourceMatchesResourceTemplate(): void


### PR DESCRIPTION
Align with other references consistency:
```php
$tool->tool;
$prompt->prompt;
$resource->resource;
$resourceTemplate->resourceTemplate;
```