### PR TITLE
[Server] Add autoload check for enum types in ReferenceHandler

### DIFF
--- a/src/Capability/Registry/ReferenceHandler.php
+++ b/src/Capability/Registry/ReferenceHandler.php
@@ -173,7 +173,9 @@ final class ReferenceHandler implements ReferenceHandlerInterface
 
         $typeName = $type->getName();
 
-        if (enum_exists($typeName)) {
+        $shouldAutoload = !in_array($typeName, ['int', 'float', 'string', 'bool', 'array', 'object', 'callable', 'iterable', 'mixed', 'void', 'null', 'false', 'true', 'never']);
+
+        if (enum_exists($typeName, $shouldAutoload)) {
             if (\is_object($argument) && $argument instanceof $typeName) {
                 return $argument;
             }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Some old framework is using autoload to include with the typeName directly, e.g. `include(ini.php)` when the typeName is `ini`.

If the typeName is the arbitrary type, set autoload in `enum_exists` to `false`

## How Has This Been Tested?
Yes

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
None
