### PR TITLE
ci: replace sleep with compose --wait + nginx healthcheck

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -91,8 +91,7 @@ jobs:
         run: |
           mkdir -p tests/Conformance/sessions tests/Conformance/logs
           chmod -R 777 tests/Conformance/sessions tests/Conformance/logs
-          docker compose -f tests/Conformance/Fixtures/docker-compose.yml up -d
-          sleep 5
+          docker compose -f tests/Conformance/Fixtures/docker-compose.yml up -d --wait
 
       - name: Run conformance tests
         working-directory: ./tests/Conformance

--- a/tests/Conformance/Fixtures/docker-compose.yml
+++ b/tests/Conformance/Fixtures/docker-compose.yml
@@ -10,6 +10,12 @@ services:
       - php-fpm
     networks:
       - mcp-net
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost/"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+      start_period: 2s
 
   php-fpm:
     image: php:8.4-fpm-alpine

--- a/tests/Conformance/Fixtures/docker-compose.yml
+++ b/tests/Conformance/Fixtures/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     networks:
       - mcp-net
     healthcheck:
-      test: ["CMD", "wget", "-q", "-O-", "http://localhost/"]
+      test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1/healthz"]
       interval: 2s
       timeout: 2s
       retries: 10

--- a/tests/Conformance/Fixtures/nginx.conf
+++ b/tests/Conformance/Fixtures/nginx.conf
@@ -3,6 +3,11 @@ server {
     server_name localhost;
     root /app;
 
+    location = /healthz {
+        access_log off;
+        return 200 "ok\n";
+    }
+
     location / {
         try_files $uri /tests/Conformance/server.php$is_args$args;
     }


### PR DESCRIPTION
## Summary
- Replace the blind `sleep 5` after `docker compose up -d` in the conformance job with `--wait`, so CI proceeds as soon as services are actually ready.
- Add an HTTP healthcheck on the nginx service (via `wget`) so `--wait` blocks on real readiness rather than just the `running` state.

## Test plan
- [ ] Conformance / server job passes on this PR