### PR TITLE
[Schema] fix: allow URIs without double slash in Resource and ResourceTemplate (RFC 3986)

### DIFF
--- a/src/Schema/Resource.php
+++ b/src/Schema/Resource.php
@@ -40,10 +40,10 @@ class Resource implements \JsonSerializable
     private const RESOURCE_NAME_PATTERN = '/^[a-zA-Z0-9_-]+$/';
 
     /**
-     * URI pattern regex - requires a valid scheme, followed by colon and optional path.
-     * Example patterns: config://, file://path, db://table, etc.
+     * URI pattern regex - requires a valid scheme followed by colon and optional path (RFC 3986).
+     * Example patterns: file://path, db://table, urn:isbn:123, config:key, etc.
      */
-    private const URI_PATTERN = '/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s]*$/';
+    private const URI_PATTERN = '/^[a-zA-Z][a-zA-Z0-9+.-]*:[^\s]*$/';
 
     /**
      * @param string                $uri         the URI of this resource

--- a/src/Schema/ResourceTemplate.php
+++ b/src/Schema/ResourceTemplate.php
@@ -37,10 +37,10 @@ class ResourceTemplate implements \JsonSerializable
     private const RESOURCE_NAME_PATTERN = '/^[a-zA-Z0-9_-]+$/';
 
     /**
-     * URI Template pattern regex - requires a valid scheme, followed by colon and path with at least one placeholder.
-     * Example patterns: config://{key}, file://{path}/contents.txt, db://{table}/{id}, etc.
+     * URI Template pattern regex - requires a valid scheme followed by colon and path with at least one placeholder (RFC 3986).
+     * Example patterns: file://{path}/contents.txt, db://{table}/{id}, config:{key}, etc.
      */
-    private const URI_TEMPLATE_PATTERN = '/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/.*{[^{}]+}.*/';
+    private const URI_TEMPLATE_PATTERN = '/^[a-zA-Z][a-zA-Z0-9+.-]*:.*{[^{}]+}.*/';
 
     /**
      * @param string                $uriTemplate a URI template (according to RFC 6570) that can be used to construct resource URIs

--- a/tests/Unit/Schema/ResourceTemplateTest.php
+++ b/tests/Unit/Schema/ResourceTemplateTest.php
@@ -46,6 +46,25 @@ class ResourceTemplateTest extends TestCase
         );
     }
 
+    #[DataProvider('provideValidTemplatesWithoutDoubleSlash')]
+    public function testConstructorAcceptsTemplatesWithoutDoubleSlash(string $uriTemplate): void
+    {
+        $resource = new ResourceTemplate(
+            uriTemplate: $uriTemplate,
+            name: 'test-template',
+        );
+
+        $this->assertInstanceOf(ResourceTemplate::class, $resource);
+        $this->assertSame($uriTemplate, $resource->uriTemplate);
+    }
+
+    public static function provideValidTemplatesWithoutDoubleSlash(): iterable
+    {
+        yield 'custom scheme without slashes' => ['config:{key}'];
+        yield 'custom scheme with slashes' => ['config://{key}'];
+        yield 'urn-style template' => ['urn:resource:{id}'];
+    }
+
     public function testFromArrayValid(): void
     {
         $resource = ResourceTemplate::fromArray([

--- a/tests/Unit/Schema/ResourceTemplateTest.php
+++ b/tests/Unit/Schema/ResourceTemplateTest.php
@@ -46,8 +46,8 @@ class ResourceTemplateTest extends TestCase
         );
     }
 
-    #[DataProvider('provideValidTemplatesWithoutDoubleSlash')]
-    public function testConstructorAcceptsTemplatesWithoutDoubleSlash(string $uriTemplate): void
+    #[DataProvider('provideValidTemplates')]
+    public function testConstructorAcceptsTemplates(string $uriTemplate): void
     {
         $resource = new ResourceTemplate(
             uriTemplate: $uriTemplate,
@@ -58,7 +58,7 @@ class ResourceTemplateTest extends TestCase
         $this->assertSame($uriTemplate, $resource->uriTemplate);
     }
 
-    public static function provideValidTemplatesWithoutDoubleSlash(): iterable
+    public static function provideValidTemplates(): iterable
     {
         yield 'custom scheme without slashes' => ['config:{key}'];
         yield 'custom scheme with slashes' => ['config://{key}'];

--- a/tests/Unit/Schema/ResourceTest.php
+++ b/tests/Unit/Schema/ResourceTest.php
@@ -46,6 +46,27 @@ class ResourceTest extends TestCase
         );
     }
 
+    #[DataProvider('provideValidUrisWithoutDoubleSlash')]
+    public function testConstructorAcceptsUrisWithoutDoubleSlash(string $uri): void
+    {
+        $resource = new Resource(
+            uri: $uri,
+            name: 'test-resource',
+        );
+
+        $this->assertInstanceOf(Resource::class, $resource);
+        $this->assertSame($uri, $resource->uri);
+    }
+
+    public static function provideValidUrisWithoutDoubleSlash(): iterable
+    {
+        yield 'urn' => ['urn:isbn:0451450523'];
+        yield 'mailto' => ['mailto:user@example.com'];
+        yield 'data' => ['data:text/plain;base64,SGVsbG8='];
+        yield 'custom scheme without slashes' => ['config:myapp/settings'];
+        yield 'custom scheme with slashes' => ['config://myapp/settings'];
+    }
+
     public function testFromArrayValid(): void
     {
         $resource = Resource::fromArray([

--- a/tests/Unit/Schema/ResourceTest.php
+++ b/tests/Unit/Schema/ResourceTest.php
@@ -46,8 +46,8 @@ class ResourceTest extends TestCase
         );
     }
 
-    #[DataProvider('provideValidUrisWithoutDoubleSlash')]
-    public function testConstructorAcceptsUrisWithoutDoubleSlash(string $uri): void
+    #[DataProvider('provideValidUris')]
+    public function testConstructorAcceptsUris(string $uri): void
     {
         $resource = new Resource(
             uri: $uri,
@@ -58,7 +58,7 @@ class ResourceTest extends TestCase
         $this->assertSame($uri, $resource->uri);
     }
 
-    public static function provideValidUrisWithoutDoubleSlash(): iterable
+    public static function provideValidUris(): iterable
     {
         yield 'urn' => ['urn:isbn:0451450523'];
         yield 'mailto' => ['mailto:user@example.com'];


### PR DESCRIPTION
## Summary

The URI regex in `Resource` and `ResourceTemplate` requires `://` after the scheme, rejecting valid URIs where the hier-part does not start with `//`. Per [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3), the authority component (and its `//` prefix) is optional.

## What breaks

```php
// All of these throw InvalidArgumentException:
new Resource(uri: 'urn:isbn:0451450523', name: 'book');
new Resource(uri: 'mailto:user@example.com', name: 'contact');
new Resource(uri: 'data:text/plain;base64,SGVsbG8=', name: 'data');
new Resource(uri: 'config:myapp/settings', name: 'settings');

new ResourceTemplate(uriTemplate: 'config:{key}', name: 'config');
```

The [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25/server/resources) allows custom URI schemes following RFC 3986.

## Fix

Changed `://` to `:` in both regex patterns:

```diff
- '/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s]*$/'
+ '/^[a-zA-Z][a-zA-Z0-9+.-]*:[^\s]*$/'

- '/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/.*{[^{}]+}.*/'
+ '/^[a-zA-Z][a-zA-Z0-9+.-]*:.*{[^{}]+}.*/'
```

URIs with `://` (like `file://path`) continue to match.

## Test plan

- [x] Added data-provider tests for `urn:`, `mailto:`, `data:`, and custom schemes without `//`
- [x] Added data-provider tests for resource templates without `//`
- [x] All 20 tests pass (`phpunit tests/Unit/Schema/`)
- [x] Existing tests unchanged

Fixes #293