### PR TITLE
fix(session): initialize $data property with default empty array

### DIFF
--- a/src/Server/Session/Session.php
+++ b/src/Server/Session/Session.php
@@ -31,7 +31,9 @@ class Session implements SessionInterface
      *
      * @var array<string, mixed>
      */
-    private array $data;
+    private array $data = [];
+
+    private bool $loaded = false;
 
     public function __construct(
         private SessionStoreInterface $store,
@@ -126,6 +128,7 @@ class Session implements SessionInterface
     public function clear(): void
     {
         $this->data = [];
+        $this->loaded = true;
     }
 
     public function pull(string $key, mixed $default = null): mixed
@@ -144,6 +147,7 @@ class Session implements SessionInterface
     public function hydrate(array $attributes): void
     {
         $this->data = $attributes;
+        $this->loaded = true;
     }
 
     /** @return array<string, mixed> */
@@ -157,20 +161,22 @@ class Session implements SessionInterface
      */
     private function readData(): array
     {
-        if (isset($this->data)) {
+        if ($this->loaded) {
             return $this->data;
         }
+
+        $this->loaded = true;
 
         $rawData = $this->store->read($this->id);
 
         if (false === $rawData) {
-            return $this->data = [];
+            return $this->data;
         }
 
         $decoded = json_decode($rawData, true, flags: \JSON_THROW_ON_ERROR);
 
         if (!\is_array($decoded)) {
-            return $this->data = [];
+            return $this->data;
         }
 
         return $this->data = $decoded;

--- a/tests/Unit/Server/Session/SessionTest.php
+++ b/tests/Unit/Server/Session/SessionTest.php
@@ -296,6 +296,7 @@ class SessionTest extends TestCase
 
         // save() before any get()/set() should not crash
         $this->assertTrue($session->save());
+        $this->assertSame([], $session->all());
     }
 
     public function testAllReturnsEmptyArrayForNullPayload()


### PR DESCRIPTION
## Summary

- Initialize `Session::$data` with `= []` to prevent `TypeError` when the property is accessed before initialization on a newly created session
- Replace `isset($this->data)` check in `readData()` with an explicit `$loaded` flag to preserve lazy loading from the session store
- Set `$loaded = true` in `clear()` and `hydrate()` to maintain consistent state

Fixes #273

## Test plan

- [x] All 28 existing `SessionTest` tests pass
- [x] PHPStan level 6 with no errors
- [x] PHP-CS-Fixer with no violations
- [x] `testSaveBeforeReadInitializesData` confirms `save()` on a fresh session works
- [x] `testSessionLoadsDataFromStoreOnConstruction` confirms lazy loading still works