### PR TITLE
[Server][Schema] Add elicitation support for server-to-client user input requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
       "Mcp\\Example\\Server\\ClientCommunication\\": "examples/server/client-communication/",
       "Mcp\\Example\\Server\\ClientLogging\\": "examples/server/client-logging/",
       "Mcp\\Example\\Server\\CombinedRegistration\\": "examples/server/combined-registration/",
+      "Mcp\\Example\\Server\\Elicitation\\": "examples/server/elicitation/",
       "Mcp\\Example\\Server\\ComplexToolSchema\\": "examples/server/complex-tool-schema/",
       "Mcp\\Example\\Server\\Conformance\\": "examples/server/conformance/",
       "Mcp\\Example\\Server\\CustomDependencies\\": "examples/server/custom-dependencies/",

--- a/examples/server/elicitation/ElicitationHandlers.php
+++ b/examples/server/elicitation/ElicitationHandlers.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Example\Server\Elicitation;
+
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Schema\Elicitation\BooleanSchemaDefinition;
+use Mcp\Schema\Elicitation\ElicitationSchema;
+use Mcp\Schema\Elicitation\EnumSchemaDefinition;
+use Mcp\Schema\Elicitation\NumberSchemaDefinition;
+use Mcp\Schema\Elicitation\StringSchemaDefinition;
+use Mcp\Server\RequestContext;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Example handlers demonstrating the elicitation feature.
+ *
+ * Elicitation allows servers to request additional information from users
+ * during tool execution. The user can accept (providing data), decline,
+ * or cancel the request.
+ */
+final class ElicitationHandlers
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+        $this->logger->info('ElicitationHandlers instantiated.');
+    }
+
+    /**
+     * Book a restaurant reservation with user elicitation.
+     *
+     * Demonstrates multi-field elicitation with different field types:
+     * - Number field for party size with validation
+     * - String field with date format for reservation date
+     * - Enum field for dietary restrictions with human-readable labels
+     *
+     * @return array{status: string, message: string, booking?: array{party_size: int, date: string, dietary: string}}
+     */
+    #[McpTool('book_restaurant', 'Book a restaurant reservation, collecting details via elicitation.')]
+    public function bookRestaurant(RequestContext $context, string $restaurantName): array
+    {
+        if (!$context->getClientGateway()->supportsElicitation()) {
+            return [
+                'status' => 'error',
+                'message' => 'Client does not support elicitation. Please provide reservation details (party_size, date, dietary) as tool parameters instead.',
+            ];
+        }
+
+        $client = $context->getClientGateway();
+
+        $this->logger->info(\sprintf('Starting reservation process for restaurant: %s', $restaurantName));
+
+        $schema = new ElicitationSchema(
+            properties: [
+                'party_size' => new NumberSchemaDefinition(
+                    title: 'Party Size',
+                    integerOnly: true,
+                    description: 'Number of guests in your party',
+                    default: 2,
+                    minimum: 1,
+                    maximum: 20,
+                ),
+                'date' => new StringSchemaDefinition(
+                    title: 'Reservation Date',
+                    description: 'Preferred date for your reservation',
+                    format: 'date',
+                ),
+                'dietary' => new EnumSchemaDefinition(
+                    title: 'Dietary Restrictions',
+                    enum: ['none', 'vegetarian', 'vegan', 'gluten-free', 'halal', 'kosher'],
+                    description: 'Any dietary restrictions or preferences',
+                    default: 'none',
+                    enumNames: ['None', 'Vegetarian', 'Vegan', 'Gluten-Free', 'Halal', 'Kosher'],
+                ),
+            ],
+            required: ['party_size', 'date'],
+        );
+
+        $result = $client->elicit(
+            message: \sprintf('Please provide your reservation details for %s:', $restaurantName),
+            requestedSchema: $schema,
+            timeout: 120,
+        );
+
+        if ($result->isDeclined()) {
+            $this->logger->info('User declined to provide reservation details.');
+
+            return [
+                'status' => 'declined',
+                'message' => 'Reservation request was declined by user.',
+            ];
+        }
+
+        if ($result->isCancelled()) {
+            $this->logger->info('User cancelled the reservation request.');
+
+            return [
+                'status' => 'cancelled',
+                'message' => 'Reservation request was cancelled.',
+            ];
+        }
+
+        $content = $result->content;
+        if (null === $content) {
+            throw new \RuntimeException('Expected content for accepted elicitation.');
+        }
+
+        if (!isset($content['party_size']) || !isset($content['date'])) {
+            throw new \RuntimeException('Missing required fields: party_size and date.');
+        }
+
+        $partySize = (int) $content['party_size'];
+        $date = (string) $content['date'];
+        $dietary = (string) ($content['dietary'] ?? 'none');
+
+        if ($partySize < 1 || $partySize > 20) {
+            throw new \RuntimeException(\sprintf('Invalid party size: %d. Must be between 1 and 20.', $partySize));
+        }
+
+        $this->logger->info(\sprintf(
+            'Booking confirmed: %d guests on %s with %s dietary requirements',
+            $partySize,
+            $date,
+            $dietary,
+        ));
+
+        return [
+            'status' => 'confirmed',
+            'message' => \sprintf(
+                'Reservation confirmed at %s for %d guests on %s.',
+                $restaurantName,
+                $partySize,
+                $date,
+            ),
+            'booking' => [
+                'party_size' => $partySize,
+                'date' => $date,
+                'dietary' => $dietary,
+            ],
+        ];
+    }
+
+    /**
+     * Confirm an action with a simple boolean elicitation.
+     *
+     * Demonstrates the simplest elicitation pattern - a yes/no confirmation.
+     *
+     * @return array{status: string, message: string}
+     */
+    #[McpTool('confirm_action', 'Request user confirmation before proceeding with an action.')]
+    public function confirmAction(RequestContext $context, string $actionDescription): array
+    {
+        if (!$context->getClientGateway()->supportsElicitation()) {
+            return [
+                'status' => 'error',
+                'message' => 'Client does not support elicitation. Please confirm the action explicitly in your request.',
+            ];
+        }
+
+        $client = $context->getClientGateway();
+
+        $schema = new ElicitationSchema(
+            properties: [
+                'confirm' => new BooleanSchemaDefinition(
+                    title: 'Confirm',
+                    description: 'Check to confirm you want to proceed',
+                    default: false,
+                ),
+            ],
+            required: ['confirm'],
+        );
+
+        $result = $client->elicit(
+            message: \sprintf('Are you sure you want to: %s?', $actionDescription),
+            requestedSchema: $schema,
+        );
+
+        if (!$result->isAccepted()) {
+            return [
+                'status' => 'not_confirmed',
+                'message' => 'Action was not confirmed by user.',
+            ];
+        }
+
+        $content = $result->content;
+        if (null === $content) {
+            throw new \RuntimeException('Expected content for accepted elicitation.');
+        }
+
+        if (!isset($content['confirm'])) {
+            throw new \RuntimeException('Missing required field: confirm.');
+        }
+
+        $confirmed = (bool) $content['confirm'];
+
+        if (!$confirmed) {
+            return [
+                'status' => 'not_confirmed',
+                'message' => 'User did not check the confirmation box.',
+            ];
+        }
+
+        $this->logger->info(\sprintf('User confirmed action: %s', $actionDescription));
+
+        return [
+            'status' => 'confirmed',
+            'message' => \sprintf('Action confirmed: %s', $actionDescription),
+        ];
+    }
+
+    /**
+     * Collect user feedback using elicitation.
+     *
+     * Demonstrates elicitation with optional fields and enum with labels.
+     *
+     * @return array{status: string, message: string, feedback?: array{rating: string, comments: string}}
+     */
+    #[McpTool('collect_feedback', 'Collect user feedback via elicitation form.')]
+    public function collectFeedback(RequestContext $context, string $topic): array
+    {
+        if (!$context->getClientGateway()->supportsElicitation()) {
+            return [
+                'status' => 'error',
+                'message' => 'Client does not support elicitation. Please provide feedback (rating 1-5, comments) as tool parameters instead.',
+            ];
+        }
+
+        $client = $context->getClientGateway();
+
+        $schema = new ElicitationSchema(
+            properties: [
+                'rating' => new EnumSchemaDefinition(
+                    title: 'Rating',
+                    enum: ['1', '2', '3', '4', '5'],
+                    description: 'Rate your experience from 1 (poor) to 5 (excellent)',
+                    enumNames: ['1 - Poor', '2 - Fair', '3 - Good', '4 - Very Good', '5 - Excellent'],
+                ),
+                'comments' => new StringSchemaDefinition(
+                    title: 'Comments',
+                    description: 'Any additional comments or suggestions (optional)',
+                    maxLength: 500,
+                ),
+            ],
+            required: ['rating'],
+        );
+
+        $result = $client->elicit(
+            message: \sprintf('Please provide your feedback about: %s', $topic),
+            requestedSchema: $schema,
+        );
+
+        if (!$result->isAccepted()) {
+            return [
+                'status' => 'skipped',
+                'message' => 'User chose not to provide feedback.',
+            ];
+        }
+
+        $content = $result->content;
+        if (null === $content) {
+            throw new \RuntimeException('Expected content for accepted elicitation.');
+        }
+
+        if (!isset($content['rating'])) {
+            throw new \RuntimeException('Missing required field: rating.');
+        }
+
+        $rating = (string) $content['rating'];
+        $comments = (string) ($content['comments'] ?? '');
+
+        $this->logger->info(\sprintf('Feedback received: rating=%s, comments=%s', $rating, $comments));
+
+        return [
+            'status' => 'received',
+            'message' => 'Thank you for your feedback!',
+            'feedback' => [
+                'rating' => $rating,
+                'comments' => $comments,
+            ],
+        ];
+    }
+}

--- a/examples/server/elicitation/server.php
+++ b/examples/server/elicitation/server.php
@@ -1,0 +1,40 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * MCP Elicitation Example Server.
+ *
+ * Demonstrates server-to-client elicitation for interactive user input during tool execution.
+ * See docs/examples.md for detailed documentation and usage examples.
+ */
+
+require_once dirname(__DIR__).'/bootstrap.php';
+chdir(__DIR__);
+
+use Mcp\Schema\ServerCapabilities;
+use Mcp\Server;
+use Mcp\Server\Session\FileSessionStore;
+
+$server = Server::builder()
+    ->setServerInfo('Elicitation Demo', '1.0.0')
+    ->setLogger(logger())
+    ->setContainer(container())
+    ->setSession(new FileSessionStore(__DIR__.'/sessions'))
+    ->setCapabilities(new ServerCapabilities(logging: true, tools: true))
+    ->setDiscovery(__DIR__)
+    ->build();
+
+$result = $server->run(transport());
+
+shutdown($result);

--- a/src/Schema/ClientCapabilities.php
+++ b/src/Schema/ClientCapabilities.php
@@ -26,6 +26,7 @@ class ClientCapabilities implements \JsonSerializable
         public readonly ?bool $roots = false,
         public readonly ?bool $rootsListChanged = null,
         public readonly ?bool $sampling = null,
+        public readonly ?bool $elicitation = null,
         public readonly ?array $experimental = null,
     ) {
     }
@@ -36,6 +37,7 @@ class ClientCapabilities implements \JsonSerializable
      *         listChanged?: bool,
      *     },
      *     sampling?: bool,
+     *     elicitation?: bool,
      *     experimental?: array<string, mixed>,
      * } $data
      */
@@ -56,10 +58,16 @@ class ClientCapabilities implements \JsonSerializable
             $sampling = true;
         }
 
+        $elicitation = null;
+        if (isset($data['elicitation'])) {
+            $elicitation = true;
+        }
+
         return new self(
             $rootsEnabled,
             $rootsListChanged,
             $sampling,
+            $elicitation,
             $data['experimental'] ?? null
         );
     }
@@ -68,6 +76,7 @@ class ClientCapabilities implements \JsonSerializable
      * @return array{
      *     roots?: object,
      *     sampling?: object,
+     *     elicitation?: object,
      *     experimental?: object,
      * }
      */
@@ -83,6 +92,10 @@ class ClientCapabilities implements \JsonSerializable
 
         if ($this->sampling) {
             $data['sampling'] = new \stdClass();
+        }
+
+        if ($this->elicitation) {
+            $data['elicitation'] = new \stdClass();
         }
 
         if ($this->experimental) {

--- a/src/Schema/Elicitation/AbstractSchemaDefinition.php
+++ b/src/Schema/Elicitation/AbstractSchemaDefinition.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Schema\Elicitation;
+
+use Mcp\Exception\InvalidArgumentException;
+
+/**
+ * Base class for schema definitions in elicitation requests.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+abstract class AbstractSchemaDefinition implements \JsonSerializable
+{
+    public function __construct(
+        public readonly string $title,
+        public readonly ?string $description = null,
+    ) {
+    }
+
+    /**
+     * Validate that title exists and is a string in the data array.
+     *
+     * @param array<string, mixed> $data
+     *
+     * @throws InvalidArgumentException
+     */
+    protected static function validateTitle(array $data, string $schemaType): void
+    {
+        if (!isset($data['title']) || !\is_string($data['title'])) {
+            throw new InvalidArgumentException(\sprintf('Missing or invalid "title" for %s schema definition.', $schemaType));
+        }
+    }
+
+    /**
+     * Build the base JSON structure with type, title, and optional description.
+     *
+     * @return array<string, mixed>
+     */
+    protected function buildBaseJson(string $type): array
+    {
+        $data = [
+            'type' => $type,
+            'title' => $this->title,
+        ];
+
+        if (null !== $this->description) {
+            $data['description'] = $this->description;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    abstract public function jsonSerialize(): array;
+}

--- a/src/Schema/Elicitation/BooleanSchemaDefinition.php
+++ b/src/Schema/Elicitation/BooleanSchemaDefinition.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Schema\Elicitation;
+
+/**
+ * Schema definition for boolean fields in elicitation requests.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class BooleanSchemaDefinition extends AbstractSchemaDefinition
+{
+    /**
+     * @param string      $title       Human-readable title for the field
+     * @param string|null $description Optional description/help text
+     * @param bool|null   $default     Optional default value
+     */
+    public function __construct(
+        string $title,
+        ?string $description = null,
+        public readonly ?bool $default = null,
+    ) {
+        parent::__construct($title, $description);
+    }
+
+    /**
+     * @param array{
+     *     title: string,
+     *     description?: string,
+     *     default?: bool,
+     * } $data
+     */
+    public static function fromArray(array $data): self
+    {
+        self::validateTitle($data, 'boolean');
+
+        return new self(
+            title: $data['title'],
+            description: $data['description'] ?? null,
+            default: isset($data['default']) ? (bool) $data['default'] : null,
+        );
+    }
+
+    /**
+     * @return array{
+     *     type: string,
+     *     title: string,
+     *     description?: string,
+     *     default?: bool,
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        $data = $this->buildBaseJson('boolean');
+
+        if (null !== $this->default) {
+            $data['default'] = $this->default;
+        }
+
+        return $data;
+    }
+}

--- a/src/Schema/Elicitation/ElicitationSchema.php
+++ b/src/Schema/Elicitation/ElicitationSchema.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Schema\Elicitation;
+
+use Mcp\Exception\InvalidArgumentException;
+
+/**
+ * Schema wrapper for elicitation requestedSchema (JSON Schema object type).
+ *
+ * Represents an object schema with primitive property definitions and optional required fields.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ElicitationSchema implements \JsonSerializable
+{
+    /**
+     * @param array<string, StringSchemaDefinition|NumberSchemaDefinition|BooleanSchemaDefinition|EnumSchemaDefinition> $properties Property definitions keyed by name
+     * @param string[]                                                                                                  $required   Array of required property names
+     */
+    public function __construct(
+        public readonly array $properties,
+        public readonly array $required = [],
+    ) {
+        if ([] === $properties) {
+            throw new InvalidArgumentException('properties array must not be empty.');
+        }
+
+        foreach ($required as $name) {
+            if (!\array_key_exists($name, $properties)) {
+                throw new InvalidArgumentException(\sprintf('Required property "%s" is not defined in properties.', $name));
+            }
+        }
+    }
+
+    /**
+     * Create an ElicitationSchema from array data.
+     *
+     * @param array{
+     *     type?: string,
+     *     properties: array<string, array{type: string, title: string, ...}>,
+     *     required?: string[],
+     * } $data
+     */
+    public static function fromArray(array $data): self
+    {
+        if (isset($data['type']) && 'object' !== $data['type']) {
+            throw new InvalidArgumentException('ElicitationSchema type must be "object".');
+        }
+
+        if (!isset($data['properties']) || !\is_array($data['properties'])) {
+            throw new InvalidArgumentException('Missing or invalid "properties" for elicitation schema.');
+        }
+
+        $properties = [];
+        foreach ($data['properties'] as $name => $propertyData) {
+            if (!\is_array($propertyData)) {
+                throw new InvalidArgumentException(\sprintf('Property "%s" must be an array.', $name));
+            }
+            $properties[$name] = PrimitiveSchemaDefinition::fromArray($propertyData);
+        }
+
+        return new self(
+            properties: $properties,
+            required: $data['required'] ?? [],
+        );
+    }
+
+    /**
+     * @return array{
+     *     type: string,
+     *     properties: array<string, mixed>,
+     *     required?: string[],
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        $data = [
+            'type' => 'object',
+            'properties' => [],
+        ];
+
+        foreach ($this->properties as $name => $property) {
+            $data['properties'][$name] = $property->jsonSerialize();
+        }
+
+        if ([] !== $this->required) {
+            $data['required'] = $this->required;
+        }
+
+        return $data;
+    }
+}

--- a/src/Schema/Elicitation/EnumSchemaDefinition.php
+++ b/src/Schema/Elicitation/EnumSchemaDefinition.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Schema\Elicitation;
+
+use Mcp\Exception\InvalidArgumentException;
+
+/**
+ * Schema definition for string enum fields in elicitation requests.
+ *
+ * Provides a list of allowed values with optional human-readable labels.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class EnumSchemaDefinition extends AbstractSchemaDefinition
+{
+    /**
+     * @param string        $title       Human-readable title for the field
+     * @param string[]      $enum        Array of allowed string values
+     * @param string|null   $description Optional description/help text
+     * @param string|null   $default     Optional default value (must be in enum)
+     * @param string[]|null $enumNames   Optional human-readable labels for each enum value
+     */
+    public function __construct(
+        string $title,
+        public readonly array $enum,
+        ?string $description = null,
+        public readonly ?string $default = null,
+        public readonly ?array $enumNames = null,
+    ) {
+        parent::__construct($title, $description);
+
+        if ([] === $enum) {
+            throw new InvalidArgumentException('enum array must not be empty.');
+        }
+
+        foreach ($enum as $value) {
+            if (!\is_string($value)) {
+                throw new InvalidArgumentException('All enum values must be strings.');
+            }
+        }
+
+        if (null !== $enumNames && \count($enumNames) !== \count($enum)) {
+            throw new InvalidArgumentException('enumNames length must match enum length.');
+        }
+
+        if (null !== $default && !\in_array($default, $enum, true)) {
+            throw new InvalidArgumentException(\sprintf('Default value "%s" is not in the enum array.', $default));
+        }
+    }
+
+    /**
+     * @param array{
+     *     title: string,
+     *     enum: string[],
+     *     description?: string,
+     *     default?: string,
+     *     enumNames?: string[],
+     * } $data
+     */
+    public static function fromArray(array $data): self
+    {
+        self::validateTitle($data, 'enum');
+
+        if (!isset($data['enum']) || !\is_array($data['enum'])) {
+            throw new InvalidArgumentException('Missing or invalid "enum" for enum schema definition.');
+        }
+
+        return new self(
+            title: $data['title'],
+            enum: $data['enum'],
+            description: $data['description'] ?? null,
+            default: $data['default'] ?? null,
+            enumNames: $data['enumNames'] ?? null,
+        );
+    }
+
+    /**
+     * @return array{
+     *     type: string,
+     *     title: string,
+     *     enum: string[],
+     *     description?: string,
+     *     default?: string,
+     *     enumNames?: string[],
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        $data = [
+            'type' => 'string',
+            'title' => $this->title,
+            'enum' => $this->enum,
+        ];
+
+        if (null !== $this->description) {
+            $data['description'] = $this->description;
+        }
+
+        if (null !== $this->default) {
+            $data['default'] = $this->default;
+        }
+
+        if (null !== $this->enumNames) {
+            $data['enumNames'] = $this->enumNames;
+        }
+
+        return $data;
+    }
+}

--- a/src/Schema/Elicitation/NumberSchemaDefinition.php
+++ b/src/Schema/Elicitation/NumberSchemaDefinition.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Schema\Elicitation;
+
+use Mcp\Exception\InvalidArgumentException;
+
+/**
+ * Schema definition for number/integer fields in elicitation requests.
+ *
+ * Supports minimum and maximum value constraints.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class NumberSchemaDefinition extends AbstractSchemaDefinition
+{
+    /**
+     * @param string         $title       Human-readable title for the field
+     * @param bool           $integerOnly Whether to restrict to integer values only
+     * @param string|null    $description Optional description/help text
+     * @param int|float|null $default     Optional default value
+     * @param int|float|null $minimum     Optional minimum value (inclusive)
+     * @param int|float|null $maximum     Optional maximum value (inclusive)
+     */
+    public function __construct(
+        string $title,
+        public readonly bool $integerOnly = false,
+        ?string $description = null,
+        public readonly int|float|null $default = null,
+        public readonly int|float|null $minimum = null,
+        public readonly int|float|null $maximum = null,
+    ) {
+        parent::__construct($title, $description);
+
+        if (null !== $minimum && null !== $maximum && $minimum > $maximum) {
+            throw new InvalidArgumentException('minimum cannot be greater than maximum.');
+        }
+
+        if (null !== $default && null !== $minimum && $default < $minimum) {
+            throw new InvalidArgumentException('default value cannot be less than minimum.');
+        }
+
+        if (null !== $default && null !== $maximum && $default > $maximum) {
+            throw new InvalidArgumentException('default value cannot be greater than maximum.');
+        }
+
+        if ($integerOnly && null !== $default && $default !== (int) $default) {
+            throw new InvalidArgumentException('default value must be an integer when integerOnly is true.');
+        }
+    }
+
+    /**
+     * @param array{
+     *     type: string,
+     *     title: string,
+     *     description?: string,
+     *     default?: int|float,
+     *     minimum?: int|float,
+     *     maximum?: int|float,
+     * } $data
+     */
+    public static function fromArray(array $data): self
+    {
+        self::validateTitle($data, 'number');
+
+        $type = $data['type'] ?? 'number';
+        $integerOnly = 'integer' === $type;
+
+        return new self(
+            title: $data['title'],
+            integerOnly: $integerOnly,
+            description: $data['description'] ?? null,
+            default: $data['default'] ?? null,
+            minimum: $data['minimum'] ?? null,
+            maximum: $data['maximum'] ?? null,
+        );
+    }
+
+    /**
+     * @return array{
+     *     type: string,
+     *     title: string,
+     *     description?: string,
+     *     default?: int|float,
+     *     minimum?: int|float,
+     *     maximum?: int|float,
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        $data = $this->buildBaseJson($this->integerOnly ? 'integer' : 'number');
+
+        if (null !== $this->default) {
+            $data['default'] = $this->default;
+        }
+
+        if (null !== $this->minimum) {
+            $data['minimum'] = $this->minimum;
+        }
+
+        if (null !== $this->maximum) {
+            $data['maximum'] = $this->maximum;
+        }
+
+        return $data;
+    }
+}

--- a/src/Schema/Elicitation/PrimitiveSchemaDefinition.php
+++ b/src/Schema/Elicitation/PrimitiveSchemaDefinition.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Schema\Elicitation;
+
+use Mcp\Exception\InvalidArgumentException;
+
+/**
+ * Factory class for creating primitive schema definitions from array data.
+ *
+ * Dispatches to the correct schema definition class based on the "type" field.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class PrimitiveSchemaDefinition
+{
+    /**
+     * Create a schema definition from array data.
+     *
+     * @param array{
+     *     type: string,
+     *     title: string,
+     *     description?: string,
+     *     default?: mixed,
+     *     enum?: string[],
+     *     enumNames?: string[],
+     *     format?: string,
+     *     minLength?: int,
+     *     maxLength?: int,
+     *     minimum?: int|float,
+     *     maximum?: int|float,
+     * } $data
+     */
+    public static function fromArray(array $data): StringSchemaDefinition|NumberSchemaDefinition|BooleanSchemaDefinition|EnumSchemaDefinition
+    {
+        if (!isset($data['type']) || !\is_string($data['type'])) {
+            throw new InvalidArgumentException('Missing or invalid "type" for primitive schema definition.');
+        }
+
+        return match ($data['type']) {
+            'string' => isset($data['enum']) ? EnumSchemaDefinition::fromArray($data) : StringSchemaDefinition::fromArray($data),
+            'integer', 'number' => NumberSchemaDefinition::fromArray($data),
+            'boolean' => BooleanSchemaDefinition::fromArray($data),
+            default => throw new InvalidArgumentException(\sprintf('Unsupported primitive type "%s". Supported types are: string, integer, number, boolean.', $data['type'])),
+        };
+    }
+}

--- a/src/Schema/Elicitation/StringSchemaDefinition.php
+++ b/src/Schema/Elicitation/StringSchemaDefinition.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Schema\Elicitation;
+
+use Mcp\Exception\InvalidArgumentException;
+
+/**
+ * Schema definition for string fields in elicitation requests.
+ *
+ * Supports optional format validation (date, date-time, email, uri) and length constraints.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class StringSchemaDefinition extends AbstractSchemaDefinition
+{
+    private const VALID_FORMATS = ['date', 'date-time', 'email', 'uri'];
+
+    /**
+     * @param string      $title       Human-readable title for the field
+     * @param string|null $description Optional description/help text
+     * @param string|null $default     Optional default value
+     * @param string|null $format      Optional format constraint (date, date-time, email, uri)
+     * @param int|null    $minLength   Optional minimum string length
+     * @param int|null    $maxLength   Optional maximum string length
+     */
+    public function __construct(
+        string $title,
+        ?string $description = null,
+        public readonly ?string $default = null,
+        public readonly ?string $format = null,
+        public readonly ?int $minLength = null,
+        public readonly ?int $maxLength = null,
+    ) {
+        parent::__construct($title, $description);
+
+        if (null !== $format && !\in_array($format, self::VALID_FORMATS, true)) {
+            throw new InvalidArgumentException(\sprintf('Invalid format "%s". Valid formats are: %s.', $format, implode(', ', self::VALID_FORMATS)));
+        }
+
+        if (null !== $minLength && $minLength < 0) {
+            throw new InvalidArgumentException('minLength must be non-negative.');
+        }
+
+        if (null !== $maxLength && $maxLength < 0) {
+            throw new InvalidArgumentException('maxLength must be non-negative.');
+        }
+
+        if (null !== $minLength && null !== $maxLength && $minLength > $maxLength) {
+            throw new InvalidArgumentException('minLength cannot be greater than maxLength.');
+        }
+    }
+
+    /**
+     * @param array{
+     *     title: string,
+     *     description?: string,
+     *     default?: string,
+     *     format?: string,
+     *     minLength?: int,
+     *     maxLength?: int,
+     * } $data
+     */
+    public static function fromArray(array $data): self
+    {
+        self::validateTitle($data, 'string');
+
+        return new self(
+            title: $data['title'],
+            description: $data['description'] ?? null,
+            default: $data['default'] ?? null,
+            format: $data['format'] ?? null,
+            minLength: isset($data['minLength']) ? (int) $data['minLength'] : null,
+            maxLength: isset($data['maxLength']) ? (int) $data['maxLength'] : null,
+        );
+    }
+
+    /**
+     * @return array{
+     *     type: string,
+     *     title: string,
+     *     description?: string,
+     *     default?: string,
+     *     format?: string,
+     *     minLength?: int,
+     *     maxLength?: int,
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        $data = $this->buildBaseJson('string');
+
+        if (null !== $this->default) {
+            $data['default'] = $this->default;
+        }
+
+        if (null !== $this->format) {
+            $data['format'] = $this->format;
+        }
+
+        if (null !== $this->minLength) {
+            $data['minLength'] = $this->minLength;
+        }
+
+        if (null !== $this->maxLength) {
+            $data['maxLength'] = $this->maxLength;
+        }
+
+        return $data;
+    }
+}

--- a/src/Schema/Enum/ElicitAction.php
+++ b/src/Schema/Enum/ElicitAction.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Schema\Enum;
+
+/**
+ * Action taken by the user in response to an elicitation request.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+enum ElicitAction: string
+{
+    case Accept = 'accept';
+    case Decline = 'decline';
+    case Cancel = 'cancel';
+}

--- a/src/Schema/Request/ElicitRequest.php
+++ b/src/Schema/Request/ElicitRequest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Schema\Request;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\Elicitation\ElicitationSchema;
+use Mcp\Schema\JsonRpc\Request;
+
+/**
+ * A request from the server to elicit additional information from the user.
+ *
+ * The client will present the message and requested schema to the user, allowing them
+ * to provide the requested information, decline, or cancel the operation.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ElicitRequest extends Request
+{
+    /**
+     * @param string            $message         A human-readable message describing what information is needed
+     * @param ElicitationSchema $requestedSchema The schema defining the fields to elicit from the user
+     */
+    public function __construct(
+        public readonly string $message,
+        public readonly ElicitationSchema $requestedSchema,
+    ) {
+    }
+
+    public static function getMethod(): string
+    {
+        return 'elicitation/create';
+    }
+
+    protected static function fromParams(?array $params): static
+    {
+        if (!isset($params['message']) || !\is_string($params['message'])) {
+            throw new InvalidArgumentException('Missing or invalid "message" parameter for elicitation/create.');
+        }
+
+        if (!isset($params['requestedSchema']) || !\is_array($params['requestedSchema'])) {
+            throw new InvalidArgumentException('Missing or invalid "requestedSchema" parameter for elicitation/create.');
+        }
+
+        return new self(
+            $params['message'],
+            ElicitationSchema::fromArray($params['requestedSchema']),
+        );
+    }
+
+    /**
+     * @return array{
+     *     message: string,
+     *     requestedSchema: ElicitationSchema,
+     * }
+     */
+    protected function getParams(): array
+    {
+        return [
+            'message' => $this->message,
+            'requestedSchema' => $this->requestedSchema,
+        ];
+    }
+}

--- a/src/Schema/Result/ElicitResult.php
+++ b/src/Schema/Result/ElicitResult.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Schema\Result;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\Enum\ElicitAction;
+use Mcp\Schema\JsonRpc\ResultInterface;
+
+/**
+ * The client's response to an elicitation/create request from the server.
+ *
+ * Contains the user's action (accept, decline, or cancel) and the content
+ * they provided when accepting.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class ElicitResult implements ResultInterface
+{
+    /**
+     * @param ElicitAction              $action  The user's action in response to the elicitation
+     * @param array<string, mixed>|null $content The content provided by the user (only present when action is "accept")
+     */
+    public function __construct(
+        public readonly ElicitAction $action,
+        public readonly ?array $content = null,
+    ) {
+    }
+
+    /**
+     * @param array{action: string, content?: array<string, mixed>} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        if (!isset($data['action']) || !\is_string($data['action'])) {
+            throw new InvalidArgumentException('Missing or invalid "action" in ElicitResult data.');
+        }
+
+        $action = ElicitAction::from($data['action']);
+        $content = isset($data['content']) && \is_array($data['content']) ? $data['content'] : null;
+
+        if (ElicitAction::Accept === $action && null === $content) {
+            throw new InvalidArgumentException('Content must be provided when action is "accept".');
+        }
+
+        return new self($action, $content);
+    }
+
+    public function isAccepted(): bool
+    {
+        return ElicitAction::Accept === $this->action;
+    }
+
+    public function isDeclined(): bool
+    {
+        return ElicitAction::Decline === $this->action;
+    }
+
+    public function isCancelled(): bool
+    {
+        return ElicitAction::Cancel === $this->action;
+    }
+
+    /**
+     * @return array{action: string, content?: array<string, mixed>}
+     */
+    public function jsonSerialize(): array
+    {
+        $result = [
+            'action' => $this->action->value,
+        ];
+
+        if (null !== $this->content) {
+            $result['content'] = $this->content;
+        }
+
+        return $result;
+    }
+}

--- a/src/Server/Handler/Request/InitializeHandler.php
+++ b/src/Server/Handler/Request/InitializeHandler.php
@@ -45,6 +45,7 @@ final class InitializeHandler implements RequestHandlerInterface
         \assert($request instanceof InitializeRequest);
 
         $session->set('client_info', $request->clientInfo->jsonSerialize());
+        $session->set('client_capabilities', $request->capabilities->jsonSerialize());
 
         return new Response(
             $request->getId(),

--- a/src/Server/Session/Session.php
+++ b/src/Server/Session/Session.php
@@ -25,6 +25,7 @@ class Session implements SessionInterface
      * Official keys are:
      * - initialized: bool
      * - client_info: array|null
+     * - client_capabilities: array|null
      * - protocol_version: string|null
      * - log_level: string|null
      *

--- a/tests/Unit/Schema/Elicitation/BooleanSchemaDefinitionTest.php
+++ b/tests/Unit/Schema/Elicitation/BooleanSchemaDefinitionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema\Elicitation;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\Elicitation\BooleanSchemaDefinition;
+use PHPUnit\Framework\TestCase;
+
+final class BooleanSchemaDefinitionTest extends TestCase
+{
+    public function testConstructorWithMinimalParams(): void
+    {
+        $schema = new BooleanSchemaDefinition('Confirm');
+
+        $this->assertSame('Confirm', $schema->title);
+        $this->assertNull($schema->description);
+        $this->assertNull($schema->default);
+    }
+
+    public function testConstructorWithAllParams(): void
+    {
+        $schema = new BooleanSchemaDefinition(
+            title: 'Confirmation',
+            description: 'Do you confirm this action?',
+            default: false,
+        );
+
+        $this->assertSame('Confirmation', $schema->title);
+        $this->assertSame('Do you confirm this action?', $schema->description);
+        $this->assertFalse($schema->default);
+    }
+
+    public function testConstructorWithTrueDefault(): void
+    {
+        $schema = new BooleanSchemaDefinition(
+            title: 'Subscribe',
+            default: true,
+        );
+
+        $this->assertTrue($schema->default);
+    }
+
+    public function testFromArrayWithMinimalParams(): void
+    {
+        $schema = BooleanSchemaDefinition::fromArray(['title' => 'Confirm']);
+
+        $this->assertSame('Confirm', $schema->title);
+        $this->assertNull($schema->description);
+        $this->assertNull($schema->default);
+    }
+
+    public function testFromArrayWithAllParams(): void
+    {
+        $schema = BooleanSchemaDefinition::fromArray([
+            'title' => 'Confirmation',
+            'description' => 'Do you confirm this action?',
+            'default' => true,
+        ]);
+
+        $this->assertSame('Confirmation', $schema->title);
+        $this->assertSame('Do you confirm this action?', $schema->description);
+        $this->assertTrue($schema->default);
+    }
+
+    public function testFromArrayWithMissingTitle(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing or invalid "title"');
+
+        /* @phpstan-ignore argument.type */
+        BooleanSchemaDefinition::fromArray([]);
+    }
+
+    public function testJsonSerializeWithMinimalParams(): void
+    {
+        $schema = new BooleanSchemaDefinition('Confirm');
+
+        $this->assertSame([
+            'type' => 'boolean',
+            'title' => 'Confirm',
+        ], $schema->jsonSerialize());
+    }
+
+    public function testJsonSerializeWithAllParams(): void
+    {
+        $schema = new BooleanSchemaDefinition(
+            title: 'Confirmation',
+            description: 'Do you confirm this action?',
+            default: false,
+        );
+
+        $this->assertSame([
+            'type' => 'boolean',
+            'title' => 'Confirmation',
+            'description' => 'Do you confirm this action?',
+            'default' => false,
+        ], $schema->jsonSerialize());
+    }
+}

--- a/tests/Unit/Schema/Elicitation/ElicitationSchemaTest.php
+++ b/tests/Unit/Schema/Elicitation/ElicitationSchemaTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema\Elicitation;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\Elicitation\BooleanSchemaDefinition;
+use Mcp\Schema\Elicitation\ElicitationSchema;
+use Mcp\Schema\Elicitation\EnumSchemaDefinition;
+use Mcp\Schema\Elicitation\NumberSchemaDefinition;
+use Mcp\Schema\Elicitation\StringSchemaDefinition;
+use PHPUnit\Framework\TestCase;
+
+final class ElicitationSchemaTest extends TestCase
+{
+    public function testConstructorWithMinimalParams(): void
+    {
+        $properties = [
+            'name' => new StringSchemaDefinition('Name'),
+        ];
+
+        $schema = new ElicitationSchema($properties);
+
+        $this->assertCount(1, $schema->properties);
+        $this->assertSame([], $schema->required);
+    }
+
+    public function testConstructorWithRequiredFields(): void
+    {
+        $properties = [
+            'name' => new StringSchemaDefinition('Name'),
+            'email' => new StringSchemaDefinition('Email'),
+        ];
+
+        $schema = new ElicitationSchema($properties, ['name']);
+
+        $this->assertCount(2, $schema->properties);
+        $this->assertSame(['name'], $schema->required);
+    }
+
+    public function testConstructorWithMultipleTypes(): void
+    {
+        $properties = [
+            'name' => new StringSchemaDefinition('Name'),
+            'age' => new NumberSchemaDefinition('Age', integerOnly: true),
+            'subscribe' => new BooleanSchemaDefinition('Subscribe'),
+            'rating' => new EnumSchemaDefinition('Rating', ['1', '2', '3', '4', '5']),
+        ];
+
+        $schema = new ElicitationSchema($properties, ['name', 'age']);
+
+        $this->assertCount(4, $schema->properties);
+        $this->assertInstanceOf(StringSchemaDefinition::class, $schema->properties['name']);
+        $this->assertInstanceOf(NumberSchemaDefinition::class, $schema->properties['age']);
+        $this->assertInstanceOf(BooleanSchemaDefinition::class, $schema->properties['subscribe']);
+        $this->assertInstanceOf(EnumSchemaDefinition::class, $schema->properties['rating']);
+    }
+
+    public function testConstructorWithEmptyProperties(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('properties array must not be empty');
+
+        new ElicitationSchema([]);
+    }
+
+    public function testConstructorWithInvalidRequired(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Required property "unknown" is not defined in properties');
+
+        new ElicitationSchema(
+            ['name' => new StringSchemaDefinition('Name')],
+            ['unknown'],
+        );
+    }
+
+    public function testFromArrayWithMinimalParams(): void
+    {
+        $schema = ElicitationSchema::fromArray([
+            'properties' => [
+                'name' => ['type' => 'string', 'title' => 'Name'],
+            ],
+        ]);
+
+        $this->assertCount(1, $schema->properties);
+        $this->assertInstanceOf(StringSchemaDefinition::class, $schema->properties['name']);
+    }
+
+    public function testFromArrayWithExplicitObjectType(): void
+    {
+        $schema = ElicitationSchema::fromArray([
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string', 'title' => 'Name'],
+            ],
+        ]);
+
+        $this->assertCount(1, $schema->properties);
+    }
+
+    public function testFromArrayWithInvalidType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('ElicitationSchema type must be "object"');
+
+        ElicitationSchema::fromArray([
+            'type' => 'array',
+            'properties' => [
+                'name' => ['type' => 'string', 'title' => 'Name'],
+            ],
+        ]);
+    }
+
+    public function testFromArrayWithMissingProperties(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing or invalid "properties"');
+
+        /* @phpstan-ignore argument.type */
+        ElicitationSchema::fromArray([]);
+    }
+
+    public function testFromArrayWithRequiredFields(): void
+    {
+        $schema = ElicitationSchema::fromArray([
+            'properties' => [
+                'name' => ['type' => 'string', 'title' => 'Name'],
+                'email' => ['type' => 'string', 'title' => 'Email', 'format' => 'email'],
+            ],
+            'required' => ['name'],
+        ]);
+
+        $this->assertSame(['name'], $schema->required);
+    }
+
+    public function testFromArrayWithMultipleTypes(): void
+    {
+        $schema = ElicitationSchema::fromArray([
+            'properties' => [
+                'name' => ['type' => 'string', 'title' => 'Name'],
+                'age' => ['type' => 'integer', 'title' => 'Age', 'minimum' => 0],
+                'confirm' => ['type' => 'boolean', 'title' => 'Confirm'],
+                'rating' => ['type' => 'string', 'title' => 'Rating', 'enum' => ['1', '2', '3']],
+            ],
+        ]);
+
+        $this->assertInstanceOf(StringSchemaDefinition::class, $schema->properties['name']);
+        $this->assertInstanceOf(NumberSchemaDefinition::class, $schema->properties['age']);
+        $this->assertInstanceOf(BooleanSchemaDefinition::class, $schema->properties['confirm']);
+        $this->assertInstanceOf(EnumSchemaDefinition::class, $schema->properties['rating']);
+    }
+
+    public function testJsonSerializeWithMinimalParams(): void
+    {
+        $schema = new ElicitationSchema([
+            'name' => new StringSchemaDefinition('Name'),
+        ]);
+
+        $result = $schema->jsonSerialize();
+
+        $this->assertSame('object', $result['type']);
+        $this->assertArrayHasKey('name', $result['properties']);
+        $this->assertSame('string', $result['properties']['name']['type']);
+        $this->assertArrayNotHasKey('required', $result);
+    }
+
+    public function testJsonSerializeWithRequiredFields(): void
+    {
+        $schema = new ElicitationSchema(
+            [
+                'name' => new StringSchemaDefinition('Name'),
+                'email' => new StringSchemaDefinition('Email'),
+            ],
+            ['name'],
+        );
+
+        $result = $schema->jsonSerialize();
+
+        $this->assertSame(['name'], $result['required']);
+    }
+
+    public function testJsonSerializeWithFullSchema(): void
+    {
+        $schema = new ElicitationSchema(
+            [
+                'name' => new StringSchemaDefinition('Full Name', description: 'Your full name'),
+                'age' => new NumberSchemaDefinition('Age', integerOnly: true, minimum: 0, maximum: 150),
+                'subscribe' => new BooleanSchemaDefinition('Subscribe', default: false),
+            ],
+            ['name', 'age'],
+        );
+
+        $result = $schema->jsonSerialize();
+
+        $this->assertSame('object', $result['type']);
+        $this->assertCount(3, $result['properties']);
+        $this->assertSame(['name', 'age'], $result['required']);
+
+        $this->assertSame('string', $result['properties']['name']['type']);
+        $this->assertSame('Full Name', $result['properties']['name']['title']);
+        $this->assertSame('Your full name', $result['properties']['name']['description']);
+
+        $this->assertSame('integer', $result['properties']['age']['type']);
+        $this->assertSame(0, $result['properties']['age']['minimum']);
+        $this->assertSame(150, $result['properties']['age']['maximum']);
+
+        $this->assertSame('boolean', $result['properties']['subscribe']['type']);
+        $this->assertFalse($result['properties']['subscribe']['default']);
+    }
+}

--- a/tests/Unit/Schema/Elicitation/EnumSchemaDefinitionTest.php
+++ b/tests/Unit/Schema/Elicitation/EnumSchemaDefinitionTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema\Elicitation;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\Elicitation\EnumSchemaDefinition;
+use PHPUnit\Framework\TestCase;
+
+final class EnumSchemaDefinitionTest extends TestCase
+{
+    public function testConstructorWithMinimalParams(): void
+    {
+        $schema = new EnumSchemaDefinition('Rating', ['1', '2', '3', '4', '5']);
+
+        $this->assertSame('Rating', $schema->title);
+        $this->assertSame(['1', '2', '3', '4', '5'], $schema->enum);
+        $this->assertNull($schema->description);
+        $this->assertNull($schema->default);
+        $this->assertNull($schema->enumNames);
+    }
+
+    public function testConstructorWithAllParams(): void
+    {
+        $schema = new EnumSchemaDefinition(
+            title: 'Satisfaction',
+            enum: ['poor', 'fair', 'good', 'excellent'],
+            description: 'Rate your satisfaction',
+            default: 'good',
+            enumNames: ['Poor', 'Fair', 'Good', 'Excellent'],
+        );
+
+        $this->assertSame('Satisfaction', $schema->title);
+        $this->assertSame(['poor', 'fair', 'good', 'excellent'], $schema->enum);
+        $this->assertSame('Rate your satisfaction', $schema->description);
+        $this->assertSame('good', $schema->default);
+        $this->assertSame(['Poor', 'Fair', 'Good', 'Excellent'], $schema->enumNames);
+    }
+
+    public function testConstructorWithEmptyEnum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('enum array must not be empty');
+
+        new EnumSchemaDefinition('Test', []);
+    }
+
+    public function testConstructorWithNonStringEnumValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('All enum values must be strings');
+
+        /* @phpstan-ignore argument.type */
+        new EnumSchemaDefinition('Test', ['a', 1, 'b']);
+    }
+
+    public function testConstructorWithEnumNamesMismatch(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('enumNames length must match enum length');
+
+        new EnumSchemaDefinition(
+            title: 'Test',
+            enum: ['a', 'b', 'c'],
+            enumNames: ['A', 'B'],
+        );
+    }
+
+    public function testConstructorWithInvalidDefault(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Default value "invalid" is not in the enum array');
+
+        new EnumSchemaDefinition(
+            title: 'Test',
+            enum: ['a', 'b', 'c'],
+            default: 'invalid',
+        );
+    }
+
+    public function testFromArrayWithMinimalParams(): void
+    {
+        $schema = EnumSchemaDefinition::fromArray([
+            'title' => 'Rating',
+            'enum' => ['1', '2', '3'],
+        ]);
+
+        $this->assertSame('Rating', $schema->title);
+        $this->assertSame(['1', '2', '3'], $schema->enum);
+    }
+
+    public function testFromArrayWithAllParams(): void
+    {
+        $schema = EnumSchemaDefinition::fromArray([
+            'title' => 'Satisfaction',
+            'enum' => ['poor', 'fair', 'good'],
+            'description' => 'Rate your satisfaction',
+            'default' => 'fair',
+            'enumNames' => ['Poor', 'Fair', 'Good'],
+        ]);
+
+        $this->assertSame('Satisfaction', $schema->title);
+        $this->assertSame(['poor', 'fair', 'good'], $schema->enum);
+        $this->assertSame('Rate your satisfaction', $schema->description);
+        $this->assertSame('fair', $schema->default);
+        $this->assertSame(['Poor', 'Fair', 'Good'], $schema->enumNames);
+    }
+
+    public function testFromArrayWithMissingTitle(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing or invalid "title"');
+
+        /* @phpstan-ignore argument.type */
+        EnumSchemaDefinition::fromArray(['enum' => ['a', 'b']]);
+    }
+
+    public function testFromArrayWithMissingEnum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing or invalid "enum"');
+
+        /* @phpstan-ignore argument.type */
+        EnumSchemaDefinition::fromArray(['title' => 'Test']);
+    }
+
+    public function testJsonSerializeWithMinimalParams(): void
+    {
+        $schema = new EnumSchemaDefinition('Rating', ['1', '2', '3']);
+
+        $this->assertSame([
+            'type' => 'string',
+            'title' => 'Rating',
+            'enum' => ['1', '2', '3'],
+        ], $schema->jsonSerialize());
+    }
+
+    public function testJsonSerializeWithAllParams(): void
+    {
+        $schema = new EnumSchemaDefinition(
+            title: 'Satisfaction',
+            enum: ['poor', 'fair', 'good'],
+            description: 'Rate your satisfaction',
+            default: 'fair',
+            enumNames: ['Poor', 'Fair', 'Good'],
+        );
+
+        $this->assertSame([
+            'type' => 'string',
+            'title' => 'Satisfaction',
+            'enum' => ['poor', 'fair', 'good'],
+            'description' => 'Rate your satisfaction',
+            'default' => 'fair',
+            'enumNames' => ['Poor', 'Fair', 'Good'],
+        ], $schema->jsonSerialize());
+    }
+}

--- a/tests/Unit/Schema/Elicitation/NumberSchemaDefinitionTest.php
+++ b/tests/Unit/Schema/Elicitation/NumberSchemaDefinitionTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema\Elicitation;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\Elicitation\NumberSchemaDefinition;
+use PHPUnit\Framework\TestCase;
+
+final class NumberSchemaDefinitionTest extends TestCase
+{
+    public function testConstructorWithMinimalParams(): void
+    {
+        $schema = new NumberSchemaDefinition('Age');
+
+        $this->assertSame('Age', $schema->title);
+        $this->assertFalse($schema->integerOnly);
+        $this->assertNull($schema->description);
+        $this->assertNull($schema->default);
+        $this->assertNull($schema->minimum);
+        $this->assertNull($schema->maximum);
+    }
+
+    public function testConstructorWithAllParams(): void
+    {
+        $schema = new NumberSchemaDefinition(
+            title: 'Party Size',
+            integerOnly: true,
+            description: 'Number of guests',
+            default: 2,
+            minimum: 1,
+            maximum: 10,
+        );
+
+        $this->assertSame('Party Size', $schema->title);
+        $this->assertTrue($schema->integerOnly);
+        $this->assertSame('Number of guests', $schema->description);
+        $this->assertSame(2, $schema->default);
+        $this->assertSame(1, $schema->minimum);
+        $this->assertSame(10, $schema->maximum);
+    }
+
+    public function testConstructorWithFloatValues(): void
+    {
+        $schema = new NumberSchemaDefinition(
+            title: 'Temperature',
+            default: 36.5,
+            minimum: 35.0,
+            maximum: 42.0,
+        );
+
+        $this->assertSame(36.5, $schema->default);
+        $this->assertSame(35.0, $schema->minimum);
+        $this->assertSame(42.0, $schema->maximum);
+    }
+
+    public function testConstructorWithMinimumGreaterThanMaximum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('minimum cannot be greater than maximum');
+
+        new NumberSchemaDefinition('Test', minimum: 10, maximum: 5);
+    }
+
+    public function testConstructorWithDefaultBelowMinimum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('default value cannot be less than minimum');
+
+        new NumberSchemaDefinition('Test', default: 5, minimum: 10);
+    }
+
+    public function testConstructorWithDefaultAboveMaximum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('default value cannot be greater than maximum');
+
+        new NumberSchemaDefinition('Test', default: 15, maximum: 10);
+    }
+
+    public function testConstructorWithNonIntegerDefaultWhenIntegerOnly(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('default value must be an integer when integerOnly is true');
+
+        new NumberSchemaDefinition('Test', integerOnly: true, default: 5.5);
+    }
+
+    public function testFromArrayWithIntegerType(): void
+    {
+        $schema = NumberSchemaDefinition::fromArray([
+            'type' => 'integer',
+            'title' => 'Count',
+        ]);
+
+        $this->assertTrue($schema->integerOnly);
+    }
+
+    public function testFromArrayWithNumberType(): void
+    {
+        $schema = NumberSchemaDefinition::fromArray([
+            'type' => 'number',
+            'title' => 'Price',
+        ]);
+
+        $this->assertFalse($schema->integerOnly);
+    }
+
+    public function testFromArrayWithAllParams(): void
+    {
+        $schema = NumberSchemaDefinition::fromArray([
+            'type' => 'integer',
+            'title' => 'Party Size',
+            'description' => 'Number of guests',
+            'default' => 2,
+            'minimum' => 1,
+            'maximum' => 10,
+        ]);
+
+        $this->assertSame('Party Size', $schema->title);
+        $this->assertTrue($schema->integerOnly);
+        $this->assertSame('Number of guests', $schema->description);
+        $this->assertSame(2, $schema->default);
+        $this->assertSame(1, $schema->minimum);
+        $this->assertSame(10, $schema->maximum);
+    }
+
+    public function testFromArrayWithMissingTitle(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing or invalid "title"');
+
+        /* @phpstan-ignore argument.type */
+        NumberSchemaDefinition::fromArray(['type' => 'integer']);
+    }
+
+    public function testJsonSerializeAsInteger(): void
+    {
+        $schema = new NumberSchemaDefinition(
+            title: 'Count',
+            integerOnly: true,
+        );
+
+        $this->assertSame([
+            'type' => 'integer',
+            'title' => 'Count',
+        ], $schema->jsonSerialize());
+    }
+
+    public function testJsonSerializeAsNumber(): void
+    {
+        $schema = new NumberSchemaDefinition(
+            title: 'Price',
+            integerOnly: false,
+        );
+
+        $this->assertSame([
+            'type' => 'number',
+            'title' => 'Price',
+        ], $schema->jsonSerialize());
+    }
+
+    public function testJsonSerializeWithAllParams(): void
+    {
+        $schema = new NumberSchemaDefinition(
+            title: 'Party Size',
+            integerOnly: true,
+            description: 'Number of guests',
+            default: 2,
+            minimum: 1,
+            maximum: 10,
+        );
+
+        $this->assertSame([
+            'type' => 'integer',
+            'title' => 'Party Size',
+            'description' => 'Number of guests',
+            'default' => 2,
+            'minimum' => 1,
+            'maximum' => 10,
+        ], $schema->jsonSerialize());
+    }
+}

--- a/tests/Unit/Schema/Elicitation/PrimitiveSchemaDefinitionTest.php
+++ b/tests/Unit/Schema/Elicitation/PrimitiveSchemaDefinitionTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema\Elicitation;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\Elicitation\BooleanSchemaDefinition;
+use Mcp\Schema\Elicitation\EnumSchemaDefinition;
+use Mcp\Schema\Elicitation\NumberSchemaDefinition;
+use Mcp\Schema\Elicitation\PrimitiveSchemaDefinition;
+use Mcp\Schema\Elicitation\StringSchemaDefinition;
+use PHPUnit\Framework\TestCase;
+
+final class PrimitiveSchemaDefinitionTest extends TestCase
+{
+    public function testFromArrayCreatesStringSchema(): void
+    {
+        $schema = PrimitiveSchemaDefinition::fromArray([
+            'type' => 'string',
+            'title' => 'Name',
+        ]);
+
+        $this->assertInstanceOf(StringSchemaDefinition::class, $schema);
+        $this->assertSame('Name', $schema->title);
+    }
+
+    public function testFromArrayCreatesEnumSchemaForStringWithEnum(): void
+    {
+        $schema = PrimitiveSchemaDefinition::fromArray([
+            'type' => 'string',
+            'title' => 'Rating',
+            'enum' => ['1', '2', '3'],
+        ]);
+
+        $this->assertInstanceOf(EnumSchemaDefinition::class, $schema);
+        $this->assertSame('Rating', $schema->title);
+        $this->assertSame(['1', '2', '3'], $schema->enum);
+    }
+
+    public function testFromArrayCreatesIntegerSchema(): void
+    {
+        $schema = PrimitiveSchemaDefinition::fromArray([
+            'type' => 'integer',
+            'title' => 'Age',
+        ]);
+
+        $this->assertInstanceOf(NumberSchemaDefinition::class, $schema);
+        $this->assertSame('Age', $schema->title);
+        $this->assertTrue($schema->integerOnly);
+    }
+
+    public function testFromArrayCreatesNumberSchema(): void
+    {
+        $schema = PrimitiveSchemaDefinition::fromArray([
+            'type' => 'number',
+            'title' => 'Price',
+        ]);
+
+        $this->assertInstanceOf(NumberSchemaDefinition::class, $schema);
+        $this->assertSame('Price', $schema->title);
+        $this->assertFalse($schema->integerOnly);
+    }
+
+    public function testFromArrayCreatesBooleanSchema(): void
+    {
+        $schema = PrimitiveSchemaDefinition::fromArray([
+            'type' => 'boolean',
+            'title' => 'Confirm',
+        ]);
+
+        $this->assertInstanceOf(BooleanSchemaDefinition::class, $schema);
+        $this->assertSame('Confirm', $schema->title);
+    }
+
+    public function testFromArrayWithMissingType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing or invalid "type"');
+
+        /* @phpstan-ignore argument.type */
+        PrimitiveSchemaDefinition::fromArray(['title' => 'Test']);
+    }
+
+    public function testFromArrayWithUnsupportedType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported primitive type "object"');
+
+        PrimitiveSchemaDefinition::fromArray([
+            'type' => 'object',
+            'title' => 'Test',
+        ]);
+    }
+
+    public function testFromArrayWithArrayType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported primitive type "array"');
+
+        PrimitiveSchemaDefinition::fromArray([
+            'type' => 'array',
+            'title' => 'Test',
+        ]);
+    }
+}

--- a/tests/Unit/Schema/Elicitation/StringSchemaDefinitionTest.php
+++ b/tests/Unit/Schema/Elicitation/StringSchemaDefinitionTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema\Elicitation;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\Elicitation\StringSchemaDefinition;
+use PHPUnit\Framework\TestCase;
+
+final class StringSchemaDefinitionTest extends TestCase
+{
+    public function testConstructorWithMinimalParams(): void
+    {
+        $schema = new StringSchemaDefinition('Name');
+
+        $this->assertSame('Name', $schema->title);
+        $this->assertNull($schema->description);
+        $this->assertNull($schema->default);
+        $this->assertNull($schema->format);
+        $this->assertNull($schema->minLength);
+        $this->assertNull($schema->maxLength);
+    }
+
+    public function testConstructorWithAllParams(): void
+    {
+        $schema = new StringSchemaDefinition(
+            title: 'Email Address',
+            description: 'Your primary email',
+            default: 'user@example.com',
+            format: 'email',
+            minLength: 5,
+            maxLength: 100,
+        );
+
+        $this->assertSame('Email Address', $schema->title);
+        $this->assertSame('Your primary email', $schema->description);
+        $this->assertSame('user@example.com', $schema->default);
+        $this->assertSame('email', $schema->format);
+        $this->assertSame(5, $schema->minLength);
+        $this->assertSame(100, $schema->maxLength);
+    }
+
+    public function testConstructorWithValidFormats(): void
+    {
+        foreach (['date', 'date-time', 'email', 'uri'] as $format) {
+            $schema = new StringSchemaDefinition('Test', format: $format);
+            $this->assertSame($format, $schema->format);
+        }
+    }
+
+    public function testConstructorWithInvalidFormat(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid format "invalid"');
+
+        new StringSchemaDefinition('Test', format: 'invalid');
+    }
+
+    public function testConstructorWithNegativeMinLength(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('minLength must be non-negative');
+
+        new StringSchemaDefinition('Test', minLength: -1);
+    }
+
+    public function testConstructorWithNegativeMaxLength(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxLength must be non-negative');
+
+        new StringSchemaDefinition('Test', maxLength: -1);
+    }
+
+    public function testConstructorWithMinLengthGreaterThanMaxLength(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('minLength cannot be greater than maxLength');
+
+        new StringSchemaDefinition('Test', minLength: 10, maxLength: 5);
+    }
+
+    public function testFromArrayWithMinimalParams(): void
+    {
+        $schema = StringSchemaDefinition::fromArray(['title' => 'Name']);
+
+        $this->assertSame('Name', $schema->title);
+    }
+
+    public function testFromArrayWithAllParams(): void
+    {
+        $schema = StringSchemaDefinition::fromArray([
+            'title' => 'Email Address',
+            'description' => 'Your primary email',
+            'default' => 'user@example.com',
+            'format' => 'email',
+            'minLength' => 5,
+            'maxLength' => 100,
+        ]);
+
+        $this->assertSame('Email Address', $schema->title);
+        $this->assertSame('Your primary email', $schema->description);
+        $this->assertSame('user@example.com', $schema->default);
+        $this->assertSame('email', $schema->format);
+        $this->assertSame(5, $schema->minLength);
+        $this->assertSame(100, $schema->maxLength);
+    }
+
+    public function testFromArrayWithMissingTitle(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing or invalid "title"');
+
+        /* @phpstan-ignore argument.type */
+        StringSchemaDefinition::fromArray([]);
+    }
+
+    public function testJsonSerializeWithMinimalParams(): void
+    {
+        $schema = new StringSchemaDefinition('Name');
+
+        $this->assertSame([
+            'type' => 'string',
+            'title' => 'Name',
+        ], $schema->jsonSerialize());
+    }
+
+    public function testJsonSerializeWithAllParams(): void
+    {
+        $schema = new StringSchemaDefinition(
+            title: 'Email Address',
+            description: 'Your primary email',
+            default: 'user@example.com',
+            format: 'email',
+            minLength: 5,
+            maxLength: 100,
+        );
+
+        $this->assertSame([
+            'type' => 'string',
+            'title' => 'Email Address',
+            'description' => 'Your primary email',
+            'default' => 'user@example.com',
+            'format' => 'email',
+            'minLength' => 5,
+            'maxLength' => 100,
+        ], $schema->jsonSerialize());
+    }
+}

--- a/tests/Unit/Schema/Enum/ElicitActionTest.php
+++ b/tests/Unit/Schema/Enum/ElicitActionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema\Enum;
+
+use Mcp\Schema\Enum\ElicitAction;
+use PHPUnit\Framework\TestCase;
+
+final class ElicitActionTest extends TestCase
+{
+    public function testEnumValues(): void
+    {
+        $this->assertSame('accept', ElicitAction::Accept->value);
+        $this->assertSame('decline', ElicitAction::Decline->value);
+        $this->assertSame('cancel', ElicitAction::Cancel->value);
+    }
+
+    public function testFromValidValues(): void
+    {
+        $this->assertSame(ElicitAction::Accept, ElicitAction::from('accept'));
+        $this->assertSame(ElicitAction::Decline, ElicitAction::from('decline'));
+        $this->assertSame(ElicitAction::Cancel, ElicitAction::from('cancel'));
+    }
+
+    public function testFromInvalidValue(): void
+    {
+        $this->expectException(\ValueError::class);
+        ElicitAction::from('invalid');
+    }
+
+    public function testTryFromValidValues(): void
+    {
+        $this->assertSame(ElicitAction::Accept, ElicitAction::tryFrom('accept'));
+        $this->assertSame(ElicitAction::Decline, ElicitAction::tryFrom('decline'));
+        $this->assertSame(ElicitAction::Cancel, ElicitAction::tryFrom('cancel'));
+    }
+
+    public function testTryFromInvalidValue(): void
+    {
+        $this->assertNull(ElicitAction::tryFrom('invalid'));
+    }
+}

--- a/tests/Unit/Schema/Request/ElicitRequestTest.php
+++ b/tests/Unit/Schema/Request/ElicitRequestTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema\Request;
+
+use Mcp\Schema\Elicitation\ElicitationSchema;
+use Mcp\Schema\Elicitation\NumberSchemaDefinition;
+use Mcp\Schema\Elicitation\StringSchemaDefinition;
+use Mcp\Schema\Request\ElicitRequest;
+use PHPUnit\Framework\TestCase;
+
+final class ElicitRequestTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $schema = new ElicitationSchema([
+            'name' => new StringSchemaDefinition('Name'),
+        ]);
+
+        $request = new ElicitRequest('Please provide your name', $schema);
+
+        $this->assertSame('Please provide your name', $request->message);
+        $this->assertSame($schema, $request->requestedSchema);
+    }
+
+    public function testGetMethod(): void
+    {
+        $this->assertSame('elicitation/create', ElicitRequest::getMethod());
+    }
+
+    public function testJsonSerialization(): void
+    {
+        $schema = new ElicitationSchema(
+            [
+                'name' => new StringSchemaDefinition('Name'),
+                'age' => new NumberSchemaDefinition('Age', integerOnly: true, minimum: 0),
+            ],
+            ['name'],
+        );
+
+        $request = new ElicitRequest('Please provide your details', $schema);
+        $request = $request->withId(1);
+
+        $json = json_encode($request);
+        $this->assertIsString($json);
+
+        $decoded = json_decode($json, true);
+        $this->assertIsArray($decoded);
+
+        $this->assertSame('2.0', $decoded['jsonrpc']);
+        $this->assertSame('elicitation/create', $decoded['method']);
+        $this->assertArrayHasKey('params', $decoded);
+
+        $params = $decoded['params'];
+        $this->assertSame('Please provide your details', $params['message']);
+        $this->assertArrayHasKey('requestedSchema', $params);
+
+        $requestedSchema = $params['requestedSchema'];
+        $this->assertSame('object', $requestedSchema['type']);
+        $this->assertArrayHasKey('name', $requestedSchema['properties']);
+        $this->assertArrayHasKey('age', $requestedSchema['properties']);
+        $this->assertSame(['name'], $requestedSchema['required']);
+    }
+}

--- a/tests/Unit/Schema/Result/ElicitResultTest.php
+++ b/tests/Unit/Schema/Result/ElicitResultTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema\Result;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\Enum\ElicitAction;
+use Mcp\Schema\Result\ElicitResult;
+use PHPUnit\Framework\TestCase;
+
+final class ElicitResultTest extends TestCase
+{
+    public function testConstructorWithAcceptAndContent(): void
+    {
+        $content = ['name' => 'John', 'age' => 30];
+        $result = new ElicitResult(ElicitAction::Accept, $content);
+
+        $this->assertSame(ElicitAction::Accept, $result->action);
+        $this->assertSame($content, $result->content);
+    }
+
+    public function testConstructorWithDecline(): void
+    {
+        $result = new ElicitResult(ElicitAction::Decline);
+
+        $this->assertSame(ElicitAction::Decline, $result->action);
+        $this->assertNull($result->content);
+    }
+
+    public function testConstructorWithCancel(): void
+    {
+        $result = new ElicitResult(ElicitAction::Cancel);
+
+        $this->assertSame(ElicitAction::Cancel, $result->action);
+        $this->assertNull($result->content);
+    }
+
+    public function testFromArrayWithAccept(): void
+    {
+        $result = ElicitResult::fromArray([
+            'action' => 'accept',
+            'content' => ['name' => 'John', 'email' => 'john@example.com'],
+        ]);
+
+        $this->assertSame(ElicitAction::Accept, $result->action);
+        $this->assertSame(['name' => 'John', 'email' => 'john@example.com'], $result->content);
+    }
+
+    public function testFromArrayWithDecline(): void
+    {
+        $result = ElicitResult::fromArray([
+            'action' => 'decline',
+        ]);
+
+        $this->assertSame(ElicitAction::Decline, $result->action);
+        $this->assertNull($result->content);
+    }
+
+    public function testFromArrayWithCancel(): void
+    {
+        $result = ElicitResult::fromArray([
+            'action' => 'cancel',
+        ]);
+
+        $this->assertSame(ElicitAction::Cancel, $result->action);
+        $this->assertNull($result->content);
+    }
+
+    public function testFromArrayWithMissingAction(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing or invalid "action"');
+
+        /* @phpstan-ignore argument.type */
+        ElicitResult::fromArray([]);
+    }
+
+    public function testFromArrayWithInvalidAction(): void
+    {
+        $this->expectException(\ValueError::class);
+
+        ElicitResult::fromArray(['action' => 'invalid']);
+    }
+
+    public function testFromArrayWithAcceptActionRequiresContent(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Content must be provided when action is "accept"');
+
+        ElicitResult::fromArray(['action' => 'accept']);
+    }
+
+    public function testIsAccepted(): void
+    {
+        $acceptResult = new ElicitResult(ElicitAction::Accept, ['name' => 'John']);
+        $declineResult = new ElicitResult(ElicitAction::Decline);
+        $cancelResult = new ElicitResult(ElicitAction::Cancel);
+
+        $this->assertTrue($acceptResult->isAccepted());
+        $this->assertFalse($declineResult->isAccepted());
+        $this->assertFalse($cancelResult->isAccepted());
+    }
+
+    public function testIsDeclined(): void
+    {
+        $acceptResult = new ElicitResult(ElicitAction::Accept, ['name' => 'John']);
+        $declineResult = new ElicitResult(ElicitAction::Decline);
+        $cancelResult = new ElicitResult(ElicitAction::Cancel);
+
+        $this->assertFalse($acceptResult->isDeclined());
+        $this->assertTrue($declineResult->isDeclined());
+        $this->assertFalse($cancelResult->isDeclined());
+    }
+
+    public function testIsCancelled(): void
+    {
+        $acceptResult = new ElicitResult(ElicitAction::Accept, ['name' => 'John']);
+        $declineResult = new ElicitResult(ElicitAction::Decline);
+        $cancelResult = new ElicitResult(ElicitAction::Cancel);
+
+        $this->assertFalse($acceptResult->isCancelled());
+        $this->assertFalse($declineResult->isCancelled());
+        $this->assertTrue($cancelResult->isCancelled());
+    }
+
+    public function testJsonSerializeWithAcceptAndContent(): void
+    {
+        $result = new ElicitResult(ElicitAction::Accept, ['name' => 'John', 'age' => 30]);
+
+        $this->assertSame([
+            'action' => 'accept',
+            'content' => ['name' => 'John', 'age' => 30],
+        ], $result->jsonSerialize());
+    }
+
+    public function testJsonSerializeWithDecline(): void
+    {
+        $result = new ElicitResult(ElicitAction::Decline);
+
+        $this->assertSame([
+            'action' => 'decline',
+        ], $result->jsonSerialize());
+    }
+
+    public function testJsonSerializeWithCancel(): void
+    {
+        $result = new ElicitResult(ElicitAction::Cancel);
+
+        $this->assertSame([
+            'action' => 'cancel',
+        ], $result->jsonSerialize());
+    }
+}

--- a/tests/Unit/Server/Handler/Request/InitializeHandlerTest.php
+++ b/tests/Unit/Server/Handler/Request/InitializeHandlerTest.php
@@ -39,12 +39,15 @@ class InitializeHandlerTest extends TestCase
         $handler = new InitializeHandler($configuration);
 
         $session = $this->createMock(SessionInterface::class);
-        $session->expects($this->once())
+        $session->expects($this->exactly(2))
             ->method('set')
-            ->with('client_info', [
-                'name' => 'client-app',
-                'version' => '1.0.0',
-            ]);
+            ->willReturnCallback(function (string $key, array $value): void {
+                match ($key) {
+                    'client_info' => $this->assertSame(['name' => 'client-app', 'version' => '1.0.0'], $value),
+                    'client_capabilities' => $this->assertSame([], $value),
+                    default => $this->fail("Unexpected session key: {$key}"),
+                };
+            });
 
         $request = InitializeRequest::fromArray([
             'jsonrpc' => MessageInterface::JSONRPC_VERSION,


### PR DESCRIPTION
## Motivation and Context

This PR implements the elicitation feature from the MCP specification (2025-06-18), which allows servers to request additional information from users during tool execution via the `elicitation/create` method.

Elicitation enables interactive workflows where the server can:
- Ask for user preferences or choices
- Collect form data with validated fields
- Request confirmation before performing actions

This is particularly useful for tools that need dynamic user input that can't be determined upfront.

## How Has This Been Tested?

- **Unit tests**: 87 new tests covering all elicitation classes
- **PHPStan**: No errors at configured level
- **Integration testing**: Tested with [OpenCode PR #8243](https://github.com/anomalyco/opencode/pull/8243) which adds elicitation client support
  - Verified `book_restaurant` tool with multi-field form (number, date, enum)
  - Verified `confirm_action` tool with boolean confirmation
  - Verified `collect_feedback` tool with rating enum and optional comments
  - Tested accept, decline, and cancel user responses

![elicitations](https://github.com/user-attachments/assets/9e7346e8-08d6-4120-8540-c5b02357a465)

## Breaking Changes

None. This is a purely additive feature.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

### Files added

**Schema definitions** (`src/Schema/Elicitation/`):
- `StringSchemaDefinition` - String fields with optional format (date, email, uri), minLength, maxLength
- `NumberSchemaDefinition` - Integer/number fields with min/max validation
- `BooleanSchemaDefinition` - Boolean checkbox fields
- `EnumSchemaDefinition` - String enums with optional human-readable labels (enumNames)
- `PrimitiveSchemaDefinition` - Factory for deserializing schema definitions
- `ElicitationSchema` - Wrapper for the requestedSchema object

**Request/Result** (`src/Schema/`):
- `Enum/ElicitAction` - User response actions (accept, decline, cancel)
- `Request/ElicitRequest` - The `elicitation/create` request
- `Result/ElicitResult` - The client's response with convenience methods (`isAccepted()`, `isDeclined()`, `isCancelled()`)

**Server changes**:
- `ClientGateway::elicit()` - Convenience method for sending elicitation requests
- `InitializeHandler` - Now stores client capabilities in session for capability checking

**Example** (`examples/server/elicitation/`):
- Complete working example with three tools demonstrating different elicitation patterns
- Includes capability checking for graceful fallback when client doesn't support elicitation

### Protocol details

Request format:
```json
{
  "method": "elicitation/create",
  "params": {
    "message": "Please provide your reservation details:",
    "requestedSchema": {
      "type": "object",
      "properties": {
        "party_size": { "type": "integer", "minimum": 1, "maximum": 20 },
        "date": { "type": "string", "format": "date" }
      },
      "required": ["party_size", "date"]
    }
  }
}
```

Response format:
```json
{
  "action": "accept",
  "content": { "party_size": 4, "date": "2025-02-14" }
}
```

Link to the MCP Specification: https://modelcontextprotocol.io/specification/draft/client/elicitation