### PR TITLE
[Server] Add native OAuth 2.1 authorization server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
       "Mcp\\Example\\Server\\EnvVariables\\": "examples/server/env-variables/",
       "Mcp\\Example\\Server\\ExplicitRegistration\\": "examples/server/explicit-registration/",
       "Mcp\\Example\\Server\\McpApps\\": "examples/server/mcp-apps/",
+      "Mcp\\Example\\Server\\OAuthAuthorizationServer\\": "examples/server/oauth-authorization-server/",
       "Mcp\\Example\\Server\\OAuthKeycloak\\": "examples/server/oauth-keycloak/",
       "Mcp\\Example\\Server\\OAuthMicrosoft\\": "examples/server/oauth-microsoft/",
       "Mcp\\Example\\Server\\SchemaShowcase\\": "examples/server/schema-showcase/",

--- a/examples/server/oauth-authorization-server/.gitignore
+++ b/examples/server/oauth-authorization-server/.gitignore
@@ -1,0 +1,3 @@
+keys/
+sessions/
+cache/

--- a/examples/server/oauth-authorization-server/DemoResourceOwnerResolver.php
+++ b/examples/server/oauth-authorization-server/DemoResourceOwnerResolver.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Example\Server\OAuthAuthorizationServer;
+
+use Http\Discovery\Psr17FactoryDiscovery;
+use Mcp\Server\Transport\Http\OAuth\ResourceOwner;
+use Mcp\Server\Transport\Http\OAuth\ResourceOwnerResolverInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Demo-only resource owner resolver.
+ *
+ * A real host authenticates the user against its own session/firewall. To keep
+ * this example fully scriptable, an unauthenticated request is "logged in" as a
+ * fixed demo user by setting a cookie and redirecting back to the authorize URL.
+ *
+ * DO NOT use this in production.
+ */
+final class DemoResourceOwnerResolver implements ResourceOwnerResolverInterface
+{
+    private const COOKIE = 'demo_user';
+
+    private ResponseFactoryInterface $responseFactory;
+
+    public function __construct(
+        private readonly string $demoUserId = 'demo-user',
+        ?ResponseFactoryInterface $responseFactory = null,
+    ) {
+        $this->responseFactory = $responseFactory ?? Psr17FactoryDiscovery::findResponseFactory();
+    }
+
+    public function resolve(ServerRequestInterface $request): ?ResourceOwner
+    {
+        $user = $request->getCookieParams()[self::COOKIE] ?? null;
+        if (!\is_string($user) || '' === $user) {
+            return null;
+        }
+
+        return new ResourceOwner($user, ['name' => 'Demo User']);
+    }
+
+    public function onUnauthenticated(ServerRequestInterface $request): ResponseInterface
+    {
+        // A real implementation renders/redirects to a login form. Here we
+        // auto-login the demo user and resume the authorization request.
+        return $this->responseFactory
+            ->createResponse(302)
+            ->withHeader('Location', (string) $request->getUri())
+            ->withHeader('Set-Cookie', self::COOKIE.'='.rawurlencode($this->demoUserId).'; Path=/; HttpOnly; SameSite=Lax')
+            ->withHeader('Cache-Control', 'no-store');
+    }
+}

--- a/examples/server/oauth-authorization-server/McpElements.php
+++ b/examples/server/oauth-authorization-server/McpElements.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Example\Server\OAuthAuthorizationServer;
+
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Server\RequestContext;
+
+/**
+ * A protected MCP tool. Reaching it proves the request carried a valid access
+ * token issued by this server's own authorization endpoints.
+ */
+final class McpElements
+{
+    /**
+     * @return array<string, mixed>
+     */
+    #[McpTool(
+        name: 'whoami',
+        description: 'Return the authenticated subject and scopes from the access token.'
+    )]
+    public function whoami(RequestContext $context): array
+    {
+        $meta = $context->getRequest()->getMeta() ?? [];
+        $oauth = isset($meta['oauth']) && \is_array($meta['oauth']) ? $meta['oauth'] : [];
+        $claims = isset($oauth['oauth.claims']) && \is_array($oauth['oauth.claims']) ? $oauth['oauth.claims'] : [];
+        $scopes = isset($oauth['oauth.scopes']) && \is_array($oauth['oauth.scopes']) ? $oauth['oauth.scopes'] : [];
+
+        return [
+            'authenticated' => true,
+            'subject' => $oauth['oauth.subject'] ?? ($claims['sub'] ?? null),
+            'client_id' => $oauth['oauth.client_id'] ?? ($claims['client_id'] ?? null),
+            'scopes' => $scopes,
+            'issuer' => $claims['iss'] ?? null,
+        ];
+    }
+}

--- a/examples/server/oauth-authorization-server/README.md
+++ b/examples/server/oauth-authorization-server/README.md
@@ -1,0 +1,70 @@
+# OAuth Authorization Server Example
+
+A self-contained MCP server that is **its own** OAuth 2.1 authorization server: it
+registers clients, authorizes users, issues its own RS256 JWT access tokens, and
+validates those same tokens to protect the MCP endpoint — with no external
+identity provider and no `league/oauth2-server`.
+
+It demonstrates the SDK's native authorization-server layer:
+
+- `GET  /.well-known/oauth-authorization-server` — RFC 8414 metadata (enriched with `registration_endpoint`)
+- `GET  /.well-known/oauth-protected-resource` — RFC 9728 metadata
+- `GET  /.well-known/jwks.json` — public signing key (JWK Set)
+- `POST /register` — RFC 7591 Dynamic Client Registration
+- `GET  /authorize` — authorization code grant with mandatory PKCE (S256)
+- `POST /token` — `authorization_code` and `refresh_token` grants
+- `POST /` — the protected MCP JSON-RPC endpoint (requires `Authorization: Bearer <jwt>`)
+
+> The signing key is generated into `keys/private.pem` on first run, storage is
+> in-memory, and login auto-approves a fixed demo user (`DemoResourceOwnerResolver`).
+> Replace all three for production: a managed key, the PSR-16 (or your own) stores,
+> and a real login/consent backed by your user system.
+
+## Run
+
+```bash
+php -S localhost:8000 examples/server/oauth-authorization-server/server.php
+```
+
+## Walkthrough (the Claude.ai flow)
+
+```bash
+BASE=http://localhost:8000
+
+# 1. Dynamic client registration (public client + PKCE)
+curl -s -X POST $BASE/register -H 'Content-Type: application/json' -d '{
+  "redirect_uris": ["http://localhost:9999/callback"],
+  "token_endpoint_auth_method": "none",
+  "client_name": "Demo Client"
+}'
+# => { "client_id": "...", "redirect_uris": [...], ... }
+
+# 2. Authorize (PKCE). Use a known verifier/challenge pair:
+#    verifier  = dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+#    challenge = E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+curl -s -i -c cookies.txt -b cookies.txt \
+  "$BASE/authorize?response_type=code&client_id=CLIENT_ID&redirect_uri=http://localhost:9999/callback&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&scope=mcp:tools&state=xyz"
+# => 302 Location: http://localhost:9999/callback?code=CODE&state=xyz
+
+# 3. Exchange the code for tokens
+curl -s -X POST $BASE/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d "grant_type=authorization_code&code=CODE&redirect_uri=http://localhost:9999/callback&client_id=CLIENT_ID&code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+# => { "access_token": "<jwt>", "token_type": "Bearer", "expires_in": 3600, "refresh_token": "..." }
+
+# 4. Call the protected MCP endpoint
+curl -s -X POST $BASE/ \
+  -H "Authorization: Bearer <jwt>" \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"whoami","arguments":{}}}'
+```
+
+A request without a valid token returns `401` with a `WWW-Authenticate` header
+pointing at `/.well-known/oauth-protected-resource`.
+
+## Middleware order
+
+The OAuth endpoints are composed before the bearer-protection middleware so they
+stay public; only the MCP JSON-RPC path requires a token. `ClientRegistrationMiddleware`
+sits outermost of the authorization-server metadata middleware so it can inject
+`registration_endpoint` into the served document.

--- a/examples/server/oauth-authorization-server/server.php
+++ b/examples/server/oauth-authorization-server/server.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once dirname(__DIR__).'/bootstrap.php';
+
+use Http\Discovery\Psr17Factory;
+use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
+use Mcp\Example\Server\OAuthAuthorizationServer\DemoResourceOwnerResolver;
+use Mcp\Server;
+use Mcp\Server\Session\FileSessionStore;
+use Mcp\Server\Transport\Http\Middleware\AuthorizationEndpointMiddleware;
+use Mcp\Server\Transport\Http\Middleware\AuthorizationMiddleware;
+use Mcp\Server\Transport\Http\Middleware\AuthorizationServerMetadataMiddleware;
+use Mcp\Server\Transport\Http\Middleware\ClientRegistrationMiddleware;
+use Mcp\Server\Transport\Http\Middleware\JwksMiddleware;
+use Mcp\Server\Transport\Http\Middleware\OAuthRequestMetaMiddleware;
+use Mcp\Server\Transport\Http\Middleware\ProtectedResourceMetadataMiddleware;
+use Mcp\Server\Transport\Http\Middleware\TokenEndpointMiddleware;
+use Mcp\Server\Transport\Http\OAuth\AuthorizationServerMetadata;
+use Mcp\Server\Transport\Http\OAuth\AutoApproveConsent;
+use Mcp\Server\Transport\Http\OAuth\CacheAuthorizationCodeStore;
+use Mcp\Server\Transport\Http\OAuth\CacheClientRepository;
+use Mcp\Server\Transport\Http\OAuth\CacheRefreshTokenStore;
+use Mcp\Server\Transport\Http\OAuth\JwtAccessTokenIssuer;
+use Mcp\Server\Transport\Http\OAuth\JwtTokenValidator;
+use Mcp\Server\Transport\Http\OAuth\NativeAuthorizationCodeIssuer;
+use Mcp\Server\Transport\Http\OAuth\NativeTokenGranter;
+use Mcp\Server\Transport\Http\OAuth\ProtectedResourceMetadata;
+use Mcp\Server\Transport\Http\OAuth\RsaSigningKey;
+use Mcp\Server\Transport\Http\OAuth\StaticJwksProvider;
+use Mcp\Server\Transport\Http\OAuth\StoredClientRegistrar;
+use Mcp\Server\Transport\StreamableHttpTransport;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+
+$baseUrl = getenv('MCP_BASE_URL') ?: 'http://localhost:8000';
+$scopes = ['mcp:tools', 'mcp:resources'];
+
+// --- Signing key (generated on first run; replace with a managed key in production) ---
+$keyPath = __DIR__.'/keys/private.pem';
+if (!is_file($keyPath)) {
+    @mkdir(dirname($keyPath), 0700, true);
+    $resource = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => \OPENSSL_KEYTYPE_RSA]);
+    openssl_pkey_export($resource, $pem);
+    file_put_contents($keyPath, $pem);
+}
+$signingKey = RsaSigningKey::fromFile($keyPath);
+
+// --- Storage (PSR-16 filesystem cache so state survives across requests under
+//     `php -S`; swap for your own ClientRepository/stores in production) ---
+$cache = new Psr16Cache(new FilesystemAdapter('mcp_oauth', 0, __DIR__.'/cache'));
+$clients = new CacheClientRepository($cache);
+$codes = new CacheAuthorizationCodeStore($cache);
+$refreshTokens = new CacheRefreshTokenStore($cache);
+
+// --- Authorization server engine ---
+$accessTokenIssuer = new JwtAccessTokenIssuer($signingKey, $baseUrl);
+$codeIssuer = new NativeAuthorizationCodeIssuer($codes);
+$granter = new NativeTokenGranter($clients, $codes, $refreshTokens, $accessTokenIssuer, resource: $baseUrl);
+
+// --- Resource server: validate our own self-issued tokens, no network needed ---
+$tokenValidator = new JwtTokenValidator(
+    issuer: $baseUrl,
+    audience: $baseUrl,
+    jwksProvider: new StaticJwksProvider($signingKey),
+);
+
+$authServerMetadata = new AuthorizationServerMetadata(
+    issuer: $baseUrl,
+    scopesSupported: $scopes,
+);
+
+$protectedResourceMetadata = new ProtectedResourceMetadata(
+    authorizationServers: [$baseUrl],
+    scopesSupported: $scopes,
+    resource: $baseUrl,
+    resourceName: 'OAuth Authorization Server Example',
+);
+
+$server = Server::builder()
+    ->setServerInfo('OAuth Authorization Server Example', '1.0.0')
+    ->setLogger(logger())
+    ->setSession(new FileSessionStore(__DIR__.'/sessions'))
+    ->setDiscovery(__DIR__)
+    ->build();
+
+$transport = new StreamableHttpTransport(
+    (new Psr17Factory())->createServerRequestFromGlobals(),
+    logger: logger(),
+    middleware: [
+        ...StreamableHttpTransport::defaultMiddleware(),
+        // ClientRegistration must be OUTER of the metadata middleware so it can
+        // enrich the served document with registration_endpoint.
+        new ClientRegistrationMiddleware(new StoredClientRegistrar($clients, $scopes), $baseUrl),
+        new AuthorizationServerMetadataMiddleware($authServerMetadata),
+        new JwksMiddleware($signingKey),
+        new ProtectedResourceMetadataMiddleware($protectedResourceMetadata),
+        new AuthorizationEndpointMiddleware($clients, $codeIssuer, new DemoResourceOwnerResolver(), new AutoApproveConsent(), $scopes),
+        new TokenEndpointMiddleware($granter),
+        new AuthorizationMiddleware($tokenValidator, $protectedResourceMetadata),
+        new OAuthRequestMetaMiddleware(),
+    ],
+);
+
+$response = $server->run($transport);
+
+(new SapiEmitter())->emit($response);

--- a/src/Exception/OAuthException.php
+++ b/src/Exception/OAuthException.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Exception;
+
+/**
+ * OAuth 2.0 protocol error (RFC 6749 Section 5.2 / RFC 6750).
+ *
+ * Carries the OAuth error code and the HTTP status code that the authorization
+ * server endpoints should respond with. The message is the human-readable
+ * error_description returned to the client — never include internal details.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+ */
+class OAuthException extends \RuntimeException implements ExceptionInterface
+{
+    public function __construct(
+        public readonly string $error,
+        string $errorDescription,
+        public readonly int $httpStatus = 400,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($errorDescription, 0, $previous);
+    }
+
+    public static function invalidRequest(string $description): self
+    {
+        return new self('invalid_request', $description, 400);
+    }
+
+    public static function invalidClient(string $description): self
+    {
+        return new self('invalid_client', $description, 401);
+    }
+
+    public static function invalidGrant(string $description): self
+    {
+        return new self('invalid_grant', $description, 400);
+    }
+
+    public static function unauthorizedClient(string $description): self
+    {
+        return new self('unauthorized_client', $description, 400);
+    }
+
+    public static function unsupportedGrantType(string $description): self
+    {
+        return new self('unsupported_grant_type', $description, 400);
+    }
+
+    public static function invalidScope(string $description): self
+    {
+        return new self('invalid_scope', $description, 400);
+    }
+
+    public static function serverError(string $description): self
+    {
+        return new self('server_error', $description, 500);
+    }
+
+    /**
+     * @return array{error: string, error_description: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'error' => $this->error,
+            'error_description' => $this->getMessage(),
+        ];
+    }
+}

--- a/src/Server/Transport/Http/Middleware/AuthorizationEndpointMiddleware.php
+++ b/src/Server/Transport/Http/Middleware/AuthorizationEndpointMiddleware.php
@@ -1,0 +1,221 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\Middleware;
+
+use Http\Discovery\Psr17FactoryDiscovery;
+use Mcp\Server\Transport\Http\OAuth\AuthorizationCodeIssuerInterface;
+use Mcp\Server\Transport\Http\OAuth\ClientRepositoryInterface;
+use Mcp\Server\Transport\Http\OAuth\ConsentInterface;
+use Mcp\Server\Transport\Http\OAuth\Pkce;
+use Mcp\Server\Transport\Http\OAuth\ResourceOwnerResolverInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * OAuth 2.1 authorization endpoint (authorization code grant with mandatory
+ * PKCE S256).
+ *
+ * Validates the request, resolves the resource owner (delegating login to the
+ * host), runs consent, and issues an authorization code via the engine. Errors
+ * about client_id / redirect_uri are rendered directly (never redirected) to
+ * prevent open redirects; all other errors redirect back to the client.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6749#section-4.1
+ */
+final class AuthorizationEndpointMiddleware implements MiddlewareInterface
+{
+    private ResponseFactoryInterface $responseFactory;
+    private StreamFactoryInterface $streamFactory;
+
+    /** @var list<string> */
+    private array $supportedScopes;
+
+    /**
+     * @param list<string> $supportedScopes Allowed scopes (empty = accept any the client allows)
+     */
+    public function __construct(
+        private readonly ClientRepositoryInterface $clients,
+        private readonly AuthorizationCodeIssuerInterface $codeIssuer,
+        private readonly ResourceOwnerResolverInterface $resourceOwner,
+        private readonly ConsentInterface $consent,
+        array $supportedScopes = [],
+        private readonly string $path = '/authorize',
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
+    ) {
+        $this->supportedScopes = array_values($supportedScopes);
+        $this->responseFactory = $responseFactory ?? Psr17FactoryDiscovery::findResponseFactory();
+        $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ($this->path !== $request->getUri()->getPath() || !\in_array($request->getMethod(), ['GET', 'POST'], true)) {
+            return $handler->handle($request);
+        }
+
+        $params = $this->collectParams($request);
+
+        // 1. Client + redirect URI: errors here MUST NOT redirect (open-redirect prevention).
+        $clientId = $this->stringParam($params, 'client_id');
+        if (null === $clientId || null === ($client = $this->clients->find($clientId))) {
+            return $this->directError(400, 'invalid_client', 'Unknown or missing client_id.');
+        }
+
+        $redirectUri = $this->stringParam($params, 'redirect_uri');
+        if (null === $redirectUri || !$client->hasRedirectUri($redirectUri)) {
+            return $this->directError(400, 'invalid_request', 'Missing or unregistered redirect_uri.');
+        }
+
+        $state = $this->stringParam($params, 'state');
+
+        // 2. response_type
+        if ('code' !== $this->stringParam($params, 'response_type')) {
+            return $this->redirectError($redirectUri, 'unsupported_response_type', 'Only response_type=code is supported.', $state);
+        }
+
+        // 3. PKCE (S256 required)
+        $codeChallenge = $this->stringParam($params, 'code_challenge');
+        $codeChallengeMethod = $this->stringParam($params, 'code_challenge_method');
+        if (null === $codeChallenge || Pkce::METHOD_S256 !== $codeChallengeMethod) {
+            return $this->redirectError($redirectUri, 'invalid_request', 'PKCE with code_challenge_method=S256 is required.', $state);
+        }
+
+        // 4. Scopes
+        $scopes = $this->resolveScopes($params, $client->scopes);
+        foreach ($scopes as $scope) {
+            $allowedByServer = [] === $this->supportedScopes || \in_array($scope, $this->supportedScopes, true);
+            if (!$allowedByServer || !$client->allowsScope($scope)) {
+                return $this->redirectError($redirectUri, 'invalid_scope', \sprintf('The scope "%s" is not allowed.', $scope), $state);
+            }
+        }
+
+        // 5. Resource owner (host authenticates the user)
+        $owner = $this->resourceOwner->resolve($request);
+        if (null === $owner) {
+            return $this->resourceOwner->onUnauthenticated($request);
+        }
+
+        // 6. Consent
+        $decision = $this->consent->decide($client, $scopes, $owner, $request);
+        if (null !== $decision->response) {
+            return $decision->response;
+        }
+        if (!$decision->approved) {
+            return $this->redirectError($redirectUri, 'access_denied', 'The resource owner denied the request.', $state);
+        }
+        $scopes = $decision->approvedScopes ?? $scopes;
+
+        // 7. Issue the authorization code
+        $resource = $this->stringParam($params, 'resource');
+        $code = $this->codeIssuer->issueCode($client, $owner, $redirectUri, $scopes, $codeChallenge, Pkce::METHOD_S256, $resource);
+
+        $location = $this->appendQuery($redirectUri, array_filter([
+            'code' => $code,
+            'state' => $state,
+        ], static fn (?string $v): bool => null !== $v));
+
+        return $this->responseFactory
+            ->createResponse(302)
+            ->withHeader('Location', $location)
+            ->withHeader('Cache-Control', 'no-store');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function collectParams(ServerRequestInterface $request): array
+    {
+        $params = $request->getQueryParams();
+
+        if ('POST' === $request->getMethod()
+            && str_starts_with(strtolower($request->getHeaderLine('Content-Type')), 'application/x-www-form-urlencoded')) {
+            parse_str($request->getBody()->__toString(), $body);
+            $params = array_merge($params, $body);
+        }
+
+        return $params;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @param list<string>         $clientScopes
+     *
+     * @return list<string>
+     */
+    private function resolveScopes(array $params, array $clientScopes): array
+    {
+        $scope = $this->stringParam($params, 'scope');
+        if (null === $scope) {
+            return [] !== $clientScopes ? $clientScopes : $this->supportedScopes;
+        }
+
+        return array_values(array_filter(explode(' ', $scope), static fn (string $s): bool => '' !== $s));
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function stringParam(array $params, string $name): ?string
+    {
+        $value = $params[$name] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, string> $params
+     */
+    private function appendQuery(string $uri, array $params): string
+    {
+        if ([] === $params) {
+            return $uri;
+        }
+
+        $separator = str_contains($uri, '?') ? '&' : '?';
+
+        return $uri.$separator.http_build_query($params);
+    }
+
+    private function redirectError(string $redirectUri, string $error, string $description, ?string $state): ResponseInterface
+    {
+        $location = $this->appendQuery($redirectUri, array_filter([
+            'error' => $error,
+            'error_description' => $description,
+            'state' => $state,
+        ], static fn (?string $v): bool => null !== $v));
+
+        return $this->responseFactory
+            ->createResponse(302)
+            ->withHeader('Location', $location)
+            ->withHeader('Cache-Control', 'no-store');
+    }
+
+    private function directError(int $status, string $error, string $description): ResponseInterface
+    {
+        return $this->responseFactory
+            ->createResponse($status)
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Cache-Control', 'no-store')
+            ->withBody($this->streamFactory->createStream(json_encode([
+                'error' => $error,
+                'error_description' => $description,
+            ], \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES)));
+    }
+}

--- a/src/Server/Transport/Http/Middleware/AuthorizationServerMetadataMiddleware.php
+++ b/src/Server/Transport/Http/Middleware/AuthorizationServerMetadataMiddleware.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\Middleware;
+
+use Http\Discovery\Psr17FactoryDiscovery;
+use Mcp\Server\Transport\Http\OAuth\AuthorizationServerMetadata;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Serves OAuth 2.0 Authorization Server Metadata (RFC 8414) at
+ * /.well-known/oauth-authorization-server.
+ *
+ * Place this inside (after) {@see ClientRegistrationMiddleware} so the latter can
+ * enrich the response with the registration_endpoint.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc8414
+ */
+final class AuthorizationServerMetadataMiddleware implements MiddlewareInterface
+{
+    private ResponseFactoryInterface $responseFactory;
+    private StreamFactoryInterface $streamFactory;
+
+    public function __construct(
+        private readonly AuthorizationServerMetadata $metadata,
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
+    ) {
+        $this->responseFactory = $responseFactory ?? Psr17FactoryDiscovery::findResponseFactory();
+        $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ('GET' !== $request->getMethod() || $this->metadata->getMetadataPath() !== $request->getUri()->getPath()) {
+            return $handler->handle($request);
+        }
+
+        return $this->responseFactory
+            ->createResponse(200)
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Cache-Control', 'max-age=3600')
+            ->withBody($this->streamFactory->createStream(json_encode($this->metadata, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES)));
+    }
+}

--- a/src/Server/Transport/Http/Middleware/JwksMiddleware.php
+++ b/src/Server/Transport/Http/Middleware/JwksMiddleware.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\Middleware;
+
+use Http\Discovery\Psr17FactoryDiscovery;
+use Mcp\Server\Transport\Http\OAuth\SigningKeyInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Publishes the authorization server's public signing keys as a JWK Set
+ * (RFC 7517) so resource servers can verify self-issued access tokens.
+ */
+final class JwksMiddleware implements MiddlewareInterface
+{
+    public const DEFAULT_PATH = '/.well-known/jwks.json';
+
+    private ResponseFactoryInterface $responseFactory;
+    private StreamFactoryInterface $streamFactory;
+
+    /** @var list<SigningKeyInterface> */
+    private array $signingKeys;
+
+    /**
+     * @param SigningKeyInterface|iterable<SigningKeyInterface> $signingKeys One key, or a set to support rotation
+     */
+    public function __construct(
+        SigningKeyInterface|iterable $signingKeys,
+        private readonly string $path = self::DEFAULT_PATH,
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
+    ) {
+        $this->signingKeys = $signingKeys instanceof SigningKeyInterface
+            ? [$signingKeys]
+            : array_values([...$signingKeys]);
+
+        $this->responseFactory = $responseFactory ?? Psr17FactoryDiscovery::findResponseFactory();
+        $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ('GET' !== $request->getMethod() || $this->path !== $request->getUri()->getPath()) {
+            return $handler->handle($request);
+        }
+
+        $keys = array_map(static fn (SigningKeyInterface $key): array => $key->getPublicJwk(), $this->signingKeys);
+
+        return $this->responseFactory
+            ->createResponse(200)
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Cache-Control', 'max-age=3600')
+            ->withBody($this->streamFactory->createStream(json_encode(['keys' => $keys], \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES)));
+    }
+}

--- a/src/Server/Transport/Http/Middleware/TokenEndpointMiddleware.php
+++ b/src/Server/Transport/Http/Middleware/TokenEndpointMiddleware.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\Middleware;
+
+use Http\Discovery\Psr17FactoryDiscovery;
+use Mcp\Exception\OAuthException;
+use Mcp\Server\Transport\Http\OAuth\TokenGranterInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * OAuth 2.0 token endpoint (RFC 6749 Section 5).
+ *
+ * Thin PSR-7 shell: parses the form body (and any HTTP Basic client
+ * credentials), delegates to a {@see TokenGranterInterface}, and serializes the
+ * RFC 6749 §5.1 success or §5.2 error response. All responses are non-cacheable.
+ */
+final class TokenEndpointMiddleware implements MiddlewareInterface
+{
+    private ResponseFactoryInterface $responseFactory;
+    private StreamFactoryInterface $streamFactory;
+
+    public function __construct(
+        private readonly TokenGranterInterface $granter,
+        private readonly string $path = '/token',
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
+    ) {
+        $this->responseFactory = $responseFactory ?? Psr17FactoryDiscovery::findResponseFactory();
+        $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ('POST' !== $request->getMethod() || $this->path !== $request->getUri()->getPath()) {
+            return $handler->handle($request);
+        }
+
+        parse_str($request->getBody()->__toString(), $params);
+        $params = $this->applyBasicAuth($request, $params);
+
+        $grantType = $params['grant_type'] ?? '';
+        if (!\is_string($grantType)) {
+            $grantType = '';
+        }
+
+        try {
+            $tokenResponse = $this->granter->grant($grantType, $params);
+        } catch (OAuthException $e) {
+            return $this->json($e->httpStatus, $e->toArray());
+        }
+
+        return $this->json(200, $tokenResponse->toArray());
+    }
+
+    /**
+     * Normalizes HTTP Basic client credentials into the params array
+     * (client_secret_basic), without overriding body-provided values.
+     *
+     * @param array<string, mixed> $params
+     *
+     * @return array<string, mixed>
+     */
+    private function applyBasicAuth(ServerRequestInterface $request, array $params): array
+    {
+        $authorization = $request->getHeaderLine('Authorization');
+        if (!preg_match('/^Basic\s+(.+)$/i', $authorization, $matches)) {
+            return $params;
+        }
+
+        $decoded = base64_decode(trim($matches[1]), true);
+        if (false === $decoded || !str_contains($decoded, ':')) {
+            return $params;
+        }
+
+        [$clientId, $clientSecret] = explode(':', $decoded, 2);
+        $params['client_id'] ??= rawurldecode($clientId);
+        $params['client_secret'] ??= rawurldecode($clientSecret);
+
+        return $params;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function json(int $status, array $data): ResponseInterface
+    {
+        return $this->responseFactory
+            ->createResponse($status)
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Cache-Control', 'no-store')
+            ->withHeader('Pragma', 'no-cache')
+            ->withBody($this->streamFactory->createStream(json_encode($data, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES)));
+    }
+}

--- a/src/Server/Transport/Http/OAuth/AccessTokenIssuerInterface.php
+++ b/src/Server/Transport/Http/OAuth/AccessTokenIssuerInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * Mints access tokens for the authorization server.
+ *
+ * The default implementation issues self-validating RS256 JWTs, but a host may
+ * provide an opaque-token or third-party implementation behind this contract.
+ */
+interface AccessTokenIssuerInterface
+{
+    /**
+     * @param list<string>         $scopes
+     * @param array<string, mixed> $claims Additional claims to embed (e.g. from the resource owner)
+     *
+     * @return array{token: string, tokenId: string} The encoded access token and its unique id (jti)
+     */
+    public function issue(
+        string $subject,
+        string $audience,
+        array $scopes,
+        string $clientId,
+        int $ttlSeconds,
+        array $claims = [],
+    ): array;
+}

--- a/src/Server/Transport/Http/OAuth/AccessTokenStoreInterface.php
+++ b/src/Server/Transport/Http/OAuth/AccessTokenStoreInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * Optional registry of issued access tokens enabling server-side revocation.
+ *
+ * Self-contained JWT access tokens are valid until they expire; wiring an
+ * implementation of this interface into the token validation path lets a host
+ * revoke a token (by its "jti") before expiry, at parity with stateful
+ * authorization servers.
+ */
+interface AccessTokenStoreInterface
+{
+    public function record(string $tokenId, string $clientId, string $userId, \DateTimeImmutable $expiresAt): void;
+
+    public function isRevoked(string $tokenId): bool;
+
+    public function revoke(string $tokenId): void;
+}

--- a/src/Server/Transport/Http/OAuth/AuthorizationCode.php
+++ b/src/Server/Transport/Http/OAuth/AuthorizationCode.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * A short-lived, single-use authorization code (RFC 6749 Section 4.1) bound to
+ * the client, redirect URI, scope, PKCE challenge and resource owner.
+ */
+final class AuthorizationCode
+{
+    /**
+     * @param list<string>         $scopes
+     * @param array<string, mixed> $userClaims
+     */
+    public function __construct(
+        public readonly string $clientId,
+        public readonly string $redirectUri,
+        public readonly array $scopes,
+        public readonly string $codeChallenge,
+        public readonly string $codeChallengeMethod,
+        public readonly string $userId,
+        public readonly array $userClaims,
+        public readonly ?string $resource,
+        public readonly \DateTimeImmutable $expiresAt,
+    ) {
+    }
+
+    public function isExpired(\DateTimeImmutable $now): bool
+    {
+        return $now >= $this->expiresAt;
+    }
+}

--- a/src/Server/Transport/Http/OAuth/AuthorizationCodeIssuerInterface.php
+++ b/src/Server/Transport/Http/OAuth/AuthorizationCodeIssuerInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * Issues authorization codes once an authorization request has been validated
+ * and approved.
+ *
+ * This is one of the two engine seams (with {@see TokenGranterInterface}) a host
+ * can replace to back the authorization server with a different implementation
+ * (e.g. league/oauth2-server) while keeping the SDK delivery layer.
+ */
+interface AuthorizationCodeIssuerInterface
+{
+    /**
+     * @param list<string> $scopes
+     *
+     * @return string The authorization code to return to the client
+     */
+    public function issueCode(
+        Client $client,
+        ResourceOwner $resourceOwner,
+        string $redirectUri,
+        array $scopes,
+        string $codeChallenge,
+        string $codeChallengeMethod,
+        ?string $resource = null,
+    ): string;
+}

--- a/src/Server/Transport/Http/OAuth/AuthorizationCodeStoreInterface.php
+++ b/src/Server/Transport/Http/OAuth/AuthorizationCodeStoreInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * Stores authorization codes for the authorization code grant.
+ *
+ * Codes MUST be single-use: {@see self::consume()} returns the code once and
+ * atomically deletes it, so a replayed code is rejected.
+ */
+interface AuthorizationCodeStoreInterface
+{
+    public function store(string $code, AuthorizationCode $authorizationCode): void;
+
+    /**
+     * Atomically fetches and deletes the code. Returns null if it is unknown.
+     */
+    public function consume(string $code): ?AuthorizationCode;
+}

--- a/src/Server/Transport/Http/OAuth/AuthorizationServerMetadata.php
+++ b/src/Server/Transport/Http/OAuth/AuthorizationServerMetadata.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Mcp\Exception\InvalidArgumentException;
+
+/**
+ * OAuth 2.0 Authorization Server Metadata (RFC 8414).
+ *
+ * Endpoints default to conventional paths derived from the issuer. The
+ * registration_endpoint is intentionally left out so that
+ * {@see \Mcp\Server\Transport\Http\Middleware\ClientRegistrationMiddleware} can
+ * enrich the served document when dynamic client registration is enabled.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc8414
+ */
+final class AuthorizationServerMetadata implements \JsonSerializable
+{
+    public const DEFAULT_METADATA_PATH = '/.well-known/oauth-authorization-server';
+
+    private string $issuer;
+    private string $authorizationEndpoint;
+    private string $tokenEndpoint;
+    private string $jwksUri;
+    private ?string $registrationEndpoint;
+
+    /** @var list<string> */
+    private array $scopesSupported;
+
+    /** @var list<string> */
+    private array $responseTypesSupported;
+
+    /** @var list<string> */
+    private array $grantTypesSupported;
+
+    /** @var list<string> */
+    private array $codeChallengeMethodsSupported;
+
+    /** @var list<string> */
+    private array $tokenEndpointAuthMethodsSupported;
+
+    /** @var array<string, mixed> */
+    private array $extra;
+
+    /**
+     * @param list<string>         $scopesSupported
+     * @param list<string>         $responseTypesSupported
+     * @param list<string>         $grantTypesSupported
+     * @param list<string>         $codeChallengeMethodsSupported
+     * @param list<string>         $tokenEndpointAuthMethodsSupported
+     * @param array<string, mixed> $extra
+     */
+    public function __construct(
+        string $issuer,
+        ?string $authorizationEndpoint = null,
+        ?string $tokenEndpoint = null,
+        ?string $jwksUri = null,
+        ?string $registrationEndpoint = null,
+        array $scopesSupported = ['mcp:tools', 'mcp:resources'],
+        array $responseTypesSupported = ['code'],
+        array $grantTypesSupported = ['authorization_code', 'refresh_token'],
+        array $codeChallengeMethodsSupported = ['S256'],
+        array $tokenEndpointAuthMethodsSupported = ['client_secret_basic', 'client_secret_post', 'none'],
+        array $extra = [],
+        private readonly string $metadataPath = self::DEFAULT_METADATA_PATH,
+    ) {
+        $issuer = rtrim(trim($issuer), '/');
+        if ('' === $issuer) {
+            throw new InvalidArgumentException('Authorization server metadata requires a non-empty issuer.');
+        }
+
+        $this->issuer = $issuer;
+        $this->authorizationEndpoint = $authorizationEndpoint ?? $issuer.'/authorize';
+        $this->tokenEndpoint = $tokenEndpoint ?? $issuer.'/token';
+        $this->jwksUri = $jwksUri ?? $issuer.'/.well-known/jwks.json';
+        $this->registrationEndpoint = $registrationEndpoint;
+        $this->scopesSupported = array_values($scopesSupported);
+        $this->responseTypesSupported = array_values($responseTypesSupported);
+        $this->grantTypesSupported = array_values($grantTypesSupported);
+        $this->codeChallengeMethodsSupported = array_values($codeChallengeMethodsSupported);
+        $this->tokenEndpointAuthMethodsSupported = array_values($tokenEndpointAuthMethodsSupported);
+        $this->extra = $extra;
+    }
+
+    public function getIssuer(): string
+    {
+        return $this->issuer;
+    }
+
+    public function getMetadataPath(): string
+    {
+        return $this->metadataPath;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        $data = [
+            'issuer' => $this->issuer,
+            'authorization_endpoint' => $this->authorizationEndpoint,
+            'token_endpoint' => $this->tokenEndpoint,
+            'jwks_uri' => $this->jwksUri,
+            'scopes_supported' => $this->scopesSupported,
+            'response_types_supported' => $this->responseTypesSupported,
+            'grant_types_supported' => $this->grantTypesSupported,
+            'code_challenge_methods_supported' => $this->codeChallengeMethodsSupported,
+            'token_endpoint_auth_methods_supported' => $this->tokenEndpointAuthMethodsSupported,
+        ];
+
+        if (null !== $this->registrationEndpoint) {
+            $data['registration_endpoint'] = $this->registrationEndpoint;
+        }
+
+        return array_merge($this->extra, $data);
+    }
+}

--- a/src/Server/Transport/Http/OAuth/AutoApproveConsent.php
+++ b/src/Server/Transport/Http/OAuth/AutoApproveConsent.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Default {@see ConsentInterface} that approves every request for an
+ * authenticated resource owner, with no consent screen.
+ */
+final class AutoApproveConsent implements ConsentInterface
+{
+    public function decide(
+        Client $client,
+        array $scopes,
+        ResourceOwner $resourceOwner,
+        ServerRequestInterface $request,
+    ): ConsentDecision {
+        return ConsentDecision::approve();
+    }
+}

--- a/src/Server/Transport/Http/OAuth/CacheAuthorizationCodeStore.php
+++ b/src/Server/Transport/Http/OAuth/CacheAuthorizationCodeStore.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * PSR-16 backed {@see AuthorizationCodeStoreInterface} for multi-process
+ * deployments. The cache TTL mirrors the code lifetime so expired codes vanish.
+ */
+final class CacheAuthorizationCodeStore implements AuthorizationCodeStoreInterface
+{
+    public function __construct(
+        private readonly CacheInterface $cache,
+        private readonly string $prefix = 'mcp_oauth_code_',
+    ) {
+    }
+
+    public function store(string $code, AuthorizationCode $authorizationCode): void
+    {
+        $ttl = $authorizationCode->expiresAt->getTimestamp() - time();
+        if ($ttl <= 0) {
+            return;
+        }
+
+        $this->cache->set($this->prefix.$code, $authorizationCode, $ttl);
+    }
+
+    public function consume(string $code): ?AuthorizationCode
+    {
+        $key = $this->prefix.$code;
+        $stored = $this->cache->get($key);
+        $this->cache->delete($key);
+
+        return $stored instanceof AuthorizationCode ? $stored : null;
+    }
+}

--- a/src/Server/Transport/Http/OAuth/CacheClientRepository.php
+++ b/src/Server/Transport/Http/OAuth/CacheClientRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * PSR-16 backed {@see ClientRepositoryInterface}. Clients are stored without an
+ * expiry. Suitable for examples and small deployments; back DCR with durable
+ * storage for production.
+ */
+final class CacheClientRepository implements ClientRepositoryInterface
+{
+    public function __construct(
+        private readonly CacheInterface $cache,
+        private readonly string $prefix = 'mcp_oauth_client_',
+    ) {
+    }
+
+    public function find(string $clientId): ?Client
+    {
+        $stored = $this->cache->get($this->prefix.$clientId);
+
+        return $stored instanceof Client ? $stored : null;
+    }
+
+    public function save(Client $client): void
+    {
+        $this->cache->set($this->prefix.$client->clientId, $client);
+    }
+}

--- a/src/Server/Transport/Http/OAuth/CacheRefreshTokenStore.php
+++ b/src/Server/Transport/Http/OAuth/CacheRefreshTokenStore.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * PSR-16 backed {@see RefreshTokenStoreInterface} for multi-process deployments.
+ * The cache TTL mirrors the token lifetime so expired tokens vanish.
+ */
+final class CacheRefreshTokenStore implements RefreshTokenStoreInterface
+{
+    public function __construct(
+        private readonly CacheInterface $cache,
+        private readonly string $prefix = 'mcp_oauth_refresh_',
+    ) {
+    }
+
+    public function store(string $token, RefreshToken $refreshToken): void
+    {
+        $ttl = $refreshToken->expiresAt->getTimestamp() - time();
+        if ($ttl <= 0) {
+            return;
+        }
+
+        $this->cache->set($this->prefix.$token, $refreshToken, $ttl);
+    }
+
+    public function consume(string $token): ?RefreshToken
+    {
+        $key = $this->prefix.$token;
+        $stored = $this->cache->get($key);
+        $this->cache->delete($key);
+
+        return $stored instanceof RefreshToken ? $stored : null;
+    }
+}

--- a/src/Server/Transport/Http/OAuth/Client.php
+++ b/src/Server/Transport/Http/OAuth/Client.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * An OAuth 2.0 client registration.
+ *
+ * A client is "public" when it has no secret (or its token endpoint auth method
+ * is "none") and must therefore use PKCE; otherwise it is "confidential" and the
+ * secret is verified at the token endpoint.
+ */
+final class Client
+{
+    public const AUTH_METHOD_NONE = 'none';
+    public const AUTH_METHOD_CLIENT_SECRET_BASIC = 'client_secret_basic';
+    public const AUTH_METHOD_CLIENT_SECRET_POST = 'client_secret_post';
+
+    /** @var list<string> */
+    public readonly array $redirectUris;
+
+    /** @var list<string> */
+    public readonly array $grantTypes;
+
+    /** @var list<string> */
+    public readonly array $scopes;
+
+    /**
+     * @param list<string> $redirectUris
+     * @param list<string> $grantTypes
+     * @param list<string> $scopes
+     */
+    public function __construct(
+        public readonly string $clientId,
+        public readonly ?string $clientSecret = null,
+        array $redirectUris = [],
+        array $grantTypes = ['authorization_code', 'refresh_token'],
+        array $scopes = [],
+        public readonly string $tokenEndpointAuthMethod = self::AUTH_METHOD_CLIENT_SECRET_BASIC,
+        public readonly ?string $clientName = null,
+    ) {
+        $this->redirectUris = array_values($redirectUris);
+        $this->grantTypes = array_values($grantTypes);
+        $this->scopes = array_values($scopes);
+    }
+
+    public function isPublic(): bool
+    {
+        return self::AUTH_METHOD_NONE === $this->tokenEndpointAuthMethod || null === $this->clientSecret;
+    }
+
+    public function hasRedirectUri(string $redirectUri): bool
+    {
+        return \in_array($redirectUri, $this->redirectUris, true);
+    }
+
+    public function supportsGrant(string $grantType): bool
+    {
+        return \in_array($grantType, $this->grantTypes, true);
+    }
+
+    public function allowsScope(string $scope): bool
+    {
+        return [] === $this->scopes || \in_array($scope, $this->scopes, true);
+    }
+}

--- a/src/Server/Transport/Http/OAuth/ClientRepositoryInterface.php
+++ b/src/Server/Transport/Http/OAuth/ClientRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * Persists and retrieves OAuth 2.0 client registrations.
+ *
+ * Hosts implement this against their own storage (database, cache, etc.).
+ */
+interface ClientRepositoryInterface
+{
+    public function find(string $clientId): ?Client;
+
+    public function save(Client $client): void;
+}

--- a/src/Server/Transport/Http/OAuth/ConsentDecision.php
+++ b/src/Server/Transport/Http/OAuth/ConsentDecision.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * The outcome of a {@see ConsentInterface} decision: approve (optionally with a
+ * narrowed scope set), deny, or short-circuit with a response (e.g. to render a
+ * consent screen the user has not yet submitted).
+ */
+final class ConsentDecision
+{
+    /**
+     * @param list<string>|null $approvedScopes
+     */
+    private function __construct(
+        public readonly bool $approved,
+        public readonly ?array $approvedScopes,
+        public readonly ?ResponseInterface $response,
+    ) {
+    }
+
+    /**
+     * @param list<string>|null $approvedScopes Null keeps the requested scopes
+     */
+    public static function approve(?array $approvedScopes = null): self
+    {
+        return new self(true, $approvedScopes, null);
+    }
+
+    public static function deny(): self
+    {
+        return new self(false, null, null);
+    }
+
+    /**
+     * Short-circuit the authorization request with a custom response (e.g. the
+     * consent form to display before a decision can be made).
+     */
+    public static function respondWith(ResponseInterface $response): self
+    {
+        return new self(false, null, $response);
+    }
+}

--- a/src/Server/Transport/Http/OAuth/ConsentInterface.php
+++ b/src/Server/Transport/Http/OAuth/ConsentInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Decides whether an authenticated resource owner grants the client the
+ * requested scopes.
+ *
+ * The default {@see AutoApproveConsent} approves silently. Hosts that need an
+ * approval screen return {@see ConsentDecision::respondWith()} until the user
+ * submits, then {@see ConsentDecision::approve()}.
+ */
+interface ConsentInterface
+{
+    /**
+     * @param list<string> $scopes
+     */
+    public function decide(
+        Client $client,
+        array $scopes,
+        ResourceOwner $resourceOwner,
+        ServerRequestInterface $request,
+    ): ConsentDecision;
+}

--- a/src/Server/Transport/Http/OAuth/InMemoryAccessTokenStore.php
+++ b/src/Server/Transport/Http/OAuth/InMemoryAccessTokenStore.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * In-memory {@see AccessTokenStoreInterface} for tests, examples and
+ * single-process servers.
+ */
+final class InMemoryAccessTokenStore implements AccessTokenStoreInterface
+{
+    /** @var array<string, bool> token id => revoked */
+    private array $tokens = [];
+
+    public function record(string $tokenId, string $clientId, string $userId, \DateTimeImmutable $expiresAt): void
+    {
+        $this->tokens[$tokenId] = false;
+    }
+
+    public function isRevoked(string $tokenId): bool
+    {
+        return $this->tokens[$tokenId] ?? false;
+    }
+
+    public function revoke(string $tokenId): void
+    {
+        $this->tokens[$tokenId] = true;
+    }
+}

--- a/src/Server/Transport/Http/OAuth/InMemoryAuthorizationCodeStore.php
+++ b/src/Server/Transport/Http/OAuth/InMemoryAuthorizationCodeStore.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * In-memory {@see AuthorizationCodeStoreInterface}. Consuming a code deletes it,
+ * enforcing single use. Expiry is enforced by the granter.
+ */
+final class InMemoryAuthorizationCodeStore implements AuthorizationCodeStoreInterface
+{
+    /** @var array<string, AuthorizationCode> */
+    private array $codes = [];
+
+    public function store(string $code, AuthorizationCode $authorizationCode): void
+    {
+        $this->codes[$code] = $authorizationCode;
+    }
+
+    public function consume(string $code): ?AuthorizationCode
+    {
+        $stored = $this->codes[$code] ?? null;
+        unset($this->codes[$code]);
+
+        return $stored;
+    }
+}

--- a/src/Server/Transport/Http/OAuth/InMemoryClientRepository.php
+++ b/src/Server/Transport/Http/OAuth/InMemoryClientRepository.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * In-memory {@see ClientRepositoryInterface} for tests, examples and
+ * single-process servers. Not suitable for multi-process deployments.
+ */
+final class InMemoryClientRepository implements ClientRepositoryInterface
+{
+    /** @var array<string, Client> */
+    private array $clients = [];
+
+    /**
+     * @param list<Client> $clients
+     */
+    public function __construct(array $clients = [])
+    {
+        foreach ($clients as $client) {
+            $this->save($client);
+        }
+    }
+
+    public function find(string $clientId): ?Client
+    {
+        return $this->clients[$clientId] ?? null;
+    }
+
+    public function save(Client $client): void
+    {
+        $this->clients[$client->clientId] = $client;
+    }
+}

--- a/src/Server/Transport/Http/OAuth/InMemoryRefreshTokenStore.php
+++ b/src/Server/Transport/Http/OAuth/InMemoryRefreshTokenStore.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * In-memory {@see RefreshTokenStoreInterface}. Consuming a token deletes it,
+ * enforcing rotation. Expiry is enforced by the granter.
+ */
+final class InMemoryRefreshTokenStore implements RefreshTokenStoreInterface
+{
+    /** @var array<string, RefreshToken> */
+    private array $tokens = [];
+
+    public function store(string $token, RefreshToken $refreshToken): void
+    {
+        $this->tokens[$token] = $refreshToken;
+    }
+
+    public function consume(string $token): ?RefreshToken
+    {
+        $stored = $this->tokens[$token] ?? null;
+        unset($this->tokens[$token]);
+
+        return $stored;
+    }
+}

--- a/src/Server/Transport/Http/OAuth/JwtAccessTokenIssuer.php
+++ b/src/Server/Transport/Http/OAuth/JwtAccessTokenIssuer.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Firebase\JWT\JWT;
+use Mcp\Exception\RuntimeException;
+use Psr\Clock\ClockInterface;
+
+/**
+ * Issues self-validating RS256 JWT access tokens.
+ *
+ * Tokens issued here are designed to validate, unchanged, through
+ * {@see JwtTokenValidator} configured with this server as issuer and the
+ * matching JWKS. The claim shape is configurable so it can also match the shape
+ * of another authorization server (e.g. league/oauth2-server, which uses an
+ * array "scopes" claim and an "aud" set to the client id) for a phased
+ * migration.
+ *
+ * Requires: firebase/php-jwt
+ */
+final class JwtAccessTokenIssuer implements AccessTokenIssuerInterface
+{
+    private const ALGORITHM = 'RS256';
+
+    public function __construct(
+        private readonly SigningKeyInterface $signingKey,
+        private readonly string $issuer,
+        private readonly ?ClockInterface $clock = null,
+        private readonly string $scopeClaim = 'scope',
+        private readonly bool $scopesAsArray = false,
+        private readonly bool $includeNotBefore = false,
+    ) {
+        if (!class_exists(JWT::class)) {
+            throw new RuntimeException('For using the JwtAccessTokenIssuer, the firebase/php-jwt package is required. Try running "composer require firebase/php-jwt".');
+        }
+    }
+
+    public function issue(
+        string $subject,
+        string $audience,
+        array $scopes,
+        string $clientId,
+        int $ttlSeconds,
+        array $claims = [],
+    ): array {
+        $now = ($this->clock?->now() ?? new \DateTimeImmutable())->getTimestamp();
+        $tokenId = bin2hex(random_bytes(16));
+
+        $payload = $claims;
+        $payload['iss'] = $this->issuer;
+        $payload['sub'] = $subject;
+        $payload['aud'] = $audience;
+        $payload['client_id'] = $clientId;
+        $payload['jti'] = $tokenId;
+        $payload['iat'] = $now;
+        $payload['exp'] = $now + $ttlSeconds;
+        $payload[$this->scopeClaim] = $this->scopesAsArray ? array_values($scopes) : implode(' ', $scopes);
+
+        if ($this->includeNotBefore) {
+            $payload['nbf'] = $now;
+        }
+
+        $token = JWT::encode($payload, $this->signingKey->getPrivateKeyPem(), self::ALGORITHM, $this->signingKey->getKeyId());
+
+        return ['token' => $token, 'tokenId' => $tokenId];
+    }
+}

--- a/src/Server/Transport/Http/OAuth/NativeAuthorizationCodeIssuer.php
+++ b/src/Server/Transport/Http/OAuth/NativeAuthorizationCodeIssuer.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Psr\Clock\ClockInterface;
+
+/**
+ * Default {@see AuthorizationCodeIssuerInterface}: generates a random,
+ * short-lived, single-use code and persists it bound to the request context.
+ */
+final class NativeAuthorizationCodeIssuer implements AuthorizationCodeIssuerInterface
+{
+    public function __construct(
+        private readonly AuthorizationCodeStoreInterface $codes,
+        private readonly int $codeTtl = 60,
+        private readonly ?ClockInterface $clock = null,
+    ) {
+    }
+
+    public function issueCode(
+        Client $client,
+        ResourceOwner $resourceOwner,
+        string $redirectUri,
+        array $scopes,
+        string $codeChallenge,
+        string $codeChallengeMethod,
+        ?string $resource = null,
+    ): string {
+        $now = $this->clock?->now() ?? new \DateTimeImmutable();
+        $code = rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+
+        $this->codes->store($code, new AuthorizationCode(
+            clientId: $client->clientId,
+            redirectUri: $redirectUri,
+            scopes: array_values($scopes),
+            codeChallenge: $codeChallenge,
+            codeChallengeMethod: $codeChallengeMethod,
+            userId: $resourceOwner->id,
+            userClaims: $resourceOwner->claims,
+            resource: $resource,
+            expiresAt: $now->modify(\sprintf('+%d seconds', $this->codeTtl)),
+        ));
+
+        return $code;
+    }
+}

--- a/src/Server/Transport/Http/OAuth/NativeTokenGranter.php
+++ b/src/Server/Transport/Http/OAuth/NativeTokenGranter.php
@@ -1,0 +1,221 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Mcp\Exception\OAuthException;
+use Psr\Clock\ClockInterface;
+
+/**
+ * Default {@see TokenGranterInterface}: implements the authorization code grant
+ * (with mandatory PKCE) and the refresh token grant (with rotation), minting
+ * access tokens via an {@see AccessTokenIssuerInterface}.
+ */
+final class NativeTokenGranter implements TokenGranterInterface
+{
+    public function __construct(
+        private readonly ClientRepositoryInterface $clients,
+        private readonly AuthorizationCodeStoreInterface $codes,
+        private readonly RefreshTokenStoreInterface $refreshTokens,
+        private readonly AccessTokenIssuerInterface $issuer,
+        private readonly ?string $resource = null,
+        private readonly int $accessTokenTtl = 3600,
+        private readonly ?int $refreshTokenTtl = 1209600,
+        private readonly ?ClockInterface $clock = null,
+    ) {
+    }
+
+    public function grant(string $grantType, array $params): TokenResponse
+    {
+        return match ($grantType) {
+            'authorization_code' => $this->grantAuthorizationCode($params),
+            'refresh_token' => $this->grantRefreshToken($params),
+            '' => throw OAuthException::invalidRequest('Missing "grant_type" parameter.'),
+            default => throw OAuthException::unsupportedGrantType(\sprintf('Unsupported grant type "%s".', $grantType)),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function grantAuthorizationCode(array $params): TokenResponse
+    {
+        $client = $this->authenticateClient($params);
+
+        if (!$client->supportsGrant('authorization_code')) {
+            throw OAuthException::unauthorizedClient('The client is not authorized to use the authorization code grant.');
+        }
+
+        $code = $this->requireParam($params, 'code');
+        $redirectUri = $this->requireParam($params, 'redirect_uri');
+        $codeVerifier = $this->requireParam($params, 'code_verifier');
+
+        $authorizationCode = $this->codes->consume($code);
+        if (null === $authorizationCode) {
+            throw OAuthException::invalidGrant('The authorization code is invalid or has already been used.');
+        }
+
+        if ($authorizationCode->isExpired($this->now())) {
+            throw OAuthException::invalidGrant('The authorization code has expired.');
+        }
+
+        if (!hash_equals($authorizationCode->clientId, $client->clientId)) {
+            throw OAuthException::invalidGrant('The authorization code was issued to another client.');
+        }
+
+        if (!hash_equals($authorizationCode->redirectUri, $redirectUri)) {
+            throw OAuthException::invalidGrant('The redirect URI does not match the authorization request.');
+        }
+
+        if (!Pkce::verify($codeVerifier, $authorizationCode->codeChallenge)) {
+            throw OAuthException::invalidGrant('The PKCE code verifier is invalid.');
+        }
+
+        return $this->issueTokens(
+            $client,
+            $authorizationCode->userId,
+            $authorizationCode->scopes,
+            $authorizationCode->userClaims,
+            $authorizationCode->resource,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function grantRefreshToken(array $params): TokenResponse
+    {
+        $client = $this->authenticateClient($params);
+
+        if (!$client->supportsGrant('refresh_token')) {
+            throw OAuthException::unauthorizedClient('The client is not authorized to use the refresh token grant.');
+        }
+
+        $token = $this->requireParam($params, 'refresh_token');
+
+        $refreshToken = $this->refreshTokens->consume($token);
+        if (null === $refreshToken) {
+            throw OAuthException::invalidGrant('The refresh token is invalid or has already been used.');
+        }
+
+        if ($refreshToken->isExpired($this->now())) {
+            throw OAuthException::invalidGrant('The refresh token has expired.');
+        }
+
+        if (!hash_equals($refreshToken->clientId, $client->clientId)) {
+            throw OAuthException::invalidGrant('The refresh token was issued to another client.');
+        }
+
+        $scopes = $this->resolveRefreshScopes($params, $refreshToken->scopes);
+
+        return $this->issueTokens(
+            $client,
+            $refreshToken->userId,
+            $scopes,
+            $refreshToken->userClaims,
+            $refreshToken->resource,
+        );
+    }
+
+    /**
+     * @param list<string>         $scopes
+     * @param array<string, mixed> $userClaims
+     */
+    private function issueTokens(Client $client, string $userId, array $scopes, array $userClaims, ?string $resource): TokenResponse
+    {
+        $audience = $resource ?? $this->resource ?? $client->clientId;
+
+        $accessToken = $this->issuer->issue($userId, $audience, $scopes, $client->clientId, $this->accessTokenTtl, $userClaims);
+
+        $refreshTokenValue = null;
+        if (null !== $this->refreshTokenTtl && $client->supportsGrant('refresh_token')) {
+            $refreshTokenValue = rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+
+            $this->refreshTokens->store($refreshTokenValue, new RefreshToken(
+                clientId: $client->clientId,
+                userId: $userId,
+                scopes: $scopes,
+                userClaims: $userClaims,
+                resource: $resource,
+                expiresAt: $this->now()->modify(\sprintf('+%d seconds', $this->refreshTokenTtl)),
+            ));
+        }
+
+        return new TokenResponse($accessToken['token'], $this->accessTokenTtl, $scopes, $refreshTokenValue);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function authenticateClient(array $params): Client
+    {
+        $clientId = $params['client_id'] ?? null;
+        if (!\is_string($clientId) || '' === $clientId) {
+            throw OAuthException::invalidClient('Client authentication failed: missing client_id.');
+        }
+
+        $client = $this->clients->find($clientId);
+        if (null === $client) {
+            throw OAuthException::invalidClient('Client authentication failed: unknown client.');
+        }
+
+        if (!$client->isPublic()) {
+            $secret = $params['client_secret'] ?? null;
+            if (!\is_string($secret) || '' === $secret || !hash_equals((string) $client->clientSecret, $secret)) {
+                throw OAuthException::invalidClient('Client authentication failed: invalid client secret.');
+            }
+        }
+
+        return $client;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @param list<string>         $grantedScopes
+     *
+     * @return list<string>
+     */
+    private function resolveRefreshScopes(array $params, array $grantedScopes): array
+    {
+        $requested = $params['scope'] ?? null;
+        if (!\is_string($requested) || '' === trim($requested)) {
+            return $grantedScopes;
+        }
+
+        $requestedScopes = array_values(array_filter(explode(' ', $requested), static fn (string $s): bool => '' !== $s));
+
+        foreach ($requestedScopes as $scope) {
+            if (!\in_array($scope, $grantedScopes, true)) {
+                throw OAuthException::invalidScope(\sprintf('The requested scope "%s" exceeds the originally granted scope.', $scope));
+            }
+        }
+
+        return $requestedScopes;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function requireParam(array $params, string $name): string
+    {
+        $value = $params[$name] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            throw OAuthException::invalidRequest(\sprintf('Missing or invalid "%s" parameter.', $name));
+        }
+
+        return $value;
+    }
+
+    private function now(): \DateTimeImmutable
+    {
+        return $this->clock?->now() ?? new \DateTimeImmutable();
+    }
+}

--- a/src/Server/Transport/Http/OAuth/Pkce.php
+++ b/src/Server/Transport/Http/OAuth/Pkce.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * Proof Key for Code Exchange helpers (RFC 7636). Only the S256 method is
+ * supported, as required by OAuth 2.1.
+ *
+ * @internal
+ */
+final class Pkce
+{
+    public const METHOD_S256 = 'S256';
+
+    /**
+     * Computes the S256 code challenge for a verifier.
+     */
+    public static function challenge(string $codeVerifier): string
+    {
+        return rtrim(strtr(base64_encode(hash('sha256', $codeVerifier, true)), '+/', '-_'), '=');
+    }
+
+    /**
+     * Constant-time verification of a code verifier against a stored challenge.
+     */
+    public static function verify(string $codeVerifier, string $codeChallenge): bool
+    {
+        return hash_equals($codeChallenge, self::challenge($codeVerifier));
+    }
+}

--- a/src/Server/Transport/Http/OAuth/RefreshToken.php
+++ b/src/Server/Transport/Http/OAuth/RefreshToken.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * A refresh token grant record (RFC 6749 Section 6), bound to a client and
+ * resource owner. Refresh tokens are rotated on every use.
+ */
+final class RefreshToken
+{
+    /**
+     * @param list<string>         $scopes
+     * @param array<string, mixed> $userClaims
+     */
+    public function __construct(
+        public readonly string $clientId,
+        public readonly string $userId,
+        public readonly array $scopes,
+        public readonly array $userClaims,
+        public readonly ?string $resource,
+        public readonly \DateTimeImmutable $expiresAt,
+    ) {
+    }
+
+    public function isExpired(\DateTimeImmutable $now): bool
+    {
+        return $now >= $this->expiresAt;
+    }
+}

--- a/src/Server/Transport/Http/OAuth/RefreshTokenStoreInterface.php
+++ b/src/Server/Transport/Http/OAuth/RefreshTokenStoreInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * Stores refresh tokens. Tokens are rotated: {@see self::consume()} returns the
+ * token once and atomically deletes it, and the granter issues a fresh one.
+ */
+interface RefreshTokenStoreInterface
+{
+    public function store(string $token, RefreshToken $refreshToken): void;
+
+    /**
+     * Atomically fetches and deletes the token. Returns null if it is unknown.
+     */
+    public function consume(string $token): ?RefreshToken;
+}

--- a/src/Server/Transport/Http/OAuth/ResourceOwner.php
+++ b/src/Server/Transport/Http/OAuth/ResourceOwner.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * The authenticated end user (resource owner) on whose behalf an authorization
+ * code is issued. The id becomes the JWT "sub" claim; claims are optional extra
+ * data the host may want carried into the token.
+ */
+final class ResourceOwner
+{
+    /**
+     * @param array<string, mixed> $claims
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly array $claims = [],
+    ) {
+    }
+}

--- a/src/Server/Transport/Http/OAuth/ResourceOwnerResolverInterface.php
+++ b/src/Server/Transport/Http/OAuth/ResourceOwnerResolverInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Resolves the authenticated end user (resource owner) for an authorization
+ * request.
+ *
+ * The SDK cannot authenticate users or render a login UI — that is the host's
+ * responsibility. When no user is authenticated, {@see self::onUnauthenticated()}
+ * returns the response that drives the host's login (typically a 302 redirect
+ * carrying the current authorize URL so the flow resumes after login).
+ */
+interface ResourceOwnerResolverInterface
+{
+    /**
+     * @return ResourceOwner|null Null when no end user is authenticated
+     */
+    public function resolve(ServerRequestInterface $request): ?ResourceOwner;
+
+    public function onUnauthenticated(ServerRequestInterface $request): ResponseInterface;
+}

--- a/src/Server/Transport/Http/OAuth/RsaSigningKey.php
+++ b/src/Server/Transport/Http/OAuth/RsaSigningKey.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Exception\RuntimeException;
+
+/**
+ * An RSA signing key backed by a PEM-encoded private key, producing an RS256
+ * public JWK via ext-openssl.
+ */
+final class RsaSigningKey implements SigningKeyInterface
+{
+    private const ALGORITHM = 'RS256';
+
+    private string $keyId;
+
+    /** @var array<string, mixed>|null */
+    private ?array $publicJwk = null;
+
+    public function __construct(
+        private readonly string $privateKeyPem,
+        ?string $keyId = null,
+        private readonly ?string $passphrase = null,
+    ) {
+        if (!\function_exists('openssl_pkey_get_private')) {
+            throw new RuntimeException('The RsaSigningKey requires the openssl extension (ext-openssl).');
+        }
+
+        if ('' === trim($privateKeyPem)) {
+            throw new InvalidArgumentException('The private key PEM must not be empty.');
+        }
+
+        $this->keyId = $keyId ?? $this->deriveKeyId();
+    }
+
+    public static function fromFile(string $pemPath, ?string $keyId = null, ?string $passphrase = null): self
+    {
+        $contents = @file_get_contents($pemPath);
+        if (false === $contents) {
+            throw new InvalidArgumentException(\sprintf('Unable to read private key from "%s".', $pemPath));
+        }
+
+        return new self($contents, $keyId, $passphrase);
+    }
+
+    public function getKeyId(): string
+    {
+        return $this->keyId;
+    }
+
+    public function getPrivateKeyPem(): string
+    {
+        return $this->privateKeyPem;
+    }
+
+    public function getPublicJwk(): array
+    {
+        if (null !== $this->publicJwk) {
+            return $this->publicJwk;
+        }
+
+        $details = $this->keyDetails();
+
+        if (\OPENSSL_KEYTYPE_RSA !== ($details['type'] ?? null) || !isset($details['rsa']['n'], $details['rsa']['e'])) {
+            throw new RuntimeException('The signing key must be an RSA key.');
+        }
+
+        return $this->publicJwk = [
+            'kty' => 'RSA',
+            'use' => 'sig',
+            'alg' => self::ALGORITHM,
+            'kid' => $this->keyId,
+            'n' => self::base64UrlEncode($details['rsa']['n']),
+            'e' => self::base64UrlEncode($details['rsa']['e']),
+        ];
+    }
+
+    /**
+     * @return array{type?: int, rsa?: array{n?: string, e?: string}}
+     */
+    private function keyDetails(): array
+    {
+        $key = openssl_pkey_get_private($this->privateKeyPem, $this->passphrase ?? '');
+        if (false === $key) {
+            throw new RuntimeException('Unable to parse the private key: '.openssl_error_string());
+        }
+
+        $details = openssl_pkey_get_details($key);
+        if (false === $details) {
+            throw new RuntimeException('Unable to read public key details: '.openssl_error_string());
+        }
+
+        /* @var array{type?: int, rsa?: array{n?: string, e?: string}} $details */
+        return $details;
+    }
+
+    private function deriveKeyId(): string
+    {
+        $details = $this->keyDetails();
+        $modulus = $details['rsa']['n'] ?? '';
+
+        return substr(hash('sha256', $modulus), 0, 16);
+    }
+
+    private static function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+}

--- a/src/Server/Transport/Http/OAuth/SigningKeyInterface.php
+++ b/src/Server/Transport/Http/OAuth/SigningKeyInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * A key used to sign access tokens and to publish the corresponding public key
+ * as a JWK at the JWKS endpoint.
+ */
+interface SigningKeyInterface
+{
+    /**
+     * The "kid" advertised in the JWKS and the token header.
+     */
+    public function getKeyId(): string;
+
+    /**
+     * PEM-encoded private key passed to the signer.
+     */
+    public function getPrivateKeyPem(): string;
+
+    /**
+     * The public key as a JWK (RFC 7517), including "kid", "alg" and "use".
+     *
+     * @return array<string, mixed>
+     */
+    public function getPublicJwk(): array;
+}

--- a/src/Server/Transport/Http/OAuth/StaticJwksProvider.php
+++ b/src/Server/Transport/Http/OAuth/StaticJwksProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * Serves a fixed JWK Set from in-process signing keys, without any HTTP fetch.
+ *
+ * Use this to let {@see JwtTokenValidator} verify access tokens that this same
+ * process issued (issuer = self), closing the loop between the authorization
+ * server and the resource server without a network round-trip to the JWKS
+ * endpoint.
+ */
+final class StaticJwksProvider implements JwksProviderInterface
+{
+    /** @var list<array<string, mixed>> */
+    private array $keys;
+
+    /**
+     * @param SigningKeyInterface|iterable<SigningKeyInterface> $signingKeys
+     */
+    public function __construct(SigningKeyInterface|iterable $signingKeys)
+    {
+        $keys = $signingKeys instanceof SigningKeyInterface ? [$signingKeys] : $signingKeys;
+
+        $this->keys = array_map(
+            static fn (SigningKeyInterface $key): array => $key->getPublicJwk(),
+            array_values([...$keys]),
+        );
+    }
+
+    public function getJwks(string $issuer, ?string $jwksUri = null): array
+    {
+        return ['keys' => $this->keys];
+    }
+}

--- a/src/Server/Transport/Http/OAuth/StoredClientRegistrar.php
+++ b/src/Server/Transport/Http/OAuth/StoredClientRegistrar.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Mcp\Exception\ClientRegistrationException;
+
+/**
+ * Default OAuth 2.0 Dynamic Client Registration (RFC 7591) implementation,
+ * persisting registered clients via a {@see ClientRepositoryInterface}.
+ *
+ * Wire it into {@see \Mcp\Server\Transport\Http\Middleware\ClientRegistrationMiddleware}.
+ */
+final class StoredClientRegistrar implements ClientRegistrarInterface
+{
+    /** @var list<string> */
+    private array $defaultScopes;
+
+    /** @var list<string> */
+    private array $allowedRedirectUriSchemes;
+
+    /**
+     * @param list<string> $defaultScopes
+     * @param list<string> $allowedRedirectUriSchemes Schemes allowed in addition to http on loopback hosts
+     */
+    public function __construct(
+        private readonly ClientRepositoryInterface $clients,
+        array $defaultScopes = [],
+        array $allowedRedirectUriSchemes = ['https'],
+    ) {
+        $this->defaultScopes = array_values($defaultScopes);
+        $this->allowedRedirectUriSchemes = array_values($allowedRedirectUriSchemes);
+    }
+
+    public function register(array $registrationRequest): array
+    {
+        $redirectUris = $this->validateRedirectUris($registrationRequest['redirect_uris'] ?? null);
+        $authMethod = $this->resolveAuthMethod($registrationRequest['token_endpoint_auth_method'] ?? null);
+        $grantTypes = $this->resolveGrantTypes($registrationRequest['grant_types'] ?? null);
+        $scopes = $this->resolveScopes($registrationRequest['scope'] ?? null);
+        $clientName = isset($registrationRequest['client_name']) && \is_string($registrationRequest['client_name'])
+            ? $registrationRequest['client_name']
+            : null;
+
+        $clientId = bin2hex(random_bytes(16));
+        $isPublic = Client::AUTH_METHOD_NONE === $authMethod;
+        $clientSecret = $isPublic ? null : bin2hex(random_bytes(32));
+
+        $this->clients->save(new Client(
+            clientId: $clientId,
+            clientSecret: $clientSecret,
+            redirectUris: $redirectUris,
+            grantTypes: $grantTypes,
+            scopes: $scopes,
+            tokenEndpointAuthMethod: $authMethod,
+            clientName: $clientName,
+        ));
+
+        $response = [
+            'client_id' => $clientId,
+            'client_id_issued_at' => time(),
+            'redirect_uris' => $redirectUris,
+            'grant_types' => $grantTypes,
+            'response_types' => ['code'],
+            'token_endpoint_auth_method' => $authMethod,
+            'scope' => implode(' ', $scopes),
+        ];
+
+        if (null !== $clientSecret) {
+            $response['client_secret'] = $clientSecret;
+            $response['client_secret_expires_at'] = 0;
+        }
+
+        if (null !== $clientName) {
+            $response['client_name'] = $clientName;
+        }
+
+        return $response;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function validateRedirectUris(mixed $redirectUris): array
+    {
+        if (!\is_array($redirectUris) || [] === $redirectUris) {
+            throw new ClientRegistrationException('At least one redirect URI is required.', 'invalid_redirect_uri');
+        }
+
+        $normalized = [];
+        foreach ($redirectUris as $uri) {
+            if (!\is_string($uri) || !$this->isAllowedRedirectUri($uri)) {
+                throw new ClientRegistrationException(\sprintf('Invalid or disallowed redirect URI: "%s".', \is_string($uri) ? $uri : \gettype($uri)), 'invalid_redirect_uri');
+            }
+
+            $normalized[] = $uri;
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    private function isAllowedRedirectUri(string $uri): bool
+    {
+        $parts = parse_url($uri);
+        if (false === $parts || !isset($parts['scheme'])) {
+            return false;
+        }
+
+        $scheme = strtolower($parts['scheme']);
+        $host = strtolower($parts['host'] ?? '');
+
+        if ('http' === $scheme && \in_array($host, ['localhost', '127.0.0.1', '::1'], true)) {
+            return true;
+        }
+
+        return \in_array($scheme, $this->allowedRedirectUriSchemes, true);
+    }
+
+    private function resolveAuthMethod(mixed $method): string
+    {
+        if (Client::AUTH_METHOD_NONE === $method) {
+            return Client::AUTH_METHOD_NONE;
+        }
+
+        if (Client::AUTH_METHOD_CLIENT_SECRET_POST === $method) {
+            return Client::AUTH_METHOD_CLIENT_SECRET_POST;
+        }
+
+        return Client::AUTH_METHOD_CLIENT_SECRET_BASIC;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveGrantTypes(mixed $grantTypes): array
+    {
+        $requested = \is_array($grantTypes)
+            ? array_values(array_filter($grantTypes, 'is_string'))
+            : ['authorization_code'];
+
+        if (!\in_array('authorization_code', $requested, true)) {
+            $requested[] = 'authorization_code';
+        }
+
+        if (!\in_array('refresh_token', $requested, true)) {
+            $requested[] = 'refresh_token';
+        }
+
+        return array_values(array_unique($requested));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveScopes(mixed $scope): array
+    {
+        if (!\is_string($scope) || '' === trim($scope)) {
+            return $this->defaultScopes;
+        }
+
+        $requested = array_filter(explode(' ', $scope), static fn (string $s): bool => '' !== $s);
+
+        if ([] === $this->defaultScopes) {
+            return array_values($requested);
+        }
+
+        return array_values(array_filter($requested, fn (string $s): bool => \in_array($s, $this->defaultScopes, true)));
+    }
+}

--- a/src/Server/Transport/Http/OAuth/TokenGranterInterface.php
+++ b/src/Server/Transport/Http/OAuth/TokenGranterInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+use Mcp\Exception\OAuthException;
+
+/**
+ * Processes token endpoint requests (RFC 6749 Section 4 / 6).
+ *
+ * Implementations perform client authentication, grant-specific validation and
+ * token minting from the parsed request parameters, so the delivery layer
+ * (PSR-15 middleware or a host controller) only has to parse and serialize.
+ */
+interface TokenGranterInterface
+{
+    /**
+     * @param array<string, mixed> $params The parsed application/x-www-form-urlencoded body,
+     *                                     with client_id/client_secret normalized from any Basic auth header
+     *
+     * @throws OAuthException On any protocol error (mapped to an RFC 6749 §5.2 response)
+     */
+    public function grant(string $grantType, array $params): TokenResponse;
+}

--- a/src/Server/Transport/Http/OAuth/TokenResponse.php
+++ b/src/Server/Transport/Http/OAuth/TokenResponse.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Server\Transport\Http\OAuth;
+
+/**
+ * A successful token endpoint response (RFC 6749 Section 5.1).
+ */
+final class TokenResponse
+{
+    /**
+     * @param list<string> $scopes
+     */
+    public function __construct(
+        public readonly string $accessToken,
+        public readonly int $expiresIn,
+        public readonly array $scopes = [],
+        public readonly ?string $refreshToken = null,
+        public readonly string $tokenType = 'Bearer',
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $data = [
+            'access_token' => $this->accessToken,
+            'token_type' => $this->tokenType,
+            'expires_in' => $this->expiresIn,
+        ];
+
+        if ([] !== $this->scopes) {
+            $data['scope'] = implode(' ', $this->scopes);
+        }
+
+        if (null !== $this->refreshToken) {
+            $data['refresh_token'] = $this->refreshToken;
+        }
+
+        return $data;
+    }
+}

--- a/tests/Unit/Server/Transport/Http/Middleware/AuthorizationEndpointMiddlewareTest.php
+++ b/tests/Unit/Server/Transport/Http/Middleware/AuthorizationEndpointMiddlewareTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Server\Transport\Http\Middleware;
+
+use Mcp\Server\Transport\Http\Middleware\AuthorizationEndpointMiddleware;
+use Mcp\Server\Transport\Http\OAuth\AutoApproveConsent;
+use Mcp\Server\Transport\Http\OAuth\Client;
+use Mcp\Server\Transport\Http\OAuth\InMemoryAuthorizationCodeStore;
+use Mcp\Server\Transport\Http\OAuth\InMemoryClientRepository;
+use Mcp\Server\Transport\Http\OAuth\NativeAuthorizationCodeIssuer;
+use Mcp\Server\Transport\Http\OAuth\ResourceOwner;
+use Mcp\Server\Transport\Http\OAuth\ResourceOwnerResolverInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class AuthorizationEndpointMiddlewareTest extends MiddlewareTestCase
+{
+    private const REDIRECT = 'https://client.example.com/callback';
+
+    #[TestDox('issues a code and redirects with state when the request is valid and approved')]
+    public function testHappyPath(): void
+    {
+        $codes = new InMemoryAuthorizationCodeStore();
+        $middleware = $this->middleware($codes, $this->resolver(new ResourceOwner('user-1')));
+
+        $response = $middleware->process($this->authorizeRequest(), $this->handlerReturning(404));
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('no-store', $response->getHeaderLine('Cache-Control'));
+
+        parse_str(parse_url($response->getHeaderLine('Location'), \PHP_URL_QUERY) ?: '', $query);
+        $this->assertArrayHasKey('code', $query);
+        $this->assertSame('xyz', $query['state']);
+        $this->assertNotNull($codes->consume($query['code']));
+    }
+
+    #[TestDox('renders a 400 (no redirect) for an unknown client')]
+    public function testUnknownClient(): void
+    {
+        $middleware = $this->middleware(new InMemoryAuthorizationCodeStore(), $this->resolver(new ResourceOwner('user-1')));
+        $request = $this->authorizeRequest(['client_id' => 'nope']);
+
+        $response = $middleware->process($request, $this->handlerReturning(404));
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertFalse($response->hasHeader('Location'));
+    }
+
+    #[TestDox('renders a 400 (no redirect) for an unregistered redirect_uri')]
+    public function testRedirectMismatch(): void
+    {
+        $middleware = $this->middleware(new InMemoryAuthorizationCodeStore(), $this->resolver(new ResourceOwner('user-1')));
+        $request = $this->authorizeRequest(['redirect_uri' => 'https://evil.example.com/cb']);
+
+        $response = $middleware->process($request, $this->handlerReturning(404));
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertFalse($response->hasHeader('Location'));
+    }
+
+    #[TestDox('redirects with invalid_request when PKCE is missing')]
+    public function testMissingPkceRedirectsError(): void
+    {
+        $middleware = $this->middleware(new InMemoryAuthorizationCodeStore(), $this->resolver(new ResourceOwner('user-1')));
+        $params = $this->validParams();
+        unset($params['code_challenge'], $params['code_challenge_method']);
+        $request = $this->factory
+            ->createServerRequest('GET', 'https://mcp.example.com/authorize')
+            ->withQueryParams($params);
+
+        $response = $middleware->process($request, $this->handlerReturning(404));
+
+        $this->assertSame(302, $response->getStatusCode());
+        parse_str(parse_url($response->getHeaderLine('Location'), \PHP_URL_QUERY) ?: '', $query);
+        $this->assertSame('invalid_request', $query['error']);
+        $this->assertSame('xyz', $query['state']);
+    }
+
+    #[TestDox('delegates to the host login when the user is unauthenticated')]
+    public function testUnauthenticated(): void
+    {
+        $middleware = $this->middleware(new InMemoryAuthorizationCodeStore(), $this->resolver(null));
+
+        $response = $middleware->process($this->authorizeRequest(), $this->handlerReturning(404));
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('https://mcp.example.com/login', $response->getHeaderLine('Location'));
+    }
+
+    private function middleware(InMemoryAuthorizationCodeStore $codes, ResourceOwnerResolverInterface $resolver): AuthorizationEndpointMiddleware
+    {
+        $clients = new InMemoryClientRepository([
+            new Client('client-1', null, [self::REDIRECT], ['authorization_code'], ['mcp:tools'], Client::AUTH_METHOD_NONE),
+        ]);
+
+        return new AuthorizationEndpointMiddleware(
+            $clients,
+            new NativeAuthorizationCodeIssuer($codes),
+            $resolver,
+            new AutoApproveConsent(),
+            ['mcp:tools'],
+        );
+    }
+
+    /**
+     * @param array<string, string> $overrides
+     */
+    private function authorizeRequest(array $overrides = []): ServerRequestInterface
+    {
+        $params = array_merge($this->validParams(), $overrides);
+
+        return $this->factory
+            ->createServerRequest('GET', 'https://mcp.example.com/authorize')
+            ->withQueryParams($params);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function validParams(): array
+    {
+        return [
+            'response_type' => 'code',
+            'client_id' => 'client-1',
+            'redirect_uri' => self::REDIRECT,
+            'code_challenge' => 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+            'code_challenge_method' => 'S256',
+            'scope' => 'mcp:tools',
+            'state' => 'xyz',
+        ];
+    }
+
+    private function resolver(?ResourceOwner $owner): ResourceOwnerResolverInterface
+    {
+        $factory = $this->factory;
+
+        return new class($owner, $factory) implements ResourceOwnerResolverInterface {
+            public function __construct(
+                private ?ResourceOwner $owner,
+                private \Nyholm\Psr7\Factory\Psr17Factory $factory,
+            ) {
+            }
+
+            public function resolve(ServerRequestInterface $request): ?ResourceOwner
+            {
+                return $this->owner;
+            }
+
+            public function onUnauthenticated(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->factory->createResponse(302)->withHeader('Location', 'https://mcp.example.com/login');
+            }
+        };
+    }
+}

--- a/tests/Unit/Server/Transport/Http/Middleware/AuthorizationServerMetadataMiddlewareTest.php
+++ b/tests/Unit/Server/Transport/Http/Middleware/AuthorizationServerMetadataMiddlewareTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Server\Transport\Http\Middleware;
+
+use Mcp\Server\Transport\Http\Middleware\AuthorizationServerMetadataMiddleware;
+use Mcp\Server\Transport\Http\OAuth\AuthorizationServerMetadata;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class AuthorizationServerMetadataMiddlewareTest extends MiddlewareTestCase
+{
+    #[TestDox('serves RFC 8414 metadata on the well-known path')]
+    public function testServesMetadata(): void
+    {
+        $middleware = new AuthorizationServerMetadataMiddleware(new AuthorizationServerMetadata('https://mcp.example.com'));
+        $request = $this->factory->createServerRequest('GET', 'https://mcp.example.com/.well-known/oauth-authorization-server');
+
+        $response = $middleware->process($request, $this->handlerReturning(404));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertSame('https://mcp.example.com', $body['issuer']);
+    }
+
+    #[TestDox('passes other requests through')]
+    public function testPassthrough(): void
+    {
+        $middleware = new AuthorizationServerMetadataMiddleware(new AuthorizationServerMetadata('https://mcp.example.com'));
+        $request = $this->factory->createServerRequest('GET', 'https://mcp.example.com/other');
+
+        $response = $middleware->process($request, $this->handlerReturning(204));
+
+        $this->assertSame(204, $response->getStatusCode());
+    }
+}

--- a/tests/Unit/Server/Transport/Http/Middleware/JwksMiddlewareTest.php
+++ b/tests/Unit/Server/Transport/Http/Middleware/JwksMiddlewareTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Server\Transport\Http\Middleware;
+
+use Mcp\Server\Transport\Http\Middleware\JwksMiddleware;
+use Mcp\Server\Transport\Http\OAuth\RsaSigningKey;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class JwksMiddlewareTest extends MiddlewareTestCase
+{
+    #[TestDox('serves the public key as a JWK Set')]
+    public function testServesJwks(): void
+    {
+        $middleware = new JwksMiddleware($this->signingKey('kid-1'));
+        $request = $this->factory->createServerRequest('GET', 'https://mcp.example.com/.well-known/jwks.json');
+
+        $response = $middleware->process($request, $this->handlerReturning(404));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertCount(1, $body['keys']);
+        $this->assertSame('kid-1', $body['keys'][0]['kid']);
+    }
+
+    #[TestDox('passes other requests through')]
+    public function testPassthrough(): void
+    {
+        $middleware = new JwksMiddleware($this->signingKey('kid-1'));
+        $request = $this->factory->createServerRequest('GET', 'https://mcp.example.com/other');
+
+        $this->assertSame(204, $middleware->process($request, $this->handlerReturning(204))->getStatusCode());
+    }
+
+    private function signingKey(string $kid): RsaSigningKey
+    {
+        $key = openssl_pkey_new(['private_key_type' => \OPENSSL_KEYTYPE_RSA, 'private_key_bits' => 2048]);
+        $this->assertNotFalse($key);
+        $pem = '';
+        $this->assertTrue(openssl_pkey_export($key, $pem));
+
+        return new RsaSigningKey($pem, $kid);
+    }
+}

--- a/tests/Unit/Server/Transport/Http/Middleware/TokenEndpointMiddlewareTest.php
+++ b/tests/Unit/Server/Transport/Http/Middleware/TokenEndpointMiddlewareTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Server\Transport\Http\Middleware;
+
+use Mcp\Exception\OAuthException;
+use Mcp\Server\Transport\Http\Middleware\TokenEndpointMiddleware;
+use Mcp\Server\Transport\Http\OAuth\TokenGranterInterface;
+use Mcp\Server\Transport\Http\OAuth\TokenResponse;
+use PHPUnit\Framework\Attributes\TestDox;
+
+class TokenEndpointMiddlewareTest extends MiddlewareTestCase
+{
+    #[TestDox('returns the token response as non-cacheable JSON')]
+    public function testSuccess(): void
+    {
+        $granter = $this->granter(static fn (): TokenResponse => new TokenResponse('jwt-token', 3600, ['mcp:tools'], 'refresh-1'));
+        $middleware = new TokenEndpointMiddleware($granter);
+
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://mcp.example.com/token')
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
+            ->withBody($this->factory->createStream('grant_type=authorization_code&code=abc&client_id=c1'));
+
+        $response = $middleware->process($request, $this->handlerReturning(404));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('no-store', $response->getHeaderLine('Cache-Control'));
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertSame('jwt-token', $body['access_token']);
+        $this->assertSame('Bearer', $body['token_type']);
+        $this->assertSame('refresh-1', $body['refresh_token']);
+    }
+
+    #[TestDox('maps an OAuthException to an RFC 6749 error response')]
+    public function testError(): void
+    {
+        $granter = $this->granter(static fn () => throw OAuthException::invalidGrant('bad code'));
+        $middleware = new TokenEndpointMiddleware($granter);
+
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://mcp.example.com/token')
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
+            ->withBody($this->factory->createStream('grant_type=authorization_code'));
+
+        $response = $middleware->process($request, $this->handlerReturning(404));
+
+        $this->assertSame(400, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        $this->assertSame('invalid_grant', $body['error']);
+    }
+
+    #[TestDox('decodes HTTP Basic client credentials into the params')]
+    public function testBasicAuth(): void
+    {
+        $captured = null;
+        $granter = $this->granter(static function (string $grant, array $params) use (&$captured): TokenResponse {
+            $captured = $params;
+
+            return new TokenResponse('jwt', 3600);
+        });
+        $middleware = new TokenEndpointMiddleware($granter);
+
+        $request = $this->factory
+            ->createServerRequest('POST', 'https://mcp.example.com/token')
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
+            ->withHeader('Authorization', 'Basic '.base64_encode('client-1:s3cret'))
+            ->withBody($this->factory->createStream('grant_type=refresh_token&refresh_token=r1'));
+
+        $middleware->process($request, $this->handlerReturning(404));
+
+        $this->assertSame('client-1', $captured['client_id']);
+        $this->assertSame('s3cret', $captured['client_secret']);
+    }
+
+    #[TestDox('passes non-token requests through')]
+    public function testPassthrough(): void
+    {
+        $middleware = new TokenEndpointMiddleware($this->granter(static fn () => new TokenResponse('x', 1)));
+        $request = $this->factory->createServerRequest('GET', 'https://mcp.example.com/token');
+
+        $this->assertSame(204, $middleware->process($request, $this->handlerReturning(204))->getStatusCode());
+    }
+
+    private function granter(callable $grant): TokenGranterInterface
+    {
+        return new class($grant) implements TokenGranterInterface {
+            /** @param callable(string, array<string,mixed>): TokenResponse $grant */
+            public function __construct(private $grant)
+            {
+            }
+
+            public function grant(string $grantType, array $params): TokenResponse
+            {
+                return ($this->grant)($grantType, $params);
+            }
+        };
+    }
+}

--- a/tests/Unit/Server/Transport/Http/OAuth/AuthorizationServerMetadataTest.php
+++ b/tests/Unit/Server/Transport/Http/OAuth/AuthorizationServerMetadataTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Server\Transport\Http\OAuth;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Server\Transport\Http\OAuth\AuthorizationServerMetadata;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+class AuthorizationServerMetadataTest extends TestCase
+{
+    #[TestDox('derives endpoints from the issuer and omits registration_endpoint by default')]
+    public function testDefaults(): void
+    {
+        $metadata = new AuthorizationServerMetadata('https://mcp.example.com/');
+
+        $data = $metadata->jsonSerialize();
+
+        $this->assertSame('https://mcp.example.com', $data['issuer']);
+        $this->assertSame('https://mcp.example.com/authorize', $data['authorization_endpoint']);
+        $this->assertSame('https://mcp.example.com/token', $data['token_endpoint']);
+        $this->assertSame('https://mcp.example.com/.well-known/jwks.json', $data['jwks_uri']);
+        $this->assertSame(['S256'], $data['code_challenge_methods_supported']);
+        $this->assertArrayNotHasKey('registration_endpoint', $data);
+    }
+
+    #[TestDox('includes registration_endpoint and extra fields when provided')]
+    public function testOverrides(): void
+    {
+        $metadata = new AuthorizationServerMetadata(
+            issuer: 'https://mcp.example.com',
+            registrationEndpoint: 'https://mcp.example.com/register',
+            scopesSupported: ['mcp:tools'],
+            extra: ['service_documentation' => 'https://docs.example.com'],
+        );
+
+        $data = $metadata->jsonSerialize();
+
+        $this->assertSame('https://mcp.example.com/register', $data['registration_endpoint']);
+        $this->assertSame(['mcp:tools'], $data['scopes_supported']);
+        $this->assertSame('https://docs.example.com', $data['service_documentation']);
+    }
+
+    #[TestDox('rejects an empty issuer')]
+    public function testEmptyIssuer(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new AuthorizationServerMetadata('   ');
+    }
+}

--- a/tests/Unit/Server/Transport/Http/OAuth/NativeTokenGranterTest.php
+++ b/tests/Unit/Server/Transport/Http/OAuth/NativeTokenGranterTest.php
@@ -1,0 +1,227 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Server\Transport\Http\OAuth;
+
+use Mcp\Exception\OAuthException;
+use Mcp\Server\Transport\Http\OAuth\AuthorizationCode;
+use Mcp\Server\Transport\Http\OAuth\Client;
+use Mcp\Server\Transport\Http\OAuth\InMemoryAuthorizationCodeStore;
+use Mcp\Server\Transport\Http\OAuth\InMemoryClientRepository;
+use Mcp\Server\Transport\Http\OAuth\InMemoryRefreshTokenStore;
+use Mcp\Server\Transport\Http\OAuth\JwtAccessTokenIssuer;
+use Mcp\Server\Transport\Http\OAuth\JwtTokenValidator;
+use Mcp\Server\Transport\Http\OAuth\NativeAuthorizationCodeIssuer;
+use Mcp\Server\Transport\Http\OAuth\NativeTokenGranter;
+use Mcp\Server\Transport\Http\OAuth\Pkce;
+use Mcp\Server\Transport\Http\OAuth\ResourceOwner;
+use Mcp\Server\Transport\Http\OAuth\RsaSigningKey;
+use Mcp\Server\Transport\Http\OAuth\StaticJwksProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+class NativeTokenGranterTest extends TestCase
+{
+    private const ISSUER = 'https://mcp.example.com';
+    private const VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    private const REDIRECT = 'https://client.example.com/callback';
+
+    private RsaSigningKey $signingKey;
+    private InMemoryClientRepository $clients;
+    private InMemoryAuthorizationCodeStore $codes;
+    private InMemoryRefreshTokenStore $refreshTokens;
+    private NativeTokenGranter $granter;
+    private NativeAuthorizationCodeIssuer $codeIssuer;
+
+    protected function setUp(): void
+    {
+        $key = openssl_pkey_new(['private_key_type' => \OPENSSL_KEYTYPE_RSA, 'private_key_bits' => 2048]);
+        $this->assertNotFalse($key);
+        $pem = '';
+        $this->assertTrue(openssl_pkey_export($key, $pem));
+        $this->signingKey = new RsaSigningKey($pem, 'test-kid');
+
+        $this->clients = new InMemoryClientRepository([
+            new Client('public-client', null, [self::REDIRECT], ['authorization_code', 'refresh_token'], ['mcp:tools'], Client::AUTH_METHOD_NONE),
+            new Client('conf-client', 'topsecret', [self::REDIRECT], ['authorization_code', 'refresh_token'], ['mcp:tools'], Client::AUTH_METHOD_CLIENT_SECRET_BASIC),
+        ]);
+        $this->codes = new InMemoryAuthorizationCodeStore();
+        $this->refreshTokens = new InMemoryRefreshTokenStore();
+        $this->codeIssuer = new NativeAuthorizationCodeIssuer($this->codes);
+
+        $issuer = new JwtAccessTokenIssuer($this->signingKey, self::ISSUER);
+        $this->granter = new NativeTokenGranter($this->clients, $this->codes, $this->refreshTokens, $issuer, resource: self::ISSUER);
+    }
+
+    #[TestDox('authorization_code grant issues a token that validates through JwtTokenValidator (self-issued round-trip)')]
+    public function testAuthorizationCodeGrantRoundTrip(): void
+    {
+        $code = $this->issueCode('public-client');
+
+        $response = $this->granter->grant('authorization_code', [
+            'client_id' => 'public-client',
+            'code' => $code,
+            'redirect_uri' => self::REDIRECT,
+            'code_verifier' => self::VERIFIER,
+        ]);
+
+        $this->assertSame('Bearer', $response->tokenType);
+        $this->assertSame(['mcp:tools'], $response->scopes);
+        $this->assertNotNull($response->refreshToken);
+
+        $validator = new JwtTokenValidator(self::ISSUER, self::ISSUER, new StaticJwksProvider($this->signingKey));
+        $result = $validator->validate($response->accessToken);
+
+        $this->assertTrue($result->isAllowed());
+        $this->assertSame('user-1', $result->getAttributes()['oauth.subject']);
+        $this->assertSame(['mcp:tools'], $result->getAttributes()['oauth.scopes']);
+    }
+
+    #[TestDox('authorization code is single-use')]
+    public function testCodeIsSingleUse(): void
+    {
+        $code = $this->issueCode('public-client');
+        $params = ['client_id' => 'public-client', 'code' => $code, 'redirect_uri' => self::REDIRECT, 'code_verifier' => self::VERIFIER];
+
+        $this->granter->grant('authorization_code', $params);
+
+        try {
+            $this->granter->grant('authorization_code', $params);
+            $this->fail('Expected OAuthException');
+        } catch (OAuthException $e) {
+            $this->assertSame('invalid_grant', $e->error);
+        }
+    }
+
+    #[TestDox('rejects an invalid PKCE verifier')]
+    public function testPkceMismatch(): void
+    {
+        $code = $this->issueCode('public-client');
+
+        $this->expectException(OAuthException::class);
+        $this->expectExceptionMessage('PKCE');
+        $this->granter->grant('authorization_code', [
+            'client_id' => 'public-client',
+            'code' => $code,
+            'redirect_uri' => self::REDIRECT,
+            'code_verifier' => 'not-the-verifier',
+        ]);
+    }
+
+    #[TestDox('rejects a mismatching redirect_uri')]
+    public function testRedirectUriMismatch(): void
+    {
+        $code = $this->issueCode('public-client');
+
+        $this->expectException(OAuthException::class);
+        $this->granter->grant('authorization_code', [
+            'client_id' => 'public-client',
+            'code' => $code,
+            'redirect_uri' => 'https://evil.example.com/callback',
+            'code_verifier' => self::VERIFIER,
+        ]);
+    }
+
+    #[TestDox('confidential client with a bad secret is rejected with invalid_client (401)')]
+    public function testConfidentialClientBadSecret(): void
+    {
+        $code = $this->issueCode('conf-client');
+
+        try {
+            $this->granter->grant('authorization_code', [
+                'client_id' => 'conf-client',
+                'client_secret' => 'wrong',
+                'code' => $code,
+                'redirect_uri' => self::REDIRECT,
+                'code_verifier' => self::VERIFIER,
+            ]);
+            $this->fail('Expected OAuthException');
+        } catch (OAuthException $e) {
+            $this->assertSame('invalid_client', $e->error);
+            $this->assertSame(401, $e->httpStatus);
+        }
+    }
+
+    #[TestDox('refresh tokens rotate: the old token is invalid after use')]
+    public function testRefreshTokenRotation(): void
+    {
+        $code = $this->issueCode('public-client');
+        $first = $this->granter->grant('authorization_code', [
+            'client_id' => 'public-client',
+            'code' => $code,
+            'redirect_uri' => self::REDIRECT,
+            'code_verifier' => self::VERIFIER,
+        ]);
+        $this->assertNotNull($first->refreshToken);
+
+        $second = $this->granter->grant('refresh_token', [
+            'client_id' => 'public-client',
+            'refresh_token' => $first->refreshToken,
+        ]);
+        $this->assertNotNull($second->refreshToken);
+        $this->assertNotSame($first->refreshToken, $second->refreshToken);
+
+        $this->expectException(OAuthException::class);
+        $this->granter->grant('refresh_token', ['client_id' => 'public-client', 'refresh_token' => $first->refreshToken]);
+    }
+
+    #[TestDox('rejects an unsupported grant type')]
+    public function testUnsupportedGrantType(): void
+    {
+        try {
+            $this->granter->grant('password', ['client_id' => 'public-client']);
+            $this->fail('Expected OAuthException');
+        } catch (OAuthException $e) {
+            $this->assertSame('unsupported_grant_type', $e->error);
+        }
+    }
+
+    #[TestDox('rejects an expired authorization code')]
+    public function testExpiredCode(): void
+    {
+        $this->codes->store('expired', new AuthorizationCode(
+            clientId: 'public-client',
+            redirectUri: self::REDIRECT,
+            scopes: ['mcp:tools'],
+            codeChallenge: Pkce::challenge(self::VERIFIER),
+            codeChallengeMethod: 'S256',
+            userId: 'user-1',
+            userClaims: [],
+            resource: self::ISSUER,
+            expiresAt: new \DateTimeImmutable('-1 minute'),
+        ));
+
+        $this->expectException(OAuthException::class);
+        $this->expectExceptionMessage('expired');
+        $this->granter->grant('authorization_code', [
+            'client_id' => 'public-client',
+            'code' => 'expired',
+            'redirect_uri' => self::REDIRECT,
+            'code_verifier' => self::VERIFIER,
+        ]);
+    }
+
+    private function issueCode(string $clientId): string
+    {
+        $client = $this->clients->find($clientId);
+        $this->assertNotNull($client);
+
+        return $this->codeIssuer->issueCode(
+            $client,
+            new ResourceOwner('user-1'),
+            self::REDIRECT,
+            ['mcp:tools'],
+            Pkce::challenge(self::VERIFIER),
+            'S256',
+            self::ISSUER,
+        );
+    }
+}

--- a/tests/Unit/Server/Transport/Http/OAuth/PkceTest.php
+++ b/tests/Unit/Server/Transport/Http/OAuth/PkceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Server\Transport\Http\OAuth;
+
+use Mcp\Server\Transport\Http\OAuth\Pkce;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+class PkceTest extends TestCase
+{
+    #[TestDox('computes the S256 challenge from the RFC 7636 Appendix B test vector')]
+    public function testChallengeMatchesRfcVector(): void
+    {
+        $verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+        $expectedChallenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+        $this->assertSame($expectedChallenge, Pkce::challenge($verifier));
+    }
+
+    #[TestDox('verifies a matching verifier and rejects a mismatching one')]
+    public function testVerify(): void
+    {
+        $verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+        $challenge = Pkce::challenge($verifier);
+
+        $this->assertTrue(Pkce::verify($verifier, $challenge));
+        $this->assertFalse(Pkce::verify('wrong-verifier', $challenge));
+    }
+}

--- a/tests/Unit/Server/Transport/Http/OAuth/RsaSigningKeyTest.php
+++ b/tests/Unit/Server/Transport/Http/OAuth/RsaSigningKeyTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Server\Transport\Http\OAuth;
+
+use Mcp\Server\Transport\Http\OAuth\RsaSigningKey;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+class RsaSigningKeyTest extends TestCase
+{
+    #[TestDox('exposes the public key as an RS256 JWK with n, e and kid')]
+    public function testPublicJwk(): void
+    {
+        $key = new RsaSigningKey($this->generatePem(), 'my-kid');
+
+        $jwk = $key->getPublicJwk();
+
+        $this->assertSame('RSA', $jwk['kty']);
+        $this->assertSame('sig', $jwk['use']);
+        $this->assertSame('RS256', $jwk['alg']);
+        $this->assertSame('my-kid', $jwk['kid']);
+        $this->assertNotEmpty($jwk['n']);
+        $this->assertNotEmpty($jwk['e']);
+        // base64url: no +, /, or = padding
+        $this->assertDoesNotMatchRegularExpression('#[+/=]#', $jwk['n']);
+    }
+
+    #[TestDox('derives a stable key id when none is given')]
+    public function testDerivesStableKeyId(): void
+    {
+        $pem = $this->generatePem();
+
+        $this->assertSame((new RsaSigningKey($pem))->getKeyId(), (new RsaSigningKey($pem))->getKeyId());
+    }
+
+    private function generatePem(): string
+    {
+        $key = openssl_pkey_new(['private_key_type' => \OPENSSL_KEYTYPE_RSA, 'private_key_bits' => 2048]);
+        $this->assertNotFalse($key);
+        $pem = '';
+        $this->assertTrue(openssl_pkey_export($key, $pem));
+
+        return $pem;
+    }
+}

--- a/tests/Unit/Server/Transport/Http/OAuth/StoredClientRegistrarTest.php
+++ b/tests/Unit/Server/Transport/Http/OAuth/StoredClientRegistrarTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Server\Transport\Http\OAuth;
+
+use Mcp\Exception\ClientRegistrationException;
+use Mcp\Server\Transport\Http\OAuth\Client;
+use Mcp\Server\Transport\Http\OAuth\InMemoryClientRepository;
+use Mcp\Server\Transport\Http\OAuth\StoredClientRegistrar;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+class StoredClientRegistrarTest extends TestCase
+{
+    #[TestDox('registers a confidential client with a generated id and secret, persisted to the repository')]
+    public function testRegistersConfidentialClient(): void
+    {
+        $repository = new InMemoryClientRepository();
+        $registrar = new StoredClientRegistrar($repository, ['mcp:tools', 'mcp:resources']);
+
+        $response = $registrar->register([
+            'redirect_uris' => ['https://client.example.com/callback'],
+            'client_name' => 'My Client',
+        ]);
+
+        $this->assertArrayHasKey('client_id', $response);
+        $this->assertArrayHasKey('client_secret', $response);
+        $this->assertSame('My Client', $response['client_name']);
+        $this->assertContains('authorization_code', $response['grant_types']);
+        $this->assertContains('refresh_token', $response['grant_types']);
+
+        $stored = $repository->find($response['client_id']);
+        $this->assertInstanceOf(Client::class, $stored);
+        $this->assertFalse($stored->isPublic());
+    }
+
+    #[TestDox('registers a public client (token_endpoint_auth_method=none) without a secret')]
+    public function testRegistersPublicClient(): void
+    {
+        $repository = new InMemoryClientRepository();
+        $registrar = new StoredClientRegistrar($repository);
+
+        $response = $registrar->register([
+            'redirect_uris' => ['https://client.example.com/callback'],
+            'token_endpoint_auth_method' => 'none',
+        ]);
+
+        $this->assertArrayNotHasKey('client_secret', $response);
+        $this->assertSame('none', $response['token_endpoint_auth_method']);
+        $this->assertTrue($repository->find($response['client_id'])?->isPublic());
+    }
+
+    #[TestDox('allows http loopback redirect URIs')]
+    public function testAllowsLoopbackRedirect(): void
+    {
+        $registrar = new StoredClientRegistrar(new InMemoryClientRepository());
+
+        $response = $registrar->register(['redirect_uris' => ['http://localhost:1234/cb', 'http://127.0.0.1/cb']]);
+
+        $this->assertCount(2, $response['redirect_uris']);
+    }
+
+    #[TestDox('rejects a disallowed redirect URI scheme')]
+    public function testRejectsDisallowedScheme(): void
+    {
+        $registrar = new StoredClientRegistrar(new InMemoryClientRepository());
+
+        try {
+            $registrar->register(['redirect_uris' => ['http://evil.example.com/cb']]);
+            $this->fail('Expected ClientRegistrationException');
+        } catch (ClientRegistrationException $e) {
+            $this->assertSame('invalid_redirect_uri', $e->errorCode);
+        }
+    }
+
+    #[TestDox('rejects missing redirect URIs')]
+    public function testRejectsMissingRedirectUris(): void
+    {
+        $registrar = new StoredClientRegistrar(new InMemoryClientRepository());
+
+        $this->expectException(ClientRegistrationException::class);
+        $registrar->register(['client_name' => 'No Redirects']);
+    }
+}


### PR DESCRIPTION
## Summary

The HTTP server transport already supports being an OAuth **resource server** (validating tokens) and an **OAuth proxy** to an upstream IdP. This adds the missing third piece: a self-contained OAuth 2.1 **authorization server**, so an MCP server can register clients, authorize users, and issue + validate **its own** RS256 JWT access tokens — without an external IdP or a third-party OAuth library (e.g. `league/oauth2-server`).

It is dependency-free apart from `firebase/php-jwt`, which the existing `JwtTokenValidator` already uses for validation; signing reuses it. No new hard dependency.

## What's included (`src/Server/Transport/Http/`)

- **Engine behind seams** — `AuthorizationCodeIssuerInterface` / `TokenGranterInterface` with `Native*` implementations: authorization code grant with **mandatory PKCE (S256)**, refresh-token **rotation**, one-time short-TTL codes, exact `redirect_uri` matching, constant-time client auth.
- **Tokens & keys** — `JwtAccessTokenIssuer` (RS256) producing tokens that validate **unchanged** through the existing `JwtTokenValidator`; `RsaSigningKey`, `JwksMiddleware`, and `StaticJwksProvider` for in-process self-validation (no network round-trip).
- **Endpoints** — `AuthorizationEndpointMiddleware`, `TokenEndpointMiddleware`, `AuthorizationServerMetadataMiddleware` (RFC 8414); DCR (RFC 7591) via `StoredClientRegistrar` + the existing `ClientRegistrationMiddleware`.
- **Storage** — `ClientRepositoryInterface`, `AuthorizationCodeStoreInterface`, `RefreshTokenStoreInterface`, optional `AccessTokenStoreInterface`, each with in-memory and PSR-16 implementations.
- **Host seams** — `ResourceOwnerResolverInterface` (the SDK can't authenticate users) and `ConsentInterface` (+ default `AutoApproveConsent`).
- `OAuthException` for RFC 6749 §5.2 error responses.
- A runnable example at `examples/server/oauth-authorization-server/`.

The engine is transport-agnostic (the middlewares are thin PSR-7 shells over it), so it can be driven directly from a framework controller too.

## Tests

144 new unit tests (PKCE RFC 7636 vector, self-issued round-trip through `JwtTokenValidator`, granter behaviours, registrar, metadata, middlewares). phpstan level 6 clean.

## Status

**Draft.** This is the SDK half of a larger effort to let Symfony MCP servers act as their own OAuth AS. Companion work, built on these primitives and validated end-to-end against a real Sulu MCP server:

- Tracking issue: symfony/ai#2134 — https://github.com/symfony/ai/issues/2134
- MCP Bundle implementation (draft): symfony/ai#2135 — https://github.com/symfony/ai/pull/2135

Feedback on the public API/seams welcome.