### PR TITLE
[Schema] Fix Implementation::fromArray rejecting falsy-but-valid name/version

### DIFF
--- a/src/Schema/Implementation.php
+++ b/src/Schema/Implementation.php
@@ -45,10 +45,10 @@ class Implementation implements \JsonSerializable
      */
     public static function fromArray(array $data): self
     {
-        if (empty($data['name']) || !\is_string($data['name'])) {
+        if (!isset($data['name']) || !\is_string($data['name']) || '' === $data['name']) {
             throw new InvalidArgumentException('Invalid or missing "name" in Implementation data.');
         }
-        if (empty($data['version']) || !\is_string($data['version'])) {
+        if (!isset($data['version']) || !\is_string($data['version']) || '' === $data['version']) {
             throw new InvalidArgumentException('Invalid or missing "version" in Implementation data.');
         }
 

--- a/tests/Unit/Schema/ImplementationTest.php
+++ b/tests/Unit/Schema/ImplementationTest.php
@@ -92,6 +92,7 @@ final class ImplementationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid or missing "name" in Implementation data.');
 
+        /* @phpstan-ignore argument.type */
         Implementation::fromArray(['version' => '1.0.0']);
     }
 
@@ -108,6 +109,7 @@ final class ImplementationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid or missing "name" in Implementation data.');
 
+        /* @phpstan-ignore argument.type */
         Implementation::fromArray(['name' => 123, 'version' => '1.0.0']);
     }
 
@@ -116,6 +118,7 @@ final class ImplementationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid or missing "version" in Implementation data.');
 
+        /* @phpstan-ignore argument.type */
         Implementation::fromArray(['name' => 'my-client']);
     }
 
@@ -132,6 +135,7 @@ final class ImplementationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid or missing "version" in Implementation data.');
 
+        /* @phpstan-ignore argument.type */
         Implementation::fromArray(['name' => 'my-client', 'version' => 1]);
     }
 
@@ -140,6 +144,7 @@ final class ImplementationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid "icons" in Implementation data; expected an array.');
 
+        /* @phpstan-ignore argument.type */
         Implementation::fromArray(['name' => 'my-client', 'version' => '1.0.0', 'icons' => 'nope']);
     }
 

--- a/tests/Unit/Schema/ImplementationTest.php
+++ b/tests/Unit/Schema/ImplementationTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\Implementation;
+use PHPUnit\Framework\TestCase;
+
+final class ImplementationTest extends TestCase
+{
+    public function testConstructorDefaults(): void
+    {
+        $implementation = new Implementation();
+
+        $this->assertSame('app', $implementation->name);
+        $this->assertSame('dev', $implementation->version);
+        $this->assertNull($implementation->description);
+        $this->assertNull($implementation->icons);
+        $this->assertNull($implementation->websiteUrl);
+    }
+
+    public function testFromArrayWithMinimalData(): void
+    {
+        $implementation = Implementation::fromArray([
+            'name' => 'my-client',
+            'version' => '1.2.3',
+        ]);
+
+        $this->assertSame('my-client', $implementation->name);
+        $this->assertSame('1.2.3', $implementation->version);
+        $this->assertNull($implementation->description);
+        $this->assertNull($implementation->icons);
+        $this->assertNull($implementation->websiteUrl);
+    }
+
+    public function testFromArrayWithAllFields(): void
+    {
+        $implementation = Implementation::fromArray([
+            'name' => 'my-client',
+            'version' => '1.2.3',
+            'description' => 'A test client',
+            'icons' => [['src' => 'https://example.com/icon.png']],
+            'websiteUrl' => 'https://example.com',
+        ]);
+
+        $this->assertSame('my-client', $implementation->name);
+        $this->assertSame('1.2.3', $implementation->version);
+        $this->assertSame('A test client', $implementation->description);
+        $this->assertIsArray($implementation->icons);
+        $this->assertCount(1, $implementation->icons);
+        $this->assertSame('https://example.com', $implementation->websiteUrl);
+    }
+
+    /**
+     * Regression test for #392: falsy-but-valid version strings such as "0"
+     * were rejected because empty('0') === true.
+     */
+    public function testFromArrayAcceptsZeroStringVersion(): void
+    {
+        $implementation = Implementation::fromArray([
+            'name' => 'my-client',
+            'version' => '0',
+        ]);
+
+        $this->assertSame('0', $implementation->version);
+    }
+
+    /**
+     * Regression test for #392: a name of "0" is a valid string and must be accepted.
+     */
+    public function testFromArrayAcceptsZeroStringName(): void
+    {
+        $implementation = Implementation::fromArray([
+            'name' => '0',
+            'version' => '1.0.0',
+        ]);
+
+        $this->assertSame('0', $implementation->name);
+    }
+
+    public function testFromArrayThrowsOnMissingName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid or missing "name" in Implementation data.');
+
+        Implementation::fromArray(['version' => '1.0.0']);
+    }
+
+    public function testFromArrayThrowsOnEmptyName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid or missing "name" in Implementation data.');
+
+        Implementation::fromArray(['name' => '', 'version' => '1.0.0']);
+    }
+
+    public function testFromArrayThrowsOnNonStringName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid or missing "name" in Implementation data.');
+
+        Implementation::fromArray(['name' => 123, 'version' => '1.0.0']);
+    }
+
+    public function testFromArrayThrowsOnMissingVersion(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid or missing "version" in Implementation data.');
+
+        Implementation::fromArray(['name' => 'my-client']);
+    }
+
+    public function testFromArrayThrowsOnEmptyVersion(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid or missing "version" in Implementation data.');
+
+        Implementation::fromArray(['name' => 'my-client', 'version' => '']);
+    }
+
+    public function testFromArrayThrowsOnNonStringVersion(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid or missing "version" in Implementation data.');
+
+        Implementation::fromArray(['name' => 'my-client', 'version' => 1]);
+    }
+
+    public function testFromArrayThrowsOnNonArrayIcons(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid "icons" in Implementation data; expected an array.');
+
+        Implementation::fromArray(['name' => 'my-client', 'version' => '1.0.0', 'icons' => 'nope']);
+    }
+
+    public function testJsonSerializeRoundTrip(): void
+    {
+        $implementation = Implementation::fromArray([
+            'name' => 'my-client',
+            'version' => '0',
+            'description' => 'A test client',
+            'websiteUrl' => 'https://example.com',
+        ]);
+
+        $this->assertSame([
+            'name' => 'my-client',
+            'version' => '0',
+            'description' => 'A test client',
+            'websiteUrl' => 'https://example.com',
+        ], $implementation->jsonSerialize());
+    }
+
+    public function testJsonSerializeOmitsNullOptionalFields(): void
+    {
+        $implementation = new Implementation('my-client', '1.0.0');
+
+        $this->assertSame([
+            'name' => 'my-client',
+            'version' => '1.0.0',
+        ], $implementation->jsonSerialize());
+    }
+}


### PR DESCRIPTION
Fixes #392.

## Problem

`Implementation::fromArray()` validates the required `name` and `version` fields with `empty()`. Because `empty('0') === true` in PHP, a perfectly valid `clientInfo`/`serverInfo` carrying `"version": "0"` (or `"name": "0"`) is rejected with an `InvalidArgumentException`.

During the `initialize` handshake this is especially confusing: the exception aborts parsing of the `InitializeRequest`, and `Protocol::resolveSession()` then reports the misleading error:

> A valid session id is REQUIRED for non-initialize requests.

…which points nowhere near the actual cause.

## Change

Replace the `empty()` guards with explicit checks:

```php
if (!isset($data['name']) || !\is_string($data['name']) || '' === $data['name']) {
if (!isset($data['version']) || !\is_string($data['version']) || '' === $data['version']) {
```

This keeps rejecting the cases that should fail — missing, non-string, and genuinely empty (`""`) — while accepting falsy-but-valid strings like `"0"`. Behavior is strictly widened; nothing previously valid is now rejected.

## Tests

Adds `tests/Unit/Schema/ImplementationTest.php` (there was no existing test for this class), covering:

- **Regression:** `"version": "0"` and `"name": "0"` are accepted.
- Rejection of missing / empty-string / non-string `name` and `version`.
- Constructor defaults, minimal & full `fromArray`, non-array `icons`, and `jsonSerialize` round-trip.

```
OK (14 tests, 34 assertions)
```

`vendor/bin/phpstan` reports no errors on the changed file.

## Scope note

The same `empty()`-on-required-string pattern exists in several sibling schema DTOs (`Icon`, `Prompt`, `PromptArgument`, `ResourceDefinition`, `ResourceTemplate`, `Root`, `Tool`) — e.g. a tool literally named `"0"` would hit the identical bug. I've kept this PR scoped to the reported issue; happy to follow up with a sweep (single PR or per-DTO) if you'd prefer.
