### PR TITLE
Add dependabot configuration for composer and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
As part of SDK tiering, we introduce a dependabot config for composer and github actions.
However, the `composer.lock` is not part of the repository - not a common practice with PHP libraries I'd say.