### PR TITLE
[Server] Wire up notifications for changing prompt, resource & tools lists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
   "autoload-dev": {
     "psr-4": {
       "Mcp\\Example\\Server\\CachedDiscovery\\": "examples/server/cached-discovery/",
+      "Mcp\\Example\\Server\\ChangeEvents\\": "examples/server/change-events/",
       "Mcp\\Example\\Server\\ClientCommunication\\": "examples/server/client-communication/",
       "Mcp\\Example\\Server\\ClientLogging\\": "examples/server/client-logging/",
       "Mcp\\Example\\Server\\CombinedRegistration\\": "examples/server/combined-registration/",

--- a/examples/server/change-events/ListChangingHandlers.php
+++ b/examples/server/change-events/ListChangingHandlers.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Example\Server\ChangeEvents;
+
+use Mcp\Capability\RegistryInterface;
+use Mcp\Schema\Content\PromptMessage;
+use Mcp\Schema\Content\TextContent;
+use Mcp\Schema\Enum\Role;
+use Mcp\Schema\Prompt;
+use Mcp\Schema\Resource;
+use Mcp\Schema\Tool;
+
+final class ListChangingHandlers
+{
+    public function __construct(
+        private readonly RegistryInterface $registry,
+    ) {
+    }
+
+    public function addPrompt(string $name, string $content): string
+    {
+        $this->registry->registerPrompt(
+            new Prompt($name),
+            static fn () => [new PromptMessage(Role::User, new TextContent($content))],
+            isManual: true,
+        );
+
+        return \sprintf('Prompt "%s" registered.', $name);
+    }
+
+    public function addResource(string $uri, string $name): string
+    {
+        $this->registry->registerResource(
+            new Resource($uri, $name),
+            static fn () => \sprintf('This is the content of the dynamically added resource "%s" at URI "%s".', $name, $uri),
+            true,
+        );
+
+        return \sprintf('Resource "%s" registered.', $name);
+    }
+
+    public function addTool(string $name): string
+    {
+        $this->registry->registerTool(
+            new Tool(
+                $name,
+                ['type' => 'object', 'properties' => new \stdClass(), 'required' => []],
+                'Dynamically added tool',
+                null
+            ),
+            static fn () => \sprintf('This is the output of the dynamically added tool "%s".', $name),
+            true,
+        );
+
+        return \sprintf('Tool "%s" registered.', $name);
+    }
+}

--- a/examples/server/change-events/server.php
+++ b/examples/server/change-events/server.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once dirname(__DIR__).'/bootstrap.php';
+chdir(__DIR__);
+
+use Mcp\Capability\Registry;
+use Mcp\Capability\RegistryInterface;
+use Mcp\Event\Dispatcher;
+use Mcp\Event\ListenerProvider;
+use Mcp\Example\Server\ChangeEvents\ListChangingHandlers;
+use Mcp\Server;
+
+logger()->info('Starting MCP Change Events Server...');
+
+$listenerProvider = new ListenerProvider();
+$dispatcher = new Dispatcher($listenerProvider);
+$registry = new Registry($dispatcher, logger());
+$container = container();
+$container->set(RegistryInterface::class, $registry);
+
+$server = Server::builder()
+    ->setServerInfo('Server with Changing Lists', '1.0.0')
+    ->setLogger(logger())
+    ->setContainer($container)
+    ->setRegistry($registry)
+    ->setEventDispatcher($dispatcher)
+    ->setEventListenerProvider($listenerProvider)
+    ->addTool([ListChangingHandlers::class, 'addPrompt'], 'add_prompt', 'Tool that adds a new prompt to the registry with the given name and content.')
+    ->addTool([ListChangingHandlers::class, 'addResource'], 'add_resource', 'Tool that adds a new resource to the registry with the given name and URL.')
+    ->addTool([ListChangingHandlers::class, 'addTool'], 'add_tool', 'Tool that adds a new tool to the registry with the given name.')
+    ->build();
+
+$result = $server->run(transport());
+
+logger()->info('Server listener stopped gracefully.', ['result' => $result]);
+
+shutdown($result);

--- a/src/Event/Dispatcher.php
+++ b/src/Event/Dispatcher.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Event;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class Dispatcher implements EventDispatcherInterface
+{
+    public function __construct(
+        private readonly ListenerProvider $listenerProvider,
+    ) {
+    }
+
+    public function dispatch(object $event): object
+    {
+        foreach ($this->listenerProvider->getListenersForEvent($event) as $listener) {
+            $listener($event);
+        }
+
+        return $event;
+    }
+}

--- a/src/Event/ListenerProvider.php
+++ b/src/Event/ListenerProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Event;
+
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+/**
+ * Intended for SDK internal event listeners.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ListenerProvider implements ListenerProviderInterface
+{
+    /**
+     * @var array <class-string, callable[]>
+     */
+    private array $listeners = [];
+
+    public function addListener(string $eventClass, callable $listener): void
+    {
+        $this->listeners[$eventClass][] = $listener;
+    }
+
+    /**
+     * @return iterable<callable>
+     */
+    public function getListenersForEvent(object $event): iterable
+    {
+        if (isset($this->listeners[$event::class])) {
+            foreach ($this->listeners[$event::class] as $listener) {
+                yield $listener;
+            }
+        }
+    }
+}

--- a/src/Schema/Tool.php
+++ b/src/Schema/Tool.php
@@ -21,8 +21,8 @@ use Mcp\Exception\InvalidArgumentException;
  *
  * @phpstan-type ToolInputSchema array{
  *     type: 'object',
- *     properties: array<string, mixed>,
- *     required: string[]|null
+ *     properties: array<string, mixed>|object,
+ *     required: string[]
  * }
  * @phpstan-type ToolOutputSchema array{
  *     type: 'object',

--- a/src/Server/ChangeListener.php
+++ b/src/Server/ChangeListener.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server;
+
+use Mcp\Schema\Notification\PromptListChangedNotification;
+use Mcp\Schema\Notification\ResourceListChangedNotification;
+use Mcp\Schema\Notification\ToolListChangedNotification;
+
+/**
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ChangeListener
+{
+    public function __construct(
+        private readonly Protocol $protocol,
+    ) {
+    }
+
+    public function onPromptListChange(): void
+    {
+        $this->protocol->sendNotification(new PromptListChangedNotification());
+    }
+
+    public function onResourceListChange(): void
+    {
+        $this->protocol->sendNotification(new ResourceListChangedNotification());
+    }
+
+    public function onToolListChange(): void
+    {
+        $this->protocol->sendNotification(new ToolListChangedNotification());
+    }
+}

--- a/tests/Unit/Capability/RegistryTest.php
+++ b/tests/Unit/Capability/RegistryTest.php
@@ -620,7 +620,7 @@ class RegistryTest extends TestCase
                 'properties' => [
                     'param' => ['type' => 'string'],
                 ],
-                'required' => null,
+                'required' => [],
             ],
             description: "Test tool: {$name}",
             annotations: null,


### PR DESCRIPTION
This is a working draft for emitting change notifications on dynamically added prompts, resources and tools.

The main issue here is that we need that indirection between Registry, source of truth on changing lists, and Protocol, that is able so send notifications. That's why we have those events, but we never really adopted them.

I introduced a slim EventDispatcher/ListenerProvider setup, but it feels a bit flaky - see wire up in example. The service landscape within the SDK just grows in complexity.

**TBD**

1. Event Dispatcher
The issue I had was mostly about PSR-14 - we want to empower library users to inject their own event dispatcher, to easily register subscriber/listener/whatever - but with the current implementation we also want to add our own listeners for triggering the notifications (again, we need a decoupling between registry and protocol currently).
With PSR-14 the `EventDispatcherInterface` used in the `Registry` doesn't offer us to register our own listeners after a user injected it via `Builder::setEventDispatcher()`

2. Session ID State
I need to call the `Protocol::sendNotification(...)` from the listeners, but didn't have the session at hand - and there is basically no state in the Protocol - which is great, but we don't have a service concept to retrieve the session - it is only state in the transport or arguments looped through half the SDK.
I went for introducing the session as state in the `Protocol` - needs better null-checks tho, but wanted to check with @CodeWithKyrian first - the other option would be to keep the transport as state, since it also has the session already as state.

WDYT?

edit: this currently messes up the session handling within a fiber intermediate client request.