### PR TITLE
Preserve custom domain on docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,3 +33,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./.phpdoc/build
           enable_jekyll: false
+          cname: php.sdk.modelcontextprotocol.io


### PR DESCRIPTION
The docs deploy overwrites the `gh-pages` branch on every release, wiping the `CNAME` file and dropping the custom domain. Set the `cname` option on `peaceiris/actions-gh-pages` so `php.sdk.modelcontextprotocol.io` is rewritten on each deploy.