### PR TITLE
[Server] Fix to make Symfony Finder component optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to `mcp/sdk` will be documented in this file.
 * Add client component for building MCP clients
 * Add `Builder::setReferenceHandler()` to allow custom `ReferenceHandlerInterface` implementations (e.g. authorization decorators)
 * Add elicitation enum schema types per SEP-1330: `TitledEnumSchemaDefinition`, `MultiSelectEnumSchemaDefinition`, `TitledMultiSelectEnumSchemaDefinition`
+* [BC break] Make Symfony Finder component optional. Users would need to install `symfony/finder` now themselves
 
 0.4.0
 -----

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,10 @@
     "psr/http-server-handler": "^1.0",
     "psr/http-server-middleware": "^1.0",
     "psr/log": "^1.0 || ^2.0 || ^3.0",
-    "symfony/finder": "^5.4 || ^6.4 || ^7.3 || ^8.0",
     "symfony/uid": "^5.4 || ^6.4 || ^7.3 || ^8.0"
+  },
+  "suggest": {
+    "symfony/finder": "Required for file-based discovery."
   },
   "require-dev": {
     "ext-openssl": "*",
@@ -50,6 +52,7 @@
     "psr/simple-cache": "^2.0 || ^3.0",
     "symfony/cache": "^5.4 || ^6.4 || ^7.3 || ^8.0",
     "symfony/console": "^5.4 || ^6.4 || ^7.3 || ^8.0",
+    "symfony/finder": "^5.4 || ^6.4 || ^7.3 || ^8.0",
     "symfony/http-client": "^5.4 || ^6.4 || ^7.3 || ^8.0",
     "symfony/process": "^5.4 || ^6.4 || ^7.3 || ^8.0"
   },

--- a/src/Capability/Discovery/Discoverer.php
+++ b/src/Capability/Discovery/Discoverer.php
@@ -24,6 +24,7 @@ use Mcp\Capability\Registry\ResourceReference;
 use Mcp\Capability\Registry\ResourceTemplateReference;
 use Mcp\Capability\Registry\ToolReference;
 use Mcp\Exception\ExceptionInterface;
+use Mcp\Exception\RuntimeException;
 use Mcp\Schema\Prompt;
 use Mcp\Schema\PromptArgument;
 use Mcp\Schema\Resource;
@@ -53,6 +54,10 @@ final class Discoverer implements DiscovererInterface
         private ?DocBlockParser $docBlockParser = null,
         private ?SchemaGeneratorInterface $schemaGenerator = null,
     ) {
+        if (!class_exists(Finder::class)) {
+            throw new RuntimeException('File-based discovery requires symfony/finder. Run: composer require symfony/finder');
+        }
+
         $this->docBlockParser = $docBlockParser ?? new DocBlockParser(logger: $this->logger);
         $this->schemaGenerator = $schemaGenerator ?? new SchemaGenerator($this->docBlockParser);
     }

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -46,6 +46,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Finder\Finder;
 
 /**
  * @phpstan-import-type Handler from ElementReference
@@ -523,8 +524,12 @@ final class Builder
         );
 
         if (null !== $this->discoveryBasePath) {
-            $discoverer = $this->discoverer ?? $this->createDiscoverer($logger);
-            $loaders[] = new DiscoveryLoader($this->discoveryBasePath, $this->discoveryScanDirs, $this->discoveryExcludeDirs, $discoverer);
+            if (null !== $this->discoverer || class_exists(Finder::class)) {
+                $discoverer = $this->discoverer ?? $this->createDiscoverer($logger);
+                $loaders[] = new DiscoveryLoader($this->discoveryBasePath, $this->discoveryScanDirs, $this->discoveryExcludeDirs, $discoverer);
+            } else {
+                $logger->warning('File-based discovery requires symfony/finder. Skipping automatic discovery. Run: composer require symfony/finder');
+            }
         }
 
         foreach ($loaders as $loader) {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
## Motivation and Context
The changes make the Symfony Finder component optional, as referenced in issue #263

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Not a breaking change

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
