### PR TITLE
fix(session): initialize data lazily in save() to prevent uninitialized property access

### DIFF
--- a/src/Server/Session/Session.php
+++ b/src/Server/Session/Session.php
@@ -51,7 +51,7 @@ class Session implements SessionInterface
 
     public function save(): bool
     {
-        return $this->store->write($this->id, json_encode($this->data, \JSON_THROW_ON_ERROR));
+        return $this->store->write($this->id, json_encode($this->readData(), \JSON_THROW_ON_ERROR));
     }
 
     public function get(string $key, mixed $default = null): mixed

--- a/tests/Unit/Server/Session/SessionTest.php
+++ b/tests/Unit/Server/Session/SessionTest.php
@@ -34,6 +34,15 @@ class SessionTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $result);
     }
 
+    public function testSaveBeforeReadInitializesData()
+    {
+        $store = new InMemorySessionStore();
+        $session = new Session($store);
+
+        // save() before any get()/set() should not crash
+        $this->assertTrue($session->save());
+    }
+
     public function testAllReturnsEmptyArrayForNullPayload()
     {
         $store = $this->getMockBuilder(InMemorySessionStore::class)


### PR DESCRIPTION
I think the code is self-explanatory 