### PR TITLE
Feat: Improve resource template messages

### DIFF
--- a/src/Schema/ResourceTemplate.php
+++ b/src/Schema/ResourceTemplate.php
@@ -59,10 +59,10 @@ class ResourceTemplate implements \JsonSerializable
         public readonly ?array $meta = null,
     ) {
         if (!preg_match(self::RESOURCE_NAME_PATTERN, $name)) {
-            throw new InvalidArgumentException('Invalid resource name: must contain only alphanumeric characters, underscores, and hyphens.');
+            throw new InvalidArgumentException(\sprintf('Invalid resource name "%s": must contain only alphanumeric characters, underscores, and hyphens.', $name));
         }
         if (!preg_match(self::URI_TEMPLATE_PATTERN, $uriTemplate)) {
-            throw new InvalidArgumentException('Invalid URI template: must be a valid URI template with at least one placeholder.');
+            throw new InvalidArgumentException(\sprintf('Invalid URI template : "%s" must be a valid URI template with at least one placeholder.', $uriTemplate));
         }
     }
 

--- a/tests/Unit/Schema/ResourceTemplateTest.php
+++ b/tests/Unit/Schema/ResourceTemplateTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\ResourceTemplate;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ResourceTemplateTest extends TestCase
+{
+    private const VALID_URI = 'https://example.com/list-books/{id}';
+
+    public function testConstructorValid(): void
+    {
+        $uri = self::VALID_URI;
+
+        $resource = new ResourceTemplate(
+            uriTemplate: $uri,
+            name: 'list-books',
+        );
+
+        $this->assertInstanceOf(ResourceTemplate::class, $resource);
+        $this->assertSame($uri, $resource->uriTemplate);
+    }
+
+    public function testConstructorInvalid(): void
+    {
+        $uri = '/list-books';
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid URI template : "/list-books" must be a valid URI template with at least one placeholder.');
+
+        $resource = new ResourceTemplate(
+            uriTemplate: $uri,
+            name: 'list-books',
+        );
+    }
+
+    public function testFromArrayValid(): void
+    {
+        $resource = ResourceTemplate::fromArray([
+            'uriTemplate' => self::VALID_URI,
+            'name' => 'list-books',
+        ]);
+
+        $this->assertInstanceOf(ResourceTemplate::class, $resource);
+        $this->assertSame(self::VALID_URI, $resource->uriTemplate);
+        $this->assertSame('list-books', $resource->name);
+        $this->assertNull($resource->description);
+        $this->assertNull($resource->meta);
+    }
+
+    #[DataProvider('provideInvalidResources')]
+    public function testFromArrayInvalid(array $input, string $expectedExceptionMessage): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        ResourceTemplate::fromArray($input);
+    }
+
+    public static function provideInvalidResources(): iterable
+    {
+        yield 'missing uri' => [[], 'Invalid or missing "uriTemplate" in ResourceTemplate data.'];
+        yield 'missing name' => [
+            ['uriTemplate' => self::VALID_URI],
+            'Invalid or missing "name" in ResourceTemplate data.',
+        ];
+        yield 'meta' => [
+            [
+                'uriTemplate' => self::VALID_URI,
+                'name' => 'list-books',
+                '_meta' => 'foo',
+            ],
+            'Invalid "_meta" in ResourceTemplate data.',
+        ];
+    }
+}


### PR DESCRIPTION
Improve `resourceTemplate` messages similar to the `Resource` message 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Fixes https://github.com/modelcontextprotocol/php-sdk/issues/244

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
