### PR TITLE
chore(http): create constant for session id header

### DIFF
--- a/tests/Unit/Server/Transport/StreamableHttpTransportTest.php
+++ b/tests/Unit/Server/Transport/StreamableHttpTransportTest.php
@@ -80,7 +80,7 @@ final class StreamableHttpTransportTest extends TestCase
         $this->assertSame('*', $response->getHeaderLine('Access-Control-Allow-Origin'));
         $this->assertSame('GET, POST, DELETE, OPTIONS', $response->getHeaderLine('Access-Control-Allow-Methods'));
         $this->assertSame(
-            'Content-Type, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID, Authorization, Accept',
+            'Accept,Authorization,Content-Type,Last-Event-ID,Mcp-Protocol-Version,Mcp-Session-Id',
             $response->getHeaderLine('Access-Control-Allow-Headers')
         );
         $this->assertSame('Mcp-Session-Id', $response->getHeaderLine('Access-Control-Expose-Headers'));
@@ -120,7 +120,7 @@ final class StreamableHttpTransportTest extends TestCase
         $this->assertSame('https://another.com', $response->getHeaderLine('Access-Control-Allow-Origin'));
         $this->assertSame('GET, POST, DELETE, OPTIONS', $response->getHeaderLine('Access-Control-Allow-Methods'));
         $this->assertSame(
-            'Content-Type, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID, Authorization, Accept',
+            'Accept,Authorization,Content-Type,Last-Event-ID,Mcp-Protocol-Version,Mcp-Session-Id',
             $response->getHeaderLine('Access-Control-Allow-Headers')
         );
         $this->assertSame('Mcp-Session-Id', $response->getHeaderLine('Access-Control-Expose-Headers'));


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

The `Mcp-Session-Id` value is re-written a few times in the codebase. It should be stored in a constant to avoid duplication.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Tests are passing.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No behavioral or API change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactor

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->