### PR TITLE
chore: remove final keyword on attributes classes

### DIFF
--- a/src/Capability/Attribute/McpPrompt.php
+++ b/src/Capability/Attribute/McpPrompt.php
@@ -20,7 +20,7 @@ use Mcp\Schema\Icon;
  * @author Kyrian Obikwelu <koshnawaza@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
-final class McpPrompt
+class McpPrompt
 {
     /**
      * @param ?string               $name        overrides the prompt name (defaults to method name)

--- a/src/Capability/Attribute/McpResource.php
+++ b/src/Capability/Attribute/McpResource.php
@@ -21,7 +21,7 @@ use Mcp\Schema\Icon;
  * @author Kyrian Obikwelu <koshnawaza@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
-final class McpResource
+class McpResource
 {
     /**
      * @param string                $uri         The specific URI identifying this resource instance. Must be unique within the server.

--- a/src/Capability/Attribute/McpResourceTemplate.php
+++ b/src/Capability/Attribute/McpResourceTemplate.php
@@ -20,7 +20,7 @@ use Mcp\Schema\Annotations;
  * @author Kyrian Obikwelu <koshnawaza@gmail.com>
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
-final class McpResourceTemplate
+class McpResourceTemplate
 {
     /**
      * @param string                $uriTemplate the URI template string (RFC 6570)


### PR DESCRIPTION
This PR removes the `final` keyword from three core classes: `McpPrompt`, `McpResource`, and `McpResourceTemplate`. This change enables developers to extend these classes to implement custom logic, particularly within discovery processes.

## Motivation and Context
The current use of the `final` keyword prevents any inheritance, which is too restrictive for advanced SDK integrations. 

Specifically, when implementing a **CustomDiscoverer**, it is often necessary to extend these entities to:
- Inject additional metadata or custom attributes.
- Override or supplement default behavior without duplicating the entire class logic.
- Maintain type compatibility with the SDK's internal methods that expect these specific types.

By removing `final`, we follow the **Open-Closed Principle**, allowing for extension without modifying the core library code.

## How Has This Been Tested?
- **Inheritance Test:** Created child classes for `McpPrompt`, `McpResource`, and `McpResourceTemplate` in a local project to verify they can be instantiated and used.
- **SDK Compatibility:** Integrated these extended classes into a `CustomDiscoverer` implementation.
- **Unit Tests:** Ran existing test suites to ensure that removing the keyword does not introduce regressions in the base functionality.

## Breaking Changes
**None.** This is a non-breaking change. Existing code using these classes will continue to work exactly as before. It simply unlocks new possibilities for developers wishing to extend them.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
While `final` is often used to prevent fragile base class problems, these

Fix https://github.com/modelcontextprotocol/php-sdk/issues/239