### PR TITLE
Add title parameter to Builder::addResource() and addResourceTemplate()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to `mcp/sdk` will be documented in this file.
 * [BC Break] `RegistryInterface::registerTool()`, `registerResource()`, `registerResourceTemplate()`, `registerPrompt()` lost their trailing `bool $isManual = false` parameter. Callers using positional arguments must drop the flag.
 * [BC Break] Removed `RegistryInterface::clear()`, `getDiscoveryState()`, `setDiscoveryState()`. Rediscovery now goes through `DiscoveryLoader::load()` directly.
 * `Registry::register*()` semantics changed to plain last-write-wins (overwrites silently) and the methods now return the stored `*Reference`. The previous "discovered registration is ignored when a manual one already exists" precedence rule still applies, but is now enforced by `DiscoveryLoader` via reference-identity tracking — and still emits a debug log when a discovery is skipped due to a conflicting registration.
+* Add optional `title` parameter to `Builder::addResource()` and `Builder::addResourceTemplate()` for MCP spec compliance
+* [BC Break] `Builder::addResource()` signature changed — `$title` parameter added between `$name` and `$description`. Callers using positional arguments must switch to named arguments.
+* [BC Break] `Builder::addResourceTemplate()` signature changed — `$title` parameter added between `$name` and `$description`. Callers using positional arguments must switch to named arguments.
 
 0.5.0
 -----

--- a/src/Capability/Registry/Loader/ArrayLoader.php
+++ b/src/Capability/Registry/Loader/ArrayLoader.php
@@ -56,6 +56,7 @@ final class ArrayLoader implements LoaderInterface
      *     handler: Handler,
      *     uri: string,
      *     name: ?string,
+     *     title: ?string,
      *     description: ?string,
      *     mimeType: ?string,
      *     size: int|null,
@@ -67,6 +68,7 @@ final class ArrayLoader implements LoaderInterface
      *     handler: Handler,
      *     uriTemplate: string,
      *     name: ?string,
+     *     title: ?string,
      *     description: ?string,
      *     mimeType: ?string,
      *     annotations: ?Annotations,
@@ -157,6 +159,7 @@ final class ArrayLoader implements LoaderInterface
                 $resource = new Resource(
                     uri: $data['uri'],
                     name: $name,
+                    title: $data['title'] ?? null,
                     description: $description,
                     mimeType: $data['mimeType'] ?? null,
                     annotations: $data['annotations'] ?? null,
@@ -197,6 +200,7 @@ final class ArrayLoader implements LoaderInterface
                 $template = new ResourceTemplate(
                     uriTemplate: $data['uriTemplate'],
                     name: $name,
+                    title: $data['title'] ?? null,
                     description: $description,
                     mimeType: $data['mimeType'] ?? null,
                     annotations: $data['annotations'] ?? null,

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -119,6 +119,7 @@ final class Builder
      *     handler: Handler,
      *     uri: string,
      *     name: ?string,
+     *     title: ?string,
      *     description: ?string,
      *     mimeType: ?string,
      *     size: int|null,
@@ -134,6 +135,7 @@ final class Builder
      *     handler: Handler,
      *     uriTemplate: string,
      *     name: ?string,
+     *     title: ?string,
      *     description: ?string,
      *     mimeType: ?string,
      *     annotations: ?Annotations,
@@ -433,6 +435,7 @@ final class Builder
      * Manually registers a resource handler.
      *
      * @param Handler                   $handler
+     * @param ?string                   $title   Optional human-readable title for display in UI
      * @param ?Icon[]                   $icons
      * @param array<string, mixed>|null $meta
      */
@@ -440,6 +443,7 @@ final class Builder
         \Closure|array|string $handler,
         string $uri,
         ?string $name = null,
+        ?string $title = null,
         ?string $description = null,
         ?string $mimeType = null,
         ?int $size = null,
@@ -451,6 +455,7 @@ final class Builder
             'handler',
             'uri',
             'name',
+            'title',
             'description',
             'mimeType',
             'size',
@@ -466,12 +471,14 @@ final class Builder
      * Manually registers a resource template handler.
      *
      * @param Handler                   $handler
+     * @param ?string                   $title   Optional human-readable title for display in UI
      * @param array<string, mixed>|null $meta
      */
     public function addResourceTemplate(
         \Closure|array|string $handler,
         string $uriTemplate,
         ?string $name = null,
+        ?string $title = null,
         ?string $description = null,
         ?string $mimeType = null,
         ?Annotations $annotations = null,
@@ -481,6 +488,7 @@ final class Builder
             'handler',
             'uriTemplate',
             'name',
+            'title',
             'description',
             'mimeType',
             'annotations',

--- a/tests/Unit/Capability/Registry/Loader/ArrayLoaderResourceTitleTest.php
+++ b/tests/Unit/Capability/Registry/Loader/ArrayLoaderResourceTitleTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Capability\Registry\Loader;
+
+use Mcp\Capability\Registry;
+use Mcp\Capability\Registry\Loader\ArrayLoader;
+use PHPUnit\Framework\TestCase;
+
+class ArrayLoaderResourceTitleTest extends TestCase
+{
+    public function testLoadPropagatesResourceTitleToRegisteredResource(): void
+    {
+        $resources = [
+            [
+                'handler' => static fn (): string => 'ok',
+                'uri' => 'config://app/settings',
+                'name' => 'app_settings',
+                'title' => 'Application Settings',
+                'description' => null,
+                'mimeType' => null,
+                'size' => null,
+                'annotations' => null,
+                'icons' => null,
+                'meta' => null,
+            ],
+        ];
+
+        $loader = new ArrayLoader([], $resources);
+        $registry = new Registry();
+
+        $loader->load($registry);
+
+        $resourceRef = $registry->getResource('config://app/settings');
+        $this->assertSame('Application Settings', $resourceRef->resource->title);
+    }
+
+    public function testLoadPropagatesResourceTemplateTitleToRegisteredTemplate(): void
+    {
+        $resourceTemplates = [
+            [
+                'handler' => static fn (): string => 'ok',
+                'uriTemplate' => 'user://{userId}/profile',
+                'name' => 'user_profile',
+                'title' => 'User Profile',
+                'description' => null,
+                'mimeType' => null,
+                'annotations' => null,
+                'meta' => null,
+            ],
+        ];
+
+        $loader = new ArrayLoader([], [], $resourceTemplates);
+        $registry = new Registry();
+
+        $loader->load($registry);
+
+        $templateRef = $registry->getResourceTemplate('user://{userId}/profile');
+        $this->assertSame('User Profile', $templateRef->resourceTemplate->title);
+    }
+}


### PR DESCRIPTION
## Summary

#301 added the `title` field to the `Resource`/`ResourceTemplate` schema classes and the `McpResource`/`McpResourceTemplate` attributes, but the manual registration methods on `Builder` were missed. As a result, manual registration could not set a resource title — inconsistent with `addTool()` and `addPrompt()`, which both gained `title` lately.

## Changes

- `Builder::addResource()` and `Builder::addResourceTemplate()` gain a `$title` parameter, placed between `$name` and `$description` to match `addTool()`/`addPrompt()`.
- `ArrayLoader` propagates `title` into the constructed `Resource`/`ResourceTemplate` objects, and its PHPStan array shapes are updated accordingly.
- CHANGELOG updated under 0.6.0.

## BC Break

Inserting `$title` between `$name` and `$description` shifts positional arguments — callers passing `$description` (and later args) positionally must switch to named arguments. This mirrors the equivalent v0.5.0 breaks for `addTool()`/`addPrompt()`.

## Tests

- New `ArrayLoaderResourceTitleTest` covering title propagation for both resources and resource templates.
- `phpstan` and `php-cs-fixer` clean. Full unit suite passes (the 2 pre-existing `DiscoveryTest` failures are unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)