### PR TITLE
[Conformance] Target 2025-11-25 spec in conformance fixtures

### DIFF
--- a/tests/Conformance/client.php
+++ b/tests/Conformance/client.php
@@ -16,6 +16,7 @@ use Mcp\Client\Handler\Request\RequestHandlerInterface;
 use Mcp\Client\Transport\HttpTransport;
 use Mcp\Schema\ClientCapabilities;
 use Mcp\Schema\Enum\ElicitAction;
+use Mcp\Schema\Enum\ProtocolVersion;
 use Mcp\Schema\JsonRpc\Request;
 use Mcp\Schema\JsonRpc\Response;
 use Mcp\Schema\Request\ElicitRequest;
@@ -36,6 +37,7 @@ $logger->info(sprintf('Starting client conformance test: scenario=%s, url=%s', $
 
 $builder = Client::builder()
     ->setClientInfo('mcp-conformance-test-client', '1.0.0')
+    ->setProtocolVersion(ProtocolVersion::V2025_11_25)
     ->setInitTimeout(30)
     ->setRequestTimeout(60)
     ->setLogger($logger);

--- a/tests/Conformance/server.php
+++ b/tests/Conformance/server.php
@@ -19,6 +19,7 @@ use Mcp\Schema\Content\AudioContent;
 use Mcp\Schema\Content\EmbeddedResource;
 use Mcp\Schema\Content\ImageContent;
 use Mcp\Schema\Content\TextContent;
+use Mcp\Schema\Enum\ProtocolVersion;
 use Mcp\Schema\Result\CallToolResult;
 use Mcp\Server;
 use Mcp\Server\Session\FileSessionStore;
@@ -37,6 +38,7 @@ $transport = new StreamableHttpTransport($request, logger: $logger);
 
 $server = Server::builder()
     ->setServerInfo('mcp-conformance-test-server', '1.0.0')
+    ->setProtocolVersion(ProtocolVersion::V2025_11_25)
     ->setSession(new FileSessionStore(__DIR__.'/sessions'))
     ->setLogger($logger)
     // Tools
@@ -52,6 +54,29 @@ $server = Server::builder()
     ->addTool([Elements::class, 'toolWithElicitation'], name: 'test_elicitation', description: 'Tests server-initiated elicitation')
     ->addTool([Elements::class, 'toolWithElicitationDefaults'], name: 'test_elicitation_sep1034_defaults', description: 'Tests elicitation with default values')
     ->addTool([Elements::class, 'toolWithElicitationEnums'], name: 'test_elicitation_sep1330_enums', description: 'Tests elicitation with enum schemas')
+    ->addTool(
+        static fn () => 'ok',
+        name: 'json_schema_2020_12_tool',
+        description: 'Tool with JSON Schema 2020-12 features',
+        inputSchema: [
+            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+            'type' => 'object',
+            '$defs' => [
+                'address' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'street' => ['type' => 'string'],
+                        'city' => ['type' => 'string'],
+                    ],
+                ],
+            ],
+            'properties' => [
+                'name' => ['type' => 'string'],
+                'address' => ['$ref' => '#/$defs/address'],
+            ],
+            'additionalProperties' => false,
+        ],
+    )
     // Resources
     ->addResource(static fn () => 'This is the content of the static text resource.', 'test://static-text', 'static-text', 'A static text resource for testing')
     ->addResource(static fn () => fopen('data://image/png;base64,'.Elements::TEST_IMAGE_BASE64, 'r'), 'test://static-binary', 'static-binary', 'A static binary resource (image) for testing')


### PR DESCRIPTION
The conformance test runner (`@modelcontextprotocol/conformance@0.1.16`) covers the `2025-11-25` spec — adding 6 scenarios on top of `2025-06-18`, of which `json-schema-2020-12` (SEP-1613) requires the fixture to expose a tool whose `inputSchema` exercises `$schema` / `$defs` / `$ref` / `additionalProperties`.

## Changes

- `tests/Conformance/server.php` and `tests/Conformance/client.php` now negotiate `ProtocolVersion::V2025_11_25` via `setProtocolVersion()`.
- The server fixture registers `json_schema_2020_12_tool` with the schema expected by SEP-1613.

The SDK already supports `ProtocolVersion::V2025_11_25` in the enum; this only changes what the conformance fixtures advertise. The SDK's `MessageInterface::PROTOCOL_VERSION` default is unchanged (still `V2025_06_18`).

## Results

Run with \`--spec-version 2025-11-25 --suite all\`:

- **Server**: 42 passed, 1 failed (\`dns-rebinding-protection\`, already in \`conformance-baseline.yml\`)
- **Client**: 2 passed, 42 failed — all in baseline, \`Baseline check passed: all failures are expected.\`

## Test plan

- [x] \`make conformance-server\` against \`--spec-version 2025-11-25 --suite all\`
- [x] \`make conformance-client\` against \`--spec-version 2025-11-25 --suite all\` with baseline
- [x] \`json_schema_2020_12_tool\` registered with \`\$schema\`, \`\$defs\`, \`\$ref\`, \`additionalProperties\` preserved through \`tools/list\` serialization (verified 4/4 conformance sub-checks)