### PR TITLE
[Server] Fix completion/complete crash for plain ref/resource

### DIFF
--- a/src/Server/Handler/Request/CompletionCompleteHandler.php
+++ b/src/Server/Handler/Request/CompletionCompleteHandler.php
@@ -12,6 +12,7 @@
 namespace Mcp\Server\Handler\Request;
 
 use Mcp\Capability\Completion\ProviderInterface;
+use Mcp\Capability\Registry\ResourceTemplateReference;
 use Mcp\Capability\RegistryInterface;
 use Mcp\Exception\PromptNotFoundException;
 use Mcp\Exception\ResourceNotFoundException;
@@ -56,12 +57,11 @@ final class CompletionCompleteHandler implements RequestHandlerInterface
         $value = $request->argument['value'] ?? '';
 
         try {
-            $reference = match (true) {
-                $request->ref instanceof PromptReference => $this->registry->getPrompt($request->ref->name),
-                $request->ref instanceof ResourceReference => $this->registry->getResource($request->ref->uri),
+            $providers = match (true) {
+                $request->ref instanceof PromptReference => $this->registry->getPrompt($request->ref->name)->completionProviders,
+                $request->ref instanceof ResourceReference => $this->resourceCompletionProviders($request->ref->uri),
             };
 
-            $providers = $reference->completionProviders;
             $provider = $providers[$name] ?? null;
             if (null === $provider) {
                 return new Response($request->getId(), new CompletionCompleteResult([]));
@@ -89,5 +89,15 @@ final class CompletionCompleteHandler implements RequestHandlerInterface
         } catch (\Throwable $e) {
             return Error::forInternalError('Error while handling completion request', $request->getId());
         }
+    }
+
+    /**
+     * @return array<string, class-string|object>
+     */
+    private function resourceCompletionProviders(string $uri): array
+    {
+        $reference = $this->registry->getResource($uri);
+
+        return $reference instanceof ResourceTemplateReference ? $reference->completionProviders : [];
     }
 }

--- a/tests/Unit/Server/Handler/Request/CompletionCompleteHandlerTest.php
+++ b/tests/Unit/Server/Handler/Request/CompletionCompleteHandlerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Server\Handler\Request;
+
+use Mcp\Capability\Registry\ResourceReference;
+use Mcp\Capability\Registry\ResourceTemplateReference;
+use Mcp\Capability\RegistryInterface;
+use Mcp\Schema\JsonRpc\Response;
+use Mcp\Schema\Request\CompletionCompleteRequest;
+use Mcp\Schema\ResourceTemplate;
+use Mcp\Schema\Result\CompletionCompleteResult;
+use Mcp\Server\Handler\Request\CompletionCompleteHandler;
+use Mcp\Server\Session\SessionInterface;
+use Mcp\Tests\Unit\Capability\Attribute\CompletionProviderFixture;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CompletionCompleteHandlerTest extends TestCase
+{
+    private CompletionCompleteHandler $handler;
+    private RegistryInterface&MockObject $registry;
+    private SessionInterface&MockObject $session;
+
+    protected function setUp(): void
+    {
+        $this->registry = $this->createMock(RegistryInterface::class);
+        $this->session = $this->createMock(SessionInterface::class);
+
+        $this->handler = new CompletionCompleteHandler($this->registry);
+    }
+
+    public function testReturnsEmptyCompletionForResourceWithoutTemplate(): void
+    {
+        $uri = 'file://static/readme.txt';
+        $request = $this->createCompletionRequest($uri, ['name' => 'arg', 'value' => 'a']);
+
+        $this->registry
+            ->expects($this->once())
+            ->method('getResource')
+            ->with($uri)
+            ->willReturn($this->createMock(ResourceReference::class));
+
+        $response = $this->handler->handle($request, $this->session);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals($request->getId(), $response->id);
+        $this->assertEquals(new CompletionCompleteResult([]), $response->result);
+    }
+
+    public function testReturnsCompletionsForResourceTemplate(): void
+    {
+        $uri = 'file://users/alice';
+        $request = $this->createCompletionRequest($uri, ['name' => 'id', 'value' => 'al']);
+
+        $templateReference = new ResourceTemplateReference(
+            new ResourceTemplate('file://users/{id}', 'user'),
+            static fn () => null,
+            ['id' => new CompletionProviderFixture()],
+        );
+
+        $this->registry
+            ->expects($this->once())
+            ->method('getResource')
+            ->with($uri)
+            ->willReturn($templateReference);
+
+        $response = $this->handler->handle($request, $this->session);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(new CompletionCompleteResult(['alpha'], 1, false), $response->result);
+    }
+
+    /**
+     * @param array{ name: string, value: string } $argument
+     */
+    private function createCompletionRequest(string $uri, array $argument): CompletionCompleteRequest
+    {
+        return CompletionCompleteRequest::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => CompletionCompleteRequest::getMethod(),
+            'id' => 'test-completion-'.uniqid(),
+            'params' => [
+                'ref' => ['type' => 'ref/resource', 'uri' => $uri],
+                'argument' => $argument,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
Fixes #387.

`completion/complete` crashes for a `ref/resource` pointing at a plain resource: `getResource()` returns a `ResourceReference`, but the handler reads `$reference->completionProviders`, which only `PromptReference` and `ResourceTemplateReference` declare.

Providers now come from the prompt or the matched resource template; a resource with no template yields an empty completion result. Added a handler test for both the plain-resource regression and the resource-template path.
