### PR TITLE
[Server] Reject malformed MCP session ID headers

### DIFF
--- a/src/Server/Transport/StreamableHttpTransport.php
+++ b/src/Server/Transport/StreamableHttpTransport.php
@@ -24,7 +24,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Uid\Exception\InvalidArgumentException as UidInvalidArgumentException;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -304,7 +303,8 @@ class StreamableHttpTransport extends BaseTransport
 
         try {
             $this->sessionId = $sessionIdString ? Uuid::fromString($sessionIdString) : null;
-        } catch (UidInvalidArgumentException) {
+            // Symfony UID 5.4/6.4 throw the global parent; newer versions throw a namespaced subclass.
+        } catch (\InvalidArgumentException) {
             return $this->createErrorResponse(Error::forInvalidRequest(self::SESSION_HEADER.' header must be a valid UUID.'), 400);
         }
 

--- a/src/Server/Transport/StreamableHttpTransport.php
+++ b/src/Server/Transport/StreamableHttpTransport.php
@@ -294,8 +294,18 @@ class StreamableHttpTransport extends BaseTransport
     private function handleRequest(ServerRequestInterface $request): ResponseInterface
     {
         $this->request = $request;
-        $sessionIdString = $request->getHeaderLine(self::SESSION_HEADER);
-        $this->sessionId = $sessionIdString ? Uuid::fromString($sessionIdString) : null;
+        $sessionIdHeaders = $request->getHeader(self::SESSION_HEADER);
+        if (\count($sessionIdHeaders) > 1) {
+            return $this->createErrorResponse(Error::forInvalidRequest(self::SESSION_HEADER.' header must not be repeated.'), 400);
+        }
+
+        $sessionIdString = $sessionIdHeaders[0] ?? '';
+
+        try {
+            $this->sessionId = $sessionIdString ? Uuid::fromString($sessionIdString) : null;
+        } catch (\InvalidArgumentException) {
+            return $this->createErrorResponse(Error::forInvalidRequest(self::SESSION_HEADER.' header must be a valid UUID.'), 400);
+        }
 
         return match ($request->getMethod()) {
             'OPTIONS' => $this->handleOptionsRequest(),

--- a/src/Server/Transport/StreamableHttpTransport.php
+++ b/src/Server/Transport/StreamableHttpTransport.php
@@ -24,6 +24,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Uid\Exception\InvalidArgumentException as UidInvalidArgumentException;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -303,7 +304,7 @@ class StreamableHttpTransport extends BaseTransport
 
         try {
             $this->sessionId = $sessionIdString ? Uuid::fromString($sessionIdString) : null;
-        } catch (\InvalidArgumentException) {
+        } catch (UidInvalidArgumentException) {
             return $this->createErrorResponse(Error::forInvalidRequest(self::SESSION_HEADER.' header must be a valid UUID.'), 400);
         }
 

--- a/tests/Unit/Server/Transport/StreamableHttpTransportTest.php
+++ b/tests/Unit/Server/Transport/StreamableHttpTransportTest.php
@@ -85,6 +85,39 @@ final class StreamableHttpTransportTest extends TestCase
         $this->assertSame(400, $response->getStatusCode());
     }
 
+    #[TestDox('malformed MCP session IDs are rejected as bad requests')]
+    public function testMalformedSessionIdHeaderReturnsBadRequest(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('POST', 'http://localhost/')
+            ->withHeader('Host', 'localhost')
+            ->withHeader(StreamableHttpTransport::SESSION_HEADER, '{"not":"a-token"}');
+
+        $transport = new StreamableHttpTransport($request, $this->factory, $this->factory);
+
+        $response = $transport->listen();
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertStringContainsString(StreamableHttpTransport::SESSION_HEADER, (string) $response->getBody());
+    }
+
+    #[TestDox('duplicate MCP session ID headers are rejected as bad requests')]
+    public function testDuplicateSessionIdHeadersReturnBadRequest(): void
+    {
+        $request = $this->factory
+            ->createServerRequest('POST', 'http://localhost/')
+            ->withHeader('Host', 'localhost')
+            ->withHeader(StreamableHttpTransport::SESSION_HEADER, '2fb587fc-593f-47ce-9d9a-9c06f2b907a3')
+            ->withAddedHeader(StreamableHttpTransport::SESSION_HEADER, '5e583da8-a677-4446-b723-4ddbe00fda62');
+
+        $transport = new StreamableHttpTransport($request, $this->factory, $this->factory);
+
+        $response = $transport->listen();
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertStringContainsString('must not be repeated', (string) $response->getBody());
+    }
+
     #[TestDox('explicit empty middleware list disables defaults and emits a warning log')]
     public function testEmptyMiddlewareListDisablesDefaultsAndWarns(): void
     {


### PR DESCRIPTION
## Summary

Fixes #380.

Malformed or repeated `Mcp-Session-Id` request headers currently reach UUID parsing inside `StreamableHttpTransport`, so client-supplied bad session metadata can surface as an internal server error.

## Changes

- Reject repeated `Mcp-Session-Id` headers with `400 Bad Request`.
- Reject malformed single `Mcp-Session-Id` values with `400 Bad Request`.
- Keep valid, missing, and existing stale-session handling on the existing paths.
- Add regression coverage for malformed and duplicate session header inputs.

## Verification

Focused regressions were also run for the malformed and duplicate session-id header cases.

```bash
make unit-tests
make phpstan
git diff --check
```

## Risk

This is limited to invalid Streamable HTTP session-id request metadata. Valid session ids continue to be parsed as UUIDs, missing session ids still flow through the existing request handling, and well-formed but stale session ids still return the existing not-found response.
