### PR TITLE
[Server] Defer element loading to first registry read

### DIFF
--- a/src/Capability/Registry.php
+++ b/src/Capability/Registry.php
@@ -11,6 +11,7 @@
 
 namespace Mcp\Capability;
 
+use Mcp\Capability\Registry\Loader\LoaderInterface;
 use Mcp\Capability\Registry\PromptReference;
 use Mcp\Capability\Registry\ResourceReference;
 use Mcp\Capability\Registry\ResourceTemplateReference;
@@ -60,11 +61,40 @@ final class Registry implements RegistryInterface
      */
     private array $resourceTemplates = [];
 
+    private bool $loaded = false;
+
+    private bool $loading = false;
+
     public function __construct(
         private readonly ?EventDispatcherInterface $eventDispatcher = null,
         private readonly LoggerInterface $logger = new NullLogger(),
         private readonly NameValidator $nameValidator = new NameValidator(),
+        private readonly ?LoaderInterface $loader = null,
     ) {
+    }
+
+    /**
+     * Runs the configured loader once, on demand. Reads trigger this automatically, so element
+     * loading is deferred to the first read (request time) rather than eager at build time — under a
+     * persistent runtime a source not yet ready at build no longer freezes the registry empty.
+     *
+     * `loaded` is set only after success, so a transient failure is retried on the next read. The
+     * `loading` guard lets a loader read the registry during its own run (e.g. discovery's identity
+     * check) without re-entering the load.
+     */
+    public function load(): void
+    {
+        if ($this->loaded || $this->loading || null === $this->loader) {
+            return;
+        }
+
+        $this->loading = true;
+        try {
+            $this->loader->load($this);
+            $this->loaded = true;
+        } finally {
+            $this->loading = false;
+        }
     }
 
     public function registerTool(Tool $tool, callable|array|string $handler): ToolReference
@@ -165,31 +195,43 @@ final class Registry implements RegistryInterface
 
     public function hasTool(string $name): bool
     {
+        $this->load();
+
         return isset($this->tools[$name]);
     }
 
     public function hasResource(string $uri): bool
     {
+        $this->load();
+
         return isset($this->resources[$uri]);
     }
 
     public function hasResourceTemplate(string $uriTemplate): bool
     {
+        $this->load();
+
         return isset($this->resourceTemplates[$uriTemplate]);
     }
 
     public function hasPrompt(string $name): bool
     {
+        $this->load();
+
         return isset($this->prompts[$name]);
     }
 
     public function hasTools(): bool
     {
+        $this->load();
+
         return [] !== $this->tools;
     }
 
     public function getTools(?int $limit = null, ?string $cursor = null): Page
     {
+        $this->load();
+
         $tools = [];
         foreach ($this->tools as $toolReference) {
             $tools[$toolReference->tool->name] = $toolReference->tool;
@@ -212,16 +254,22 @@ final class Registry implements RegistryInterface
 
     public function getTool(string $name): ToolReference
     {
+        $this->load();
+
         return $this->tools[$name] ?? throw new ToolNotFoundException($name);
     }
 
     public function hasResources(): bool
     {
+        $this->load();
+
         return [] !== $this->resources;
     }
 
     public function getResources(?int $limit = null, ?string $cursor = null): Page
     {
+        $this->load();
+
         $resources = [];
         foreach ($this->resources as $resourceReference) {
             $resources[$resourceReference->resource->uri] = $resourceReference->resource;
@@ -246,6 +294,8 @@ final class Registry implements RegistryInterface
         string $uri,
         bool $includeTemplates = true,
     ): ResourceReference|ResourceTemplateReference {
+        $this->load();
+
         $registration = $this->resources[$uri] ?? null;
         if ($registration) {
             return $registration;
@@ -266,11 +316,15 @@ final class Registry implements RegistryInterface
 
     public function hasResourceTemplates(): bool
     {
+        $this->load();
+
         return [] !== $this->resourceTemplates;
     }
 
     public function getResourceTemplates(?int $limit = null, ?string $cursor = null): Page
     {
+        $this->load();
+
         $templates = [];
         foreach ($this->resourceTemplates as $templateReference) {
             $templates[$templateReference->resourceTemplate->uriTemplate] = $templateReference->resourceTemplate;
@@ -293,16 +347,22 @@ final class Registry implements RegistryInterface
 
     public function getResourceTemplate(string $uriTemplate): ResourceTemplateReference
     {
+        $this->load();
+
         return $this->resourceTemplates[$uriTemplate] ?? throw new ResourceNotFoundException($uriTemplate);
     }
 
     public function hasPrompts(): bool
     {
+        $this->load();
+
         return [] !== $this->prompts;
     }
 
     public function getPrompts(?int $limit = null, ?string $cursor = null): Page
     {
+        $this->load();
+
         $prompts = [];
         foreach ($this->prompts as $promptReference) {
             $prompts[$promptReference->prompt->name] = $promptReference->prompt;
@@ -325,6 +385,8 @@ final class Registry implements RegistryInterface
 
     public function getPrompt(string $name): PromptReference
     {
+        $this->load();
+
         return $this->prompts[$name] ?? throw new PromptNotFoundException($name);
     }
 

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -219,6 +219,10 @@ final class Builder
      */
     private array $loaders = [];
 
+    private bool $hasCustomRegistry = false;
+
+    private bool $lazyLoading = true;
+
     /**
      * Sets the server's identity. Required.
      *
@@ -344,6 +348,21 @@ final class Builder
     public function setRegistry(RegistryInterface $registry): self
     {
         $this->registry = $registry;
+        $this->hasCustomRegistry = true;
+
+        return $this;
+    }
+
+    /**
+     * Controls when configured loaders (manual elements, discovery, custom loaders) run.
+     *
+     * Lazy (the default) defers loading to the first registry read so a persistent runtime does not
+     * freeze the registry to a source not yet ready at build time. Disable to load eagerly at build.
+     * A registry supplied via setRegistry() is always loaded eagerly.
+     */
+    public function setLazyLoading(bool $lazyLoading = true): self
+    {
+        $this->lazyLoading = $lazyLoading;
 
         return $this;
     }
@@ -643,7 +662,6 @@ final class Builder
     {
         $logger = $this->logger ?? new NullLogger();
         $container = $this->container ?? new Container();
-        $registry = $this->registry ?? new Registry($this->eventDispatcher, $logger);
         $subscriptionManager = $this->subscriptionManager ?? new SessionSubscriptionManager($logger);
         $sessionManager = $this->sessionManager ?? new SessionManager(
             $this->sessionStore ?? new InMemorySessionStore(),
@@ -674,23 +692,24 @@ final class Builder
             }
         }
 
-        $loader = new ChainLoader($loaders);
-        $loader->load($registry);
+        $chainLoader = new ChainLoader($loaders);
+
+        if ($this->hasCustomRegistry) {
+            // Builder can't inject the loader into an already-constructed instance, so load it eagerly.
+            $registry = $this->registry;
+            $chainLoader->load($registry);
+            $eagerlyLoaded = true;
+        } else {
+            $registry = new Registry($this->eventDispatcher, $logger, loader: $chainLoader);
+            if (!$this->lazyLoading) {
+                $registry->load();
+            }
+            $eagerlyLoaded = !$this->lazyLoading;
+        }
 
         $messageFactory = MessageFactory::make();
 
-        $capabilities = $this->serverCapabilities ?? new ServerCapabilities(
-            tools: $registry->hasTools(),
-            toolsListChanged: $this->eventDispatcher instanceof EventDispatcherInterface,
-            resources: $registry->hasResources() || $registry->hasResourceTemplates(),
-            resourcesSubscribe: $registry->hasResources() || $registry->hasResourceTemplates(),
-            resourcesListChanged: $this->eventDispatcher instanceof EventDispatcherInterface,
-            prompts: $registry->hasPrompts(),
-            promptsListChanged: $this->eventDispatcher instanceof EventDispatcherInterface,
-            logging: true,
-            completions: true,
-            extensions: $this->extensions ?: null,
-        );
+        $capabilities = $this->serverCapabilities ?? $this->detectCapabilities($registry, $eagerlyLoaded);
 
         // Extensions enabled via enableExtension() are folded into caller-supplied
         // capabilities too, so setCapabilities() does not silently drop them.
@@ -732,6 +751,49 @@ final class Builder
         );
 
         return new Server($protocol, $logger);
+    }
+
+    /**
+     * When loaded, capabilities are read from the registry. When deferred, reading it would force
+     * the load, so they are advertised from the configured sources instead — opaque sources (custom
+     * loaders, discovery) advertise all kinds, and over-advertising is harmless per MCP semantics.
+     */
+    private function detectCapabilities(RegistryInterface $registry, bool $eagerlyLoaded): ServerCapabilities
+    {
+        $listChanged = $this->eventDispatcher instanceof EventDispatcherInterface;
+
+        if ($eagerlyLoaded) {
+            $hasResources = $registry->hasResources() || $registry->hasResourceTemplates();
+
+            return new ServerCapabilities(
+                tools: $registry->hasTools(),
+                toolsListChanged: $listChanged,
+                resources: $hasResources,
+                resourcesSubscribe: $hasResources,
+                resourcesListChanged: $listChanged,
+                prompts: $registry->hasPrompts(),
+                promptsListChanged: $listChanged,
+                logging: true,
+                completions: true,
+                extensions: $this->extensions ?: null,
+            );
+        }
+
+        $hasOpaqueSources = [] !== $this->loaders || null !== $this->discoveryBasePath;
+        $hasResources = [] !== $this->resources || [] !== $this->explicitResources || [] !== $this->resourceTemplates || [] !== $this->explicitResourceTemplates || $hasOpaqueSources;
+
+        return new ServerCapabilities(
+            tools: [] !== $this->tools || [] !== $this->explicitTools || $hasOpaqueSources,
+            toolsListChanged: $listChanged,
+            resources: $hasResources,
+            resourcesSubscribe: $hasResources,
+            resourcesListChanged: $listChanged,
+            prompts: [] !== $this->prompts || [] !== $this->explicitPrompts || $hasOpaqueSources,
+            promptsListChanged: $listChanged,
+            logging: true,
+            completions: true,
+            extensions: $this->extensions ?: null,
+        );
     }
 
     private function createDiscoverer(LoggerInterface $logger): DiscovererInterface

--- a/tests/Unit/Capability/Registry/Loader/ExplicitElementLoaderTest.php
+++ b/tests/Unit/Capability/Registry/Loader/ExplicitElementLoaderTest.php
@@ -373,11 +373,9 @@ final class ExplicitElementLoaderTest extends TestCase
      */
     private function buildAndGetRegistry(callable $configure): RegistryInterface
     {
+        // A caller-supplied registry is loaded eagerly at build, so it is populated once build() returns.
         $registry = new Registry();
-        $builder = Server::builder()
-            ->setServerInfo('test', '1.0.0')
-            ->setRegistry($registry);
-        $configure($builder)->build();
+        $configure(Server::builder()->setServerInfo('test', '1.0.0')->setRegistry($registry))->build();
 
         return $registry;
     }

--- a/tests/Unit/Capability/RegistryTest.php
+++ b/tests/Unit/Capability/RegistryTest.php
@@ -13,10 +13,12 @@ namespace Mcp\Tests\Unit\Capability;
 
 use Mcp\Capability\Completion\EnumCompletionProvider;
 use Mcp\Capability\Registry;
+use Mcp\Capability\Registry\Loader\LoaderInterface;
 use Mcp\Capability\Registry\PromptReference;
 use Mcp\Capability\Registry\ResourceReference;
 use Mcp\Capability\Registry\ResourceTemplateReference;
 use Mcp\Capability\Registry\ToolReference;
+use Mcp\Capability\RegistryInterface;
 use Mcp\Exception\PromptNotFoundException;
 use Mcp\Exception\ResourceNotFoundException;
 use Mcp\Exception\ToolNotFoundException;
@@ -532,6 +534,113 @@ class RegistryTest extends TestCase
             ['foo' => 'bar'],
             ['foo' => 'bar'],
         ], $structuredContent);
+    }
+
+    public function testConfiguredLoaderIsNotRunUntilFirstRead(): void
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader->expects($this->never())->method('load');
+
+        // Constructing (and registering) must not trigger the loader.
+        $registry = new Registry(null, $this->logger, loader: $loader);
+        $registry->registerTool($this->createValidTool('manual'), 'handler');
+    }
+
+    public function testConfiguredLoaderRunsOnFirstReadAndPopulatesTheRegistry(): void
+    {
+        $loader = $this->toolLoader($this->createValidTool('loaded'));
+        $registry = new Registry(null, $this->logger, loader: $loader);
+
+        $this->assertTrue($registry->hasTools());
+        $this->assertArrayHasKey('loaded', $registry->getTools()->references);
+    }
+
+    public function testConfiguredLoaderRunsExactlyOnceAcrossManyReads(): void
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader->expects($this->once())->method('load');
+
+        $registry = new Registry(null, $this->logger, loader: $loader);
+        $registry->hasTools();
+        $registry->getTools();
+        $registry->hasResources();
+        $registry->getPrompts();
+    }
+
+    public function testRuntimeRegistrationsSurviveTheDeferredLoad(): void
+    {
+        $loader = $this->toolLoader($this->createValidTool('loaded'));
+        $registry = new Registry(null, $this->logger, loader: $loader);
+        // Registered before the first read; the deferred load must be additive, not replacing.
+        $registry->registerTool($this->createValidTool('runtime'), 'handler');
+
+        $tools = $registry->getTools()->references;
+        $this->assertArrayHasKey('runtime', $tools);
+        $this->assertArrayHasKey('loaded', $tools);
+    }
+
+    public function testConfiguredLoaderRetriesAfterAFailedLoad(): void
+    {
+        $tool = $this->createValidTool('loaded');
+        $loader = new class($tool) implements LoaderInterface {
+            private int $calls = 0;
+
+            public function __construct(private readonly Tool $tool)
+            {
+            }
+
+            public function load(RegistryInterface $registry): void
+            {
+                ++$this->calls;
+                if (1 === $this->calls) {
+                    throw new \RuntimeException('data source not ready');
+                }
+
+                $registry->registerTool($this->tool, 'handler');
+            }
+        };
+
+        $registry = new Registry(null, $this->logger, loader: $loader);
+
+        try {
+            $registry->hasTools();
+            $this->fail('Expected the first load to throw.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('data source not ready', $e->getMessage());
+        }
+
+        $this->assertArrayHasKey('loaded', $registry->getTools()->references);
+    }
+
+    public function testLoadRunsTheConfiguredLoaderEagerly(): void
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader->expects($this->once())->method('load');
+
+        $registry = new Registry(null, $this->logger, loader: $loader);
+        $registry->load();
+    }
+
+    public function testLoadIsANoopWithoutAConfiguredLoader(): void
+    {
+        $registry = new Registry(null, $this->logger);
+        $registry->load();
+
+        $this->assertFalse($registry->hasTools());
+    }
+
+    private function toolLoader(Tool $tool): LoaderInterface
+    {
+        return new class($tool) implements LoaderInterface {
+            public function __construct(private readonly Tool $tool)
+            {
+            }
+
+            public function load(RegistryInterface $registry): void
+            {
+                $registry->registerTool($this->tool, 'handler');
+            }
+        };
     }
 
     private function createValidTool(string $name, ?array $outputSchema = null): Tool

--- a/tests/Unit/Server/BuilderTest.php
+++ b/tests/Unit/Server/BuilderTest.php
@@ -11,7 +11,9 @@
 
 namespace Mcp\Tests\Unit\Server;
 
+use Mcp\Capability\Registry;
 use Mcp\Capability\Registry\ElementReference;
+use Mcp\Capability\Registry\Loader\LoaderInterface;
 use Mcp\Capability\Registry\ReferenceHandlerInterface;
 use Mcp\Exception\LogicException;
 use Mcp\Schema\Content\TextContent;
@@ -19,6 +21,7 @@ use Mcp\Schema\Extension\Apps\McpApps;
 use Mcp\Schema\JsonRpc\Response;
 use Mcp\Schema\Request\CallToolRequest;
 use Mcp\Schema\ServerCapabilities;
+use Mcp\Schema\Tool;
 use Mcp\Server;
 use Mcp\Server\Handler\Request\CallToolHandler;
 use Mcp\Server\Handler\Request\InitializeHandler;
@@ -120,6 +123,68 @@ final class BuilderTest extends TestCase
 
         $this->assertNotNull($capabilities->extensions);
         $this->assertArrayHasKey(McpApps::EXTENSION_ID, $capabilities->extensions);
+    }
+
+    #[TestDox('build() advertises tools capability for a pre-populated registry set via setRegistry()')]
+    public function testBuildAdvertisesToolsForPreloadedCustomRegistry(): void
+    {
+        $registry = new Registry();
+        $registry->registerTool(
+            new Tool(name: 'test_tool', title: null, inputSchema: ['type' => 'object', 'properties' => [], 'required' => null], description: 'A test tool', annotations: null),
+            static fn (): string => 'result',
+        );
+
+        $server = Server::builder()
+            ->setServerInfo('test', '1.0.0')
+            ->setRegistry($registry)
+            ->build();
+
+        $capabilities = $this->extractServerCapabilities($server);
+
+        $this->assertTrue($capabilities->tools);
+    }
+
+    #[TestDox('setLazyLoading() returns the builder for fluent chaining')]
+    public function testSetLazyLoadingReturnsSelf(): void
+    {
+        $builder = Server::builder();
+
+        $this->assertSame($builder, $builder->setLazyLoading(false));
+    }
+
+    #[TestDox('Lazy loading (default) advertises tools from configured sources without running loaders')]
+    public function testLazyLoadingAdvertisesFromConfiguredSourcesWithoutLoading(): void
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader->expects($this->never())->method('load');
+
+        $server = Server::builder()
+            ->setServerInfo('test', '1.0.0')
+            ->addLoader($loader)
+            ->build();
+
+        $capabilities = $this->extractServerCapabilities($server);
+
+        // A custom loader is opaque, so its presence advertises tools even though it never ran.
+        $this->assertTrue($capabilities->tools);
+    }
+
+    #[TestDox('Eager loading runs the loaders at build time and advertises from the loaded registry')]
+    public function testEagerLoadingAdvertisesFromLoadedRegistry(): void
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader->expects($this->once())->method('load');
+
+        $server = Server::builder()
+            ->setServerInfo('test', '1.0.0')
+            ->setLazyLoading(false)
+            ->addLoader($loader)
+            ->build();
+
+        $capabilities = $this->extractServerCapabilities($server);
+
+        // The loader ran but registered nothing, so the loaded registry advertises no tools.
+        $this->assertFalse($capabilities->tools);
     }
 
     private function extractServerCapabilities(Server $server): ServerCapabilities


### PR DESCRIPTION
## Summary

`Builder::build()` runs all loaders eagerly (`ChainLoader::load($registry)`) and then snapshots server capabilities from that registry (`tools: $registry->hasTools()`, etc.). Both happen **once**, when the server is built.

Under a persistent runtime (e.g. FrankenPHP worker mode) the server is built a single time and reused across requests. If a loader's data source is not yet ready at that moment — a cold cache, an application metadata layer that gets warmed later — the registry captures an **empty** state and never recovers for the lifetime of the process. `tools/list` (which reads the registry) returns `[]`, while `tools/call` can still work if the consumer resolves handlers independently of the registry. This was reported downstream in api-platform/core#8370 (FrankenPHP worker mode).

## Change

- Add `Mcp\Capability\LazyRegistry`, a registry decorator that runs the loaders on the **first read** instead of at build time. Loading moves to request time, when the application is fully initialized; it runs once per process, and registrations made before the first read are preserved (loader writes are additive/idempotent by name).
- The deferred load is **retried on the next read if it throws**: the loaded flag is set only after a successful load, so a transient failure at the first read (data source still not ready) does not permanently freeze an empty registry for the whole process.
- In `Builder::build()`, wrap the registry in `LazyRegistry` instead of calling `$loader->load()` eagerly.
- Advertise capabilities from the **configured element sources** (`$this->tools`, `$this->explicitTools`, discovery/custom loaders, …) rather than from the now-lazy registry, so the `initialize` handshake does not force an eager load. Custom loaders and discovery are opaque about which element kinds they yield, so their presence advertises tools/resources/prompts; over-advertising is harmless (a client lists and gets an empty result).
- A registry supplied via `setRegistry()` is treated as an opaque source too, so a **pre-populated custom registry still advertises its capabilities** (it previously advertised `false` after the switch away from inspecting the registry, which would make a spec-compliant client skip `tools/list` entirely).

This also removes the need for the userland workarounds consumers currently apply (request-time list handlers, restoring-registry decorators) to keep discovery working under worker runtimes.

## Tests

- New `LazyRegistryTest`: loader not run until first read, runs on first read and populates, runs exactly once across many reads, runtime registrations survive the deferred load, and `testLoaderRetriesAfterAFailedLoad` (a throwing first load is retried on the next read).
- New `BuilderTest::testBuildAdvertisesToolsForPreloadedCustomRegistry`: a registry pre-populated via `setRegistry()` advertises `tools` in the `initialize` handshake.
- Existing `BuilderTest` and the full suite pass. PHP-CS-Fixer and PHPStan clean.

## Notes

Behavioral change worth flagging for review: capabilities are now derived from configured sources, so a server with a discovery path or custom loader that ultimately yields nothing will advertise `tools`/`resources`/`prompts` where it previously advertised `false`. This is intentional (the whole point is not to inspect the registry at build), and harmless per MCP semantics, but it is a visible difference in the `initialize` response.
