### PR TITLE
Fix Invalid data in Session

### DIFF
--- a/src/Server/Session/Session.php
+++ b/src/Server/Session/Session.php
@@ -171,6 +171,12 @@ class Session implements SessionInterface
             return $this->data = [];
         }
 
-        return $this->data = json_decode($rawData, true, flags: \JSON_THROW_ON_ERROR);
+        $decoded = json_decode($rawData, true, flags: \JSON_THROW_ON_ERROR);
+
+        if (!\is_array($decoded)) {
+            return $this->data = [];
+        }
+
+        return $this->data = $decoded;
     }
 }

--- a/tests/Unit/Server/Session/SessionTest.php
+++ b/tests/Unit/Server/Session/SessionTest.php
@@ -33,4 +33,18 @@ class SessionTest extends TestCase
         $result = $session->all();
         $this->assertEquals(['foo' => 'bar'], $result);
     }
+
+    public function testAllReturnsEmptyArrayForNullPayload()
+    {
+        $store = $this->getMockBuilder(InMemorySessionStore::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['read'])
+            ->getMock();
+        $store->expects($this->once())->method('read')->willReturn('null');
+
+        $session = new Session($store);
+        $result = $session->all();
+
+        $this->assertSame([], $result);
+    }
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
During the testsing of my application I got an error

/vendor/mcp/sdk/src/Server/Session/Session.php in Mcp\Server\Session\Session::readData at line 174
/vendor/mcp/sdk/src/Server/Session/Session.php in Mcp\Server\Session\Session::set at line 75
/vendor/mcp/sdk/src/Server/Protocol.php in Mcp\Server\Protocol::handleRequest at line 163
/vendor/mcp/sdk/src/Server/Protocol.php in Mcp\Server\Protocol::processInput at line 130
/vendor/mcp/sdk/src/Server/Transport/BaseTransport.php in Mcp\Server\Transport\BaseTransport::handleMessage at line 133



## How Has This Been Tested?
OAuth implementation

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
