### PR TITLE
[Server] force the proper Content-type for the 202 response in createJsonResponse()

### DIFF
--- a/src/Server/Transport/StreamableHttpTransport.php
+++ b/src/Server/Transport/StreamableHttpTransport.php
@@ -144,7 +144,8 @@ class StreamableHttpTransport extends BaseTransport
         $outgoingMessages = $this->getOutgoingMessages($this->sessionId);
 
         if (empty($outgoingMessages)) {
-            return $this->responseFactory->createResponse(202);
+            return $this->responseFactory->createResponse(202)
+                ->withHeader('Content-Type', 'application/json');
         }
 
         $messages = array_column($outgoingMessages, 'message');


### PR DESCRIPTION
I specifically added the `application/json` conetent-type header to the `202` response sent back by `createJsonResponse()` in `StreamableHttpTransport.php`.

## Motivation and Context
The `Accepted` response in `createJsonResponse()` is returned when there are no outgoing messages to send. Normally this is content-length 0, and so most clients do not care what Content-Type the body has. It appears to default to `text/event-stream`.

I was integrating a MCP server into AWS Bedrock AgentCore, and I discovered that if this response uses `text/event-stream` instead of `application/json`, AgentCore does not recognize the end of the transaction and waits for a response until timeout. This made it impossible to use my mcp server with AgentCore without this change.

## How Has This Been Tested?
I have tested this in:
* modelcontextprotocol/inspector
* Postman's MCP Client
* an AWS Bedrock AgentCore Gateway
* codex-cli

## Breaking Changes
No breaking changes

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
