### PR TITLE
[Schema] Fix PHPDoc type of `GetPromptRequest::$arguments`

### DIFF
--- a/src/Schema/Request/GetPromptRequest.php
+++ b/src/Schema/Request/GetPromptRequest.php
@@ -22,8 +22,8 @@ use Mcp\Schema\JsonRpc\Request;
 final class GetPromptRequest extends Request
 {
     /**
-     * @param string                    $name      the name of the prompt to get
-     * @param array<string, mixed>|null $arguments the arguments to pass to the prompt
+     * @param string                     $name      the name of the prompt to get
+     * @param array<string, string>|null $arguments the arguments to pass to the prompt
      */
     public function __construct(
         public readonly string $name,
@@ -56,7 +56,7 @@ final class GetPromptRequest extends Request
     }
 
     /**
-     * @return array{name: string, arguments?: array<string, mixed>}
+     * @return array{name: string, arguments?: array<string, string>}
      */
     protected function getParams(): array
     {


### PR DESCRIPTION
Fix PHPDoc type of `GetPromptRequest::$arguments` from `array<string, mixed>` to `array<string, string>`

## Motivation and Context

The MCP specification defines prompt arguments as a map of string keys to string values. The PHPDoc annotation for `GetPromptRequest::$arguments` incorrectly used `array<string, mixed>`, which was overly permissive and inconsistent with the spec. This fix aligns the type hint with the actual contract.

## How Has This Been Tested?

The change is documentation-only (PHPDoc annotation) and does not affect runtime behavior. Existing tests continue to pass.

## Breaking Changes

None. This is a PHPDoc-only change with no impact on runtime behavior or public API signatures.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Affected annotations:
- `@param array<string, string>|null $arguments` in the constructor
- `@return array{name: string, arguments?: array<string, string>}` in `getParams()`
