### PR TITLE
[Client][Server] Add Roots support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ All notable changes to `mcp/sdk` will be documented in this file.
 * Add `maxBodyBytes` (default 4 MiB) to `StreamableHttpTransport` — POST bodies exceeding the cap are rejected with `413`. Unknown-size/chunked bodies are read incrementally and stopped at the cap so they cannot exhaust memory.
 * Reject malformed `Mcp-Session-Id` headers with a `400` response: a repeated header or a value that is not a valid UUID is now rejected up front instead of surfacing as an uncaught `Uuid::fromString()` error.
 * Extract RFC 9728 metadata serving into `ProtectedResourceMetadataHandler`, a transport-neutral PSR-15 `RequestHandlerInterface` that can be mounted directly as a Symfony/Laravel controller; `ProtectedResourceMetadataMiddleware` now delegates to it (no BC break).
+* Add client-side `roots/list` handler (`ListRootsRequestHandler` + `RootsCallbackInterface`) and `Client::sendRootsListChanged()`, plus server-side `ClientGateway::listRoots()` / `supportsRoots()` and `ListRootsResult::fromArray()`.
 
 0.6.0
 -----
 
-* Add client-side `roots/list` handler (`ListRootsRequestHandler` + `RootsCallbackInterface`) and `Client::sendRootsListChanged()`, plus server-side `ClientGateway::listRoots()` / `supportsRoots()` and `ListRootsResult::fromArray()`.
 * Add `Builder::add(Tool|ResourceDefinition|ResourceTemplate|Prompt $definition, ElementHandlerInterface $handler)` for explicit registration of elements whose schema is only known at runtime.
 * Add handler interfaces `ToolHandlerInterface`, `ResourceHandlerInterface`, `ResourceTemplateHandlerInterface`, `PromptHandlerInterface`, and the `ElementHandlerInterface` marker.
 * [BC Break] Renamed `Mcp\Schema\Resource` to `Mcp\Schema\ResourceDefinition`. No alias.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to `mcp/sdk` will be documented in this file.
 0.6.0
 -----
 
+* Add client-side `roots/list` handler (`ListRootsRequestHandler` + `RootsCallbackInterface`) and `Client::sendRootsListChanged()`, plus server-side `ClientGateway::listRoots()` / `supportsRoots()` and `ListRootsResult::fromArray()`.
 * Add `Builder::add(Tool|ResourceDefinition|ResourceTemplate|Prompt $definition, ElementHandlerInterface $handler)` for explicit registration of elements whose schema is only known at runtime.
 * Add handler interfaces `ToolHandlerInterface`, `ResourceHandlerInterface`, `ResourceTemplateHandlerInterface`, `PromptHandlerInterface`, and the `ElementHandlerInterface` marker.
 * [BC Break] Renamed `Mcp\Schema\Resource` to `Mcp\Schema\ResourceDefinition`. No alias.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to `mcp/sdk` will be documented in this file.
 * Add `maxBodyBytes` (default 4 MiB) to `StreamableHttpTransport` — POST bodies exceeding the cap are rejected with `413`. Unknown-size/chunked bodies are read incrementally and stopped at the cap so they cannot exhaust memory.
 * Reject malformed `Mcp-Session-Id` headers with a `400` response: a repeated header or a value that is not a valid UUID is now rejected up front instead of surfacing as an uncaught `Uuid::fromString()` error.
 * Extract RFC 9728 metadata serving into `ProtectedResourceMetadataHandler`, a transport-neutral PSR-15 `RequestHandlerInterface` that can be mounted directly as a Symfony/Laravel controller; `ProtectedResourceMetadataMiddleware` now delegates to it (no BC break).
+* Add client-side `roots/list` handler (`ListRootsRequestHandler` + `RootsCallbackInterface`) and `Client::sendRootsListChanged()`, plus server-side `ClientGateway::listRoots()` / `supportsRoots()` and `ListRootsResult::fromArray()`.
 
 0.6.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `mcp/sdk` will be documented in this file.
 * Always emit `{}` for empty tool schemas: `Tool` recursively normalizes every empty sub-schema — `properties`, `items`, `additionalProperties`, `$defs`, combinators and the other draft-07 to 2020-12 schema keywords — in the constructor, for both `inputSchema` and `outputSchema`, so an object position is never serialized as `[]`.
 * Prompt generators returning content as typed arrays (`['type' => 'text', ...]` etc.) no longer lose the optional fields: `annotations` on every content type, and `_meta` and an explicit `mimeType` on embedded resource contents, now carry through to the resulting `PromptMessage` instead of being silently dropped. A missing resource `mimeType` still defaults to `text/plain`/`application/octet-stream` as before.
 * Add `annotations` support to `ImageContent` (constructor, `fromArray()`, `fromFile()`, `fromString()`, `jsonSerialize()`), matching `TextContent` and `AudioContent`.
+* Add client-side `roots/list` handler (`ListRootsRequestHandler` + `RootsCallbackInterface`) and `Client::sendRootsListChanged()`, plus server-side `ClientGateway::listRoots()` / `supportsRoots()` and `ListRootsResult::fromArray()`.
 
 0.7.0
 -----
@@ -22,7 +23,6 @@ All notable changes to `mcp/sdk` will be documented in this file.
 * Add `maxBodyBytes` (default 4 MiB) to `StreamableHttpTransport` — POST bodies exceeding the cap are rejected with `413`. Unknown-size/chunked bodies are read incrementally and stopped at the cap so they cannot exhaust memory.
 * Reject malformed `Mcp-Session-Id` headers with a `400` response: a repeated header or a value that is not a valid UUID is now rejected up front instead of surfacing as an uncaught `Uuid::fromString()` error.
 * Extract RFC 9728 metadata serving into `ProtectedResourceMetadataHandler`, a transport-neutral PSR-15 `RequestHandlerInterface` that can be mounted directly as a Symfony/Laravel controller; `ProtectedResourceMetadataMiddleware` now delegates to it (no BC break).
-* Add client-side `roots/list` handler (`ListRootsRequestHandler` + `RootsCallbackInterface`) and `Client::sendRootsListChanged()`, plus server-side `ClientGateway::listRoots()` / `supportsRoots()` and `ListRootsResult::fromArray()`.
 
 0.6.0
 -----

--- a/README.md
+++ b/README.md
@@ -243,6 +243,15 @@ $client = Client::builder()
     ->build();
 ```
 
+- **Roots Support**: Expose `file://` workspace folders to the server
+```php
+$rootsHandler = new ListRootsRequestHandler($myCallback);
+$client = Client::builder()
+    ->setCapabilities(new ClientCapabilities(roots: true, rootsListChanged: true))
+    ->addRequestHandler($rootsHandler)
+    ->build();
+```
+
 - **Logging Notifications**: Receive server log messages
 ```php
 $loggingHandler = new LoggingNotificationHandler($myCallback);

--- a/README.md
+++ b/README.md
@@ -243,6 +243,15 @@ $client = Client::builder()
     ->build();
 ```
 
+- **Roots Support**: Expose `file://` workspace folders to the server
+```php
+$rootsHandler = new ListRootsRequestHandler($myCallback);
+$client = Client::builder()
+    ->setCapabilities(new ClientCapabilities(roots: true))
+    ->addRequestHandler($rootsHandler)
+    ->build();
+```
+
 - **Logging Notifications**: Receive server log messages
 ```php
 $loggingHandler = new LoggingNotificationHandler($myCallback);

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ $client = Client::builder()
 ```php
 $rootsHandler = new ListRootsRequestHandler($myCallback);
 $client = Client::builder()
-    ->setCapabilities(new ClientCapabilities(roots: true))
+    ->setCapabilities(new ClientCapabilities(roots: true, rootsListChanged: true))
     ->addRequestHandler($rootsHandler)
     ->build();
 ```

--- a/docs/client.md
+++ b/docs/client.md
@@ -626,13 +626,15 @@ class WorkspaceRootsCallback implements RootsCallbackInterface
 }
 
 $client = Client::builder()
-    ->setCapabilities(new ClientCapabilities(roots: true))
+    ->setCapabilities(new ClientCapabilities(roots: true, rootsListChanged: true))
     ->addRequestHandler(new ListRootsRequestHandler(new WorkspaceRootsCallback))
     ->build();
 ```
 
 When the client's roots change, notify the server so it can request the updated
-list via `roots/list`:
+list via `roots/list`. This requires advertising the `roots.listChanged`
+capability (`rootsListChanged: true` above); otherwise `sendRootsListChanged()`
+throws a `RuntimeException`:
 
 ```php
 $client->sendRootsListChanged();

--- a/docs/client.md
+++ b/docs/client.md
@@ -600,6 +600,44 @@ Only the `Accept` action carries content.
 See `examples/client/stdio_elicitation.php` for a runnable example against the
 elicitation demo server.
 
+### Roots
+
+Roots let the client expose a list of `file://` "workspace folders" that the server
+is allowed to operate on. Advertise the `roots` capability and register a handler
+that answers server `roots/list` requests:
+
+```php
+use Mcp\Client\Handler\Request\ListRootsRequestHandler;
+use Mcp\Client\Handler\Request\RootsCallbackInterface;
+use Mcp\Schema\ClientCapabilities;
+use Mcp\Schema\Request\ListRootsRequest;
+use Mcp\Schema\Result\ListRootsResult;
+use Mcp\Schema\Root;
+
+class WorkspaceRootsCallback implements RootsCallbackInterface
+{
+    public function __invoke(ListRootsRequest $request): ListRootsResult
+    {
+        return new ListRootsResult([
+            new Root('file:///home/user/projects/app', 'Application'),
+            new Root('file:///home/user/projects/library', 'Library'),
+        ]);
+    }
+}
+
+$client = Client::builder()
+    ->setCapabilities(new ClientCapabilities(roots: true))
+    ->addRequestHandler(new ListRootsRequestHandler(new WorkspaceRootsCallback))
+    ->build();
+```
+
+When the client's roots change, notify the server so it can request the updated
+list via `roots/list`:
+
+```php
+$client->sendRootsListChanged();
+```
+
 ## Error Handling
 
 The client throws exceptions for various error conditions:

--- a/docs/client.md
+++ b/docs/client.md
@@ -600,6 +600,46 @@ Only the `Accept` action carries content.
 See `examples/client/stdio_elicitation.php` for a runnable example against the
 elicitation demo server.
 
+### Roots
+
+Roots let the client expose a list of `file://` "workspace folders" that the server
+is allowed to operate on. Advertise the `roots` capability and register a handler
+that answers server `roots/list` requests:
+
+```php
+use Mcp\Client\Handler\Request\ListRootsRequestHandler;
+use Mcp\Client\Handler\Request\RootsCallbackInterface;
+use Mcp\Schema\ClientCapabilities;
+use Mcp\Schema\Request\ListRootsRequest;
+use Mcp\Schema\Result\ListRootsResult;
+use Mcp\Schema\Root;
+
+class WorkspaceRootsCallback implements RootsCallbackInterface
+{
+    public function __invoke(ListRootsRequest $request): ListRootsResult
+    {
+        return new ListRootsResult([
+            new Root('file:///home/user/projects/app', 'Application'),
+            new Root('file:///home/user/projects/library', 'Library'),
+        ]);
+    }
+}
+
+$client = Client::builder()
+    ->setCapabilities(new ClientCapabilities(roots: true, rootsListChanged: true))
+    ->addRequestHandler(new ListRootsRequestHandler(new WorkspaceRootsCallback))
+    ->build();
+```
+
+When the client's roots change, notify the server so it can request the updated
+list via `roots/list`. This requires advertising the `roots.listChanged`
+capability (`rootsListChanged: true` above); otherwise `sendRootsListChanged()`
+throws a `RuntimeException`:
+
+```php
+$client->sendRootsListChanged();
+```
+
 ## Error Handling
 
 The client throws exceptions for various error conditions:

--- a/docs/client.md
+++ b/docs/client.md
@@ -634,11 +634,16 @@ $client = Client::builder()
 When the client's roots change, notify the server so it can request the updated
 list via `roots/list`. This requires advertising the `roots.listChanged`
 capability (`rootsListChanged: true` above); otherwise `sendRootsListChanged()`
-throws a `RuntimeException`:
+throws a `RuntimeException`. On a client that is not connected it throws a
+`ConnectionException`:
 
 ```php
 $client->sendRootsListChanged();
 ```
+
+See `examples/client/stdio_roots.php` for a runnable example: it calls the
+`inspect_workspace_roots` tool of the client-communication demo server, which
+answers by issuing the `roots/list` request back to the client.
 
 ## Error Handling
 

--- a/examples/client/stdio_roots.php
+++ b/examples/client/stdio_roots.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * STDIO Roots Example.
+ *
+ * This example demonstrates the "roots" client capability:
+ * - The client advertises the `roots` capability during initialization.
+ * - It answers server `roots/list` requests via a RootsCallbackInterface,
+ *   exposing a couple of `file://` workspace folders.
+ * - It can notify the server when its list of roots changes.
+ *
+ * Usage: php examples/client/stdio_roots.php
+ */
+
+require_once __DIR__.'/../../vendor/autoload.php';
+
+use Mcp\Client;
+use Mcp\Client\Handler\Request\ListRootsRequestHandler;
+use Mcp\Client\Handler\Request\RootsCallbackInterface;
+use Mcp\Client\Transport\StdioTransport;
+use Mcp\Schema\ClientCapabilities;
+use Mcp\Schema\Request\ListRootsRequest;
+use Mcp\Schema\Result\ListRootsResult;
+use Mcp\Schema\Root;
+
+$rootsRequestHandler = new ListRootsRequestHandler(new class implements RootsCallbackInterface {
+    public function __invoke(ListRootsRequest $request): ListRootsResult
+    {
+        echo "[ROOTS] Server requested the client's list of roots\n";
+
+        return new ListRootsResult([
+            new Root('file:///home/user/projects/app', 'Application'),
+            new Root('file:///home/user/projects/library', 'Library'),
+        ]);
+    }
+});
+
+$client = Client::builder()
+    ->setClientInfo('STDIO Roots Test', '1.0.0')
+    ->setInitTimeout(30)
+    ->setRequestTimeout(120)
+    ->setCapabilities(new ClientCapabilities(roots: true, rootsListChanged: true))
+    ->addRequestHandler($rootsRequestHandler)
+    ->build();
+
+$transport = new StdioTransport(
+    command: 'php',
+    args: [__DIR__.'/../server/client-communication/server.php'],
+);
+
+try {
+    echo "Connecting to MCP server...\n";
+    $client->connect($transport);
+
+    $serverInfo = $client->getServerInfo();
+    echo 'Connected to: '.($serverInfo->name ?? 'unknown')."\n\n";
+
+    echo "Available tools:\n";
+    $toolsResult = $client->listTools();
+    foreach ($toolsResult->tools as $tool) {
+        echo "  - {$tool->name}\n";
+    }
+    echo "\n";
+
+    // Whenever the client's workspace folders change, notify the server so it can
+    // request an updated list via roots/list.
+    echo "Notifying the server that the roots list changed...\n";
+    $client->sendRootsListChanged();
+
+    echo "Client is ready to answer roots/list requests from the server.\n";
+} catch (Throwable $e) {
+    echo "Error: {$e->getMessage()}\n";
+    echo $e->getTraceAsString()."\n";
+} finally {
+    $client->disconnect();
+}

--- a/examples/client/stdio_roots.php
+++ b/examples/client/stdio_roots.php
@@ -48,7 +48,7 @@ $client = Client::builder()
     ->setClientInfo('STDIO Roots Test', '1.0.0')
     ->setInitTimeout(30)
     ->setRequestTimeout(120)
-    ->setCapabilities(new ClientCapabilities(roots: true))
+    ->setCapabilities(new ClientCapabilities(roots: true, rootsListChanged: true))
     ->addRequestHandler($rootsRequestHandler)
     ->build();
 

--- a/examples/client/stdio_roots.php
+++ b/examples/client/stdio_roots.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * STDIO Roots Example.
+ *
+ * This example demonstrates the "roots" client capability:
+ * - The client advertises the `roots` capability during initialization.
+ * - It answers server `roots/list` requests via a RootsCallbackInterface,
+ *   exposing a couple of `file://` workspace folders.
+ * - It can notify the server when its list of roots changes.
+ *
+ * Usage: php examples/client/stdio_roots.php
+ */
+
+require_once __DIR__.'/../../vendor/autoload.php';
+
+use Mcp\Client;
+use Mcp\Client\Handler\Request\ListRootsRequestHandler;
+use Mcp\Client\Handler\Request\RootsCallbackInterface;
+use Mcp\Client\Transport\StdioTransport;
+use Mcp\Schema\ClientCapabilities;
+use Mcp\Schema\Request\ListRootsRequest;
+use Mcp\Schema\Result\ListRootsResult;
+use Mcp\Schema\Root;
+
+$rootsRequestHandler = new ListRootsRequestHandler(new class implements RootsCallbackInterface {
+    public function __invoke(ListRootsRequest $request): ListRootsResult
+    {
+        echo "[ROOTS] Server requested the client's list of roots\n";
+
+        return new ListRootsResult([
+            new Root('file:///home/user/projects/app', 'Application'),
+            new Root('file:///home/user/projects/library', 'Library'),
+        ]);
+    }
+});
+
+$client = Client::builder()
+    ->setClientInfo('STDIO Roots Test', '1.0.0')
+    ->setInitTimeout(30)
+    ->setRequestTimeout(120)
+    ->setCapabilities(new ClientCapabilities(roots: true))
+    ->addRequestHandler($rootsRequestHandler)
+    ->build();
+
+$transport = new StdioTransport(
+    command: 'php',
+    args: [__DIR__.'/../server/client-communication/server.php'],
+);
+
+try {
+    echo "Connecting to MCP server...\n";
+    $client->connect($transport);
+
+    $serverInfo = $client->getServerInfo();
+    echo 'Connected to: '.($serverInfo->name ?? 'unknown')."\n\n";
+
+    echo "Available tools:\n";
+    $toolsResult = $client->listTools();
+    foreach ($toolsResult->tools as $tool) {
+        echo "  - {$tool->name}\n";
+    }
+    echo "\n";
+
+    // Whenever the client's workspace folders change, notify the server so it can
+    // request an updated list via roots/list.
+    echo "Notifying the server that the roots list changed...\n";
+    $client->sendRootsListChanged();
+
+    echo "Client is ready to answer roots/list requests from the server.\n";
+} catch (Throwable $e) {
+    echo "Error: {$e->getMessage()}\n";
+    echo $e->getTraceAsString()."\n";
+} finally {
+    $client->disconnect();
+}

--- a/examples/client/stdio_roots.php
+++ b/examples/client/stdio_roots.php
@@ -16,7 +16,9 @@
  * - The client advertises the `roots` capability during initialization.
  * - It answers server `roots/list` requests via a RootsCallbackInterface,
  *   exposing a couple of `file://` workspace folders.
- * - It can notify the server when its list of roots changes.
+ * - Calling the server's `inspect_workspace_roots` tool makes the server issue
+ *   a `roots/list` request, so the handler below actually runs.
+ * - It notifies the server when its list of roots changes.
  *
  * Usage: php examples/client/stdio_roots.php
  */
@@ -28,6 +30,7 @@ use Mcp\Client\Handler\Request\ListRootsRequestHandler;
 use Mcp\Client\Handler\Request\RootsCallbackInterface;
 use Mcp\Client\Transport\StdioTransport;
 use Mcp\Schema\ClientCapabilities;
+use Mcp\Schema\Content\TextContent;
 use Mcp\Schema\Request\ListRootsRequest;
 use Mcp\Schema\Result\ListRootsResult;
 use Mcp\Schema\Root;
@@ -57,29 +60,26 @@ $transport = new StdioTransport(
     args: [__DIR__.'/../server/client-communication/server.php'],
 );
 
-try {
-    echo "Connecting to MCP server...\n";
-    $client->connect($transport);
+echo "Connecting to MCP server...\n";
+$client->connect($transport);
 
-    $serverInfo = $client->getServerInfo();
-    echo 'Connected to: '.($serverInfo->name ?? 'unknown')."\n\n";
+$serverInfo = $client->getServerInfo();
+echo 'Connected to: '.($serverInfo->name ?? 'unknown')."\n\n";
 
-    echo "Available tools:\n";
-    $toolsResult = $client->listTools();
-    foreach ($toolsResult->tools as $tool) {
-        echo "  - {$tool->name}\n";
+// The server tool asks the client for its roots, which triggers the handler above.
+echo "Calling 'inspect_workspace_roots'...\n";
+$result = $client->callTool(name: 'inspect_workspace_roots');
+
+echo "\nResult:\n";
+foreach ($result->content as $content) {
+    if ($content instanceof TextContent) {
+        echo $content->text."\n";
     }
-    echo "\n";
-
-    // Whenever the client's workspace folders change, notify the server so it can
-    // request an updated list via roots/list.
-    echo "Notifying the server that the roots list changed...\n";
-    $client->sendRootsListChanged();
-
-    echo "Client is ready to answer roots/list requests from the server.\n";
-} catch (Throwable $e) {
-    echo "Error: {$e->getMessage()}\n";
-    echo $e->getTraceAsString()."\n";
-} finally {
-    $client->disconnect();
 }
+
+// Whenever the client's workspace folders change, notify the server so it can
+// request an updated list via roots/list.
+echo "\nNotifying the server that the roots list changed...\n";
+$client->sendRootsListChanged();
+
+$client->disconnect();

--- a/examples/server/client-communication/ClientAwareService.php
+++ b/examples/server/client-communication/ClientAwareService.php
@@ -26,6 +26,42 @@ final class ClientAwareService
     }
 
     /**
+     * Ask the client which workspace folders the server is allowed to operate on.
+     *
+     * Demonstrates the server side of the "roots" client capability: the tool
+     * issues a roots/list request that the client answers from its own handler.
+     *
+     * @return array{status: string, message: string, roots?: list<array{uri: string, name: string|null}>}
+     */
+    #[McpTool(name: 'inspect_workspace_roots', description: 'Ask the client for its workspace roots via a roots/list request.')]
+    public function inspectWorkspaceRoots(RequestContext $context): array
+    {
+        $clientGateway = $context->getClientGateway();
+
+        if (!$clientGateway->supportsRoots()) {
+            return [
+                'status' => 'unsupported',
+                'message' => 'Client does not expose roots. Advertise the "roots" capability and register a ListRootsRequestHandler to let the server discover your workspace folders.',
+            ];
+        }
+
+        $result = $clientGateway->listRoots();
+
+        $roots = [];
+        foreach ($result->roots as $root) {
+            $roots[] = ['uri' => $root->uri, 'name' => $root->name];
+        }
+
+        $clientGateway->log(LoggingLevel::Info, \sprintf('Client exposed %d root(s).', \count($roots)));
+
+        return [
+            'status' => 'ok',
+            'message' => \sprintf('Client exposed %d root(s).', \count($roots)),
+            'roots' => $roots,
+        ];
+    }
+
+    /**
      * @return array{incident: string, recommended_actions: string, model: string}
      */
     #[McpTool(name: 'coordinate_incident_response', description: 'Coordinate an incident response with logging, progress, and sampling.')]

--- a/src/Client.php
+++ b/src/Client.php
@@ -22,6 +22,7 @@ use Mcp\Schema\Implementation;
 use Mcp\Schema\JsonRpc\Error;
 use Mcp\Schema\JsonRpc\Request;
 use Mcp\Schema\JsonRpc\Response;
+use Mcp\Schema\Notification\RootsListChangedNotification;
 use Mcp\Schema\PromptReference;
 use Mcp\Schema\Request\CallToolRequest;
 use Mcp\Schema\Request\CompletionCompleteRequest;
@@ -242,6 +243,16 @@ class Client
         $request = new SetLogLevelRequest($level);
 
         $this->sendRequest($request);
+    }
+
+    /**
+     * Notify the server that the client's list of roots has changed.
+     *
+     * The server should react by requesting an updated list via roots/list.
+     */
+    public function sendRootsListChanged(): void
+    {
+        $this->protocol->sendNotification(new RootsListChangedNotification());
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,11 +17,13 @@ use Mcp\Client\Protocol;
 use Mcp\Client\Transport\TransportInterface;
 use Mcp\Exception\ConnectionException;
 use Mcp\Exception\RequestException;
+use Mcp\Exception\RuntimeException;
 use Mcp\Schema\Enum\LoggingLevel;
 use Mcp\Schema\Implementation;
 use Mcp\Schema\JsonRpc\Error;
 use Mcp\Schema\JsonRpc\Request;
 use Mcp\Schema\JsonRpc\Response;
+use Mcp\Schema\Notification\RootsListChangedNotification;
 use Mcp\Schema\PromptReference;
 use Mcp\Schema\Request\CallToolRequest;
 use Mcp\Schema\Request\CompletionCompleteRequest;
@@ -242,6 +244,22 @@ class Client
         $request = new SetLogLevelRequest($level);
 
         $this->sendRequest($request);
+    }
+
+    /**
+     * Notify the server that the client's list of roots has changed.
+     *
+     * The server should react by requesting an updated list via roots/list.
+     *
+     * @throws RuntimeException if the client did not advertise the `roots.listChanged` capability
+     */
+    public function sendRootsListChanged(): void
+    {
+        if (true !== $this->config->capabilities->rootsListChanged) {
+            throw new RuntimeException('Cannot send a "roots/list_changed" notification without advertising the "roots.listChanged" capability. Build the client with new ClientCapabilities(roots: true, rootsListChanged: true).');
+        }
+
+        $this->protocol->sendNotification(new RootsListChangedNotification());
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,6 +17,7 @@ use Mcp\Client\Protocol;
 use Mcp\Client\Transport\TransportInterface;
 use Mcp\Exception\ConnectionException;
 use Mcp\Exception\RequestException;
+use Mcp\Exception\RuntimeException;
 use Mcp\Schema\Enum\LoggingLevel;
 use Mcp\Schema\Implementation;
 use Mcp\Schema\JsonRpc\Error;
@@ -249,9 +250,15 @@ class Client
      * Notify the server that the client's list of roots has changed.
      *
      * The server should react by requesting an updated list via roots/list.
+     *
+     * @throws RuntimeException if the client did not advertise the `roots.listChanged` capability
      */
     public function sendRootsListChanged(): void
     {
+        if (true !== $this->config->capabilities->rootsListChanged) {
+            throw new RuntimeException('Cannot send a "roots/list_changed" notification without advertising the "roots.listChanged" capability. Build the client with new ClientCapabilities(roots: true, rootsListChanged: true).');
+        }
+
         $this->protocol->sendNotification(new RootsListChangedNotification());
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -251,12 +251,17 @@ class Client
      *
      * The server should react by requesting an updated list via roots/list.
      *
-     * @throws RuntimeException if the client did not advertise the `roots.listChanged` capability
+     * @throws RuntimeException    if the client did not advertise the `roots.listChanged` capability
+     * @throws ConnectionException if the client is not connected
      */
     public function sendRootsListChanged(): void
     {
         if (true !== $this->config->capabilities->rootsListChanged) {
             throw new RuntimeException('Cannot send a "roots/list_changed" notification without advertising the "roots.listChanged" capability. Build the client with new ClientCapabilities(roots: true, rootsListChanged: true).');
+        }
+
+        if (!$this->isConnected()) {
+            throw new ConnectionException('Client is not connected. Call connect() first.');
         }
 
         $this->protocol->sendNotification(new RootsListChangedNotification());

--- a/src/Client/Handler/Request/ListRootsRequestHandler.php
+++ b/src/Client/Handler/Request/ListRootsRequestHandler.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Client\Handler\Request;
+
+use Mcp\Exception\RootsException;
+use Mcp\Schema\JsonRpc\Error;
+use Mcp\Schema\JsonRpc\Request;
+use Mcp\Schema\JsonRpc\Response;
+use Mcp\Schema\Request\ListRootsRequest;
+use Mcp\Schema\Result\ListRootsResult;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Handler for roots/list requests from the server.
+ *
+ * The MCP server may ask the client for the list of filesystem roots (its
+ * "workspace folders"). This handler wraps a user-provided callback that returns
+ * the roots the client wishes to expose.
+ *
+ * @implements RequestHandlerInterface<ListRootsResult>
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+class ListRootsRequestHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly RootsCallbackInterface $callback,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function supports(Request $request): bool
+    {
+        return $request instanceof ListRootsRequest;
+    }
+
+    /**
+     * @return Response<ListRootsResult>|Error
+     */
+    public function handle(Request $request): Response|Error
+    {
+        \assert($request instanceof ListRootsRequest);
+
+        try {
+            $result = $this->callback->__invoke($request);
+
+            return new Response($request->getId(), $result);
+        } catch (RootsException $e) {
+            $this->logger->error('Listing roots failed: '.$e->getMessage(), ['exception' => $e]);
+
+            return Error::forInternalError($e->getMessage(), $request->getId());
+        } catch (\Throwable $e) {
+            $this->logger->error('Unexpected error while listing roots', ['exception' => $e]);
+
+            return Error::forInternalError('Error while listing roots', $request->getId());
+        }
+    }
+}

--- a/src/Client/Handler/Request/ListRootsRequestHandler.php
+++ b/src/Client/Handler/Request/ListRootsRequestHandler.php
@@ -11,6 +11,7 @@
 
 namespace Mcp\Client\Handler\Request;
 
+use Mcp\Exception\RootsException;
 use Mcp\Schema\JsonRpc\Error;
 use Mcp\Schema\JsonRpc\Request;
 use Mcp\Schema\JsonRpc\Response;
@@ -54,6 +55,10 @@ class ListRootsRequestHandler implements RequestHandlerInterface
             $result = $this->callback->__invoke($request);
 
             return new Response($request->getId(), $result);
+        } catch (RootsException $e) {
+            $this->logger->error('Listing roots failed: '.$e->getMessage(), ['exception' => $e]);
+
+            return Error::forInternalError($e->getMessage(), $request->getId());
         } catch (\Throwable $e) {
             $this->logger->error('Unexpected error while listing roots', ['exception' => $e]);
 

--- a/src/Client/Handler/Request/ListRootsRequestHandler.php
+++ b/src/Client/Handler/Request/ListRootsRequestHandler.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Client\Handler\Request;
+
+use Mcp\Schema\JsonRpc\Error;
+use Mcp\Schema\JsonRpc\Request;
+use Mcp\Schema\JsonRpc\Response;
+use Mcp\Schema\Request\ListRootsRequest;
+use Mcp\Schema\Result\ListRootsResult;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Handler for roots/list requests from the server.
+ *
+ * The MCP server may ask the client for the list of filesystem roots (its
+ * "workspace folders"). This handler wraps a user-provided callback that returns
+ * the roots the client wishes to expose.
+ *
+ * @implements RequestHandlerInterface<ListRootsResult>
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+class ListRootsRequestHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly RootsCallbackInterface $callback,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function supports(Request $request): bool
+    {
+        return $request instanceof ListRootsRequest;
+    }
+
+    /**
+     * @return Response<ListRootsResult>|Error
+     */
+    public function handle(Request $request): Response|Error
+    {
+        \assert($request instanceof ListRootsRequest);
+
+        try {
+            $result = $this->callback->__invoke($request);
+
+            return new Response($request->getId(), $result);
+        } catch (\Throwable $e) {
+            $this->logger->error('Unexpected error while listing roots', ['exception' => $e]);
+
+            return Error::forInternalError('Error while listing roots', $request->getId());
+        }
+    }
+}

--- a/src/Client/Handler/Request/RootsCallbackInterface.php
+++ b/src/Client/Handler/Request/RootsCallbackInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Client\Handler\Request;
+
+use Mcp\Schema\Request\ListRootsRequest;
+use Mcp\Schema\Result\ListRootsResult;
+
+/**
+ * Contract for callbacks used by ListRootsRequestHandler.
+ *
+ * Implementations return the list of filesystem roots the client exposes when
+ * requested by the server.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+interface RootsCallbackInterface
+{
+    public function __invoke(ListRootsRequest $request): ListRootsResult;
+}

--- a/src/Exception/RootsException.php
+++ b/src/Exception/RootsException.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Exception;
+
+/**
+ * Exception thrown when listing roots fails.
+ *
+ * When thrown from a roots callback, this exception's message will be
+ * included in the error response sent back to the server.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+final class RootsException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Schema/Result/ListRootsResult.php
+++ b/src/Schema/Result/ListRootsResult.php
@@ -46,10 +46,14 @@ class ListRootsResult implements ResultInterface
             throw new InvalidArgumentException('Missing or invalid "roots" in ListRootsResult data.');
         }
 
-        $roots = array_map(
-            static fn (array $root): Root => Root::fromArray($root),
-            array_values($data['roots']),
-        );
+        $roots = [];
+        foreach ($data['roots'] as $root) {
+            if (!\is_array($root)) {
+                throw new InvalidArgumentException('Invalid root in ListRootsResult data, expected an array.');
+            }
+
+            $roots[] = Root::fromArray($root);
+        }
 
         $meta = isset($data['_meta']) && \is_array($data['_meta']) ? $data['_meta'] : null;
 

--- a/src/Schema/Result/ListRootsResult.php
+++ b/src/Schema/Result/ListRootsResult.php
@@ -11,6 +11,7 @@
 
 namespace Mcp\Schema\Result;
 
+use Mcp\Exception\InvalidArgumentException;
 use Mcp\Schema\JsonRpc\ResultInterface;
 use Mcp\Schema\Root;
 
@@ -31,6 +32,28 @@ class ListRootsResult implements ResultInterface
         public readonly array $roots,
         public readonly ?array $meta = null,
     ) {
+    }
+
+    /**
+     * @param array{
+     *     roots: array<array{uri: string, name?: string}>,
+     *     _meta?: ?array<string, mixed>
+     * } $data
+     */
+    public static function fromArray(array $data): self
+    {
+        if (!isset($data['roots']) || !\is_array($data['roots'])) {
+            throw new InvalidArgumentException('Missing or invalid "roots" in ListRootsResult data.');
+        }
+
+        $roots = array_map(
+            static fn (array $root): Root => Root::fromArray($root),
+            array_values($data['roots']),
+        );
+
+        $meta = isset($data['_meta']) && \is_array($data['_meta']) ? $data['_meta'] : null;
+
+        return new self($roots, $meta);
     }
 
     /**

--- a/src/Server/ClientGateway.php
+++ b/src/Server/ClientGateway.php
@@ -32,8 +32,10 @@ use Mcp\Schema\Notification\LoggingMessageNotification;
 use Mcp\Schema\Notification\ProgressNotification;
 use Mcp\Schema\Request\CreateSamplingMessageRequest;
 use Mcp\Schema\Request\ElicitRequest;
+use Mcp\Schema\Request\ListRootsRequest;
 use Mcp\Schema\Result\CreateSamplingMessageResult;
 use Mcp\Schema\Result\ElicitResult;
+use Mcp\Schema\Result\ListRootsResult;
 use Mcp\Server\Session\SessionInterface;
 
 /**
@@ -186,6 +188,49 @@ class ClientGateway
         }
 
         return ElicitResult::fromArray($response->result);
+    }
+
+    /**
+     * Request the list of filesystem roots exposed by the client.
+     *
+     * Roots are the client's "workspace folders" — the directories or files the
+     * server is allowed to operate on. The client answers the roots/list request
+     * with a list of file:// URIs.
+     *
+     * @param int $timeout The timeout in seconds
+     *
+     * @return ListRootsResult The roots exposed by the client
+     *
+     * @throws ClientException if the client request results in an error message
+     */
+    public function listRoots(int $timeout = 120): ListRootsResult
+    {
+        $request = new ListRootsRequest();
+
+        $response = $this->request($request, $timeout);
+
+        if ($response instanceof Error) {
+            throw new ClientException($response);
+        }
+
+        return ListRootsResult::fromArray($response->result);
+    }
+
+    /**
+     * Check if the connected client supports roots.
+     *
+     * Roots allow servers to ask the client for the set of directories or files
+     * it is permitted to operate on. This method checks the client's advertised
+     * capabilities to determine if roots/list requests are supported.
+     *
+     * @return bool True if the client supports roots, false otherwise
+     */
+    public function supportsRoots(): bool
+    {
+        $capabilities = $this->session->get('client_capabilities', []);
+
+        // MCP spec: capability presence indicates support (value is typically {} or [])
+        return \array_key_exists('roots', $capabilities);
     }
 
     /**

--- a/src/Server/ClientGateway.php
+++ b/src/Server/ClientGateway.php
@@ -32,8 +32,10 @@ use Mcp\Schema\Notification\LoggingMessageNotification;
 use Mcp\Schema\Notification\ProgressNotification;
 use Mcp\Schema\Request\CreateSamplingMessageRequest;
 use Mcp\Schema\Request\ElicitRequest;
+use Mcp\Schema\Request\ListRootsRequest;
 use Mcp\Schema\Result\CreateSamplingMessageResult;
 use Mcp\Schema\Result\ElicitResult;
+use Mcp\Schema\Result\ListRootsResult;
 use Mcp\Server\Session\SessionInterface;
 
 /**
@@ -189,6 +191,49 @@ class ClientGateway
     }
 
     /**
+     * Request the list of filesystem roots exposed by the client.
+     *
+     * Roots are the client's "workspace folders" — the directories or files the
+     * server is allowed to operate on. The client answers the roots/list request
+     * with a list of file:// URIs.
+     *
+     * @param int $timeout The timeout in seconds
+     *
+     * @return ListRootsResult The roots exposed by the client
+     *
+     * @throws ClientException if the client request results in an error message
+     */
+    public function listRoots(int $timeout = 120): ListRootsResult
+    {
+        $request = new ListRootsRequest();
+
+        $response = $this->request($request, $timeout);
+
+        if ($response instanceof Error) {
+            throw new ClientException($response);
+        }
+
+        return ListRootsResult::fromArray($response->result);
+    }
+
+    /**
+     * Check if the connected client supports roots.
+     *
+     * Roots allow servers to ask the client for the set of directories or files
+     * it is permitted to operate on. This method checks the client's advertised
+     * capabilities to determine if roots/list requests are supported.
+     *
+     * @return bool True if the client supports roots, false otherwise
+     */
+    public function supportsRoots(): bool
+    {
+        $capabilities = (array) $this->session->get('client_capabilities', []);
+
+        // MCP spec: capability presence indicates support (value is typically {} or [])
+        return \array_key_exists('roots', $capabilities);
+    }
+
+    /**
      * Check if the connected client supports elicitation.
      *
      * Elicitation allows servers to request additional information from users
@@ -199,7 +244,7 @@ class ClientGateway
      */
     public function supportsElicitation(): bool
     {
-        $capabilities = $this->session->get('client_capabilities', []);
+        $capabilities = (array) $this->session->get('client_capabilities', []);
 
         // MCP spec: capability presence indicates support (value is typically {} or [])
         return \array_key_exists('elicitation', $capabilities);

--- a/src/Server/ClientGateway.php
+++ b/src/Server/ClientGateway.php
@@ -227,7 +227,7 @@ class ClientGateway
      */
     public function supportsRoots(): bool
     {
-        $capabilities = $this->session->get('client_capabilities', []);
+        $capabilities = (array) $this->session->get('client_capabilities', []);
 
         // MCP spec: capability presence indicates support (value is typically {} or [])
         return \array_key_exists('roots', $capabilities);
@@ -244,7 +244,7 @@ class ClientGateway
      */
     public function supportsElicitation(): bool
     {
-        $capabilities = $this->session->get('client_capabilities', []);
+        $capabilities = (array) $this->session->get('client_capabilities', []);
 
         // MCP spec: capability presence indicates support (value is typically {} or [])
         return \array_key_exists('elicitation', $capabilities);

--- a/tests/Unit/Client/ClientTest.php
+++ b/tests/Unit/Client/ClientTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Client;
+
+use Mcp\Client;
+use Mcp\Client\Transport\TransportInterface;
+use Mcp\Exception\RuntimeException;
+use Mcp\Schema\ClientCapabilities;
+use PHPUnit\Framework\TestCase;
+
+final class ClientTest extends TestCase
+{
+    public function testSendRootsListChangedSendsNotificationWhenCapabilityDeclared(): void
+    {
+        $sent = [];
+        $transport = $this->createMock(TransportInterface::class);
+        $transport->method('send')->willReturnCallback(static function (string $data) use (&$sent): void {
+            $sent[] = $data;
+        });
+
+        $client = Client::builder()
+            ->setClientInfo('Roots Test', '1.0.0')
+            ->setCapabilities(new ClientCapabilities(roots: true, rootsListChanged: true))
+            ->build();
+
+        $client->connect($transport);
+        $client->sendRootsListChanged();
+
+        $this->assertCount(1, $sent);
+        $decoded = json_decode($sent[0], true);
+        $this->assertSame('notifications/roots/list_changed', $decoded['method']);
+    }
+
+    public function testSendRootsListChangedThrowsWhenCapabilityNotDeclared(): void
+    {
+        $transport = $this->createMock(TransportInterface::class);
+        $transport->expects($this->never())->method('send');
+
+        $client = Client::builder()
+            ->setClientInfo('Roots Test', '1.0.0')
+            ->setCapabilities(new ClientCapabilities(roots: true))
+            ->build();
+
+        $client->connect($transport);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('roots.listChanged');
+
+        $client->sendRootsListChanged();
+    }
+}

--- a/tests/Unit/Client/ClientTest.php
+++ b/tests/Unit/Client/ClientTest.php
@@ -12,7 +12,9 @@
 namespace Mcp\Tests\Unit\Client;
 
 use Mcp\Client;
+use Mcp\Client\State\ClientStateInterface;
 use Mcp\Client\Transport\TransportInterface;
+use Mcp\Exception\ConnectionException;
 use Mcp\Exception\RuntimeException;
 use Mcp\Schema\ClientCapabilities;
 use PHPUnit\Framework\TestCase;
@@ -25,6 +27,10 @@ final class ClientTest extends TestCase
         $transport = $this->createMock(TransportInterface::class);
         $transport->method('send')->willReturnCallback(static function (string $data) use (&$sent): void {
             $sent[] = $data;
+        });
+        // Stand in for a completed initialize handshake, which the transport drives.
+        $transport->method('setState')->willReturnCallback(static function (ClientStateInterface $state): void {
+            $state->setInitialized(true);
         });
 
         $client = Client::builder()
@@ -54,6 +60,19 @@ final class ClientTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('roots.listChanged');
+
+        $client->sendRootsListChanged();
+    }
+
+    public function testSendRootsListChangedThrowsWhenNotConnected(): void
+    {
+        $client = Client::builder()
+            ->setClientInfo('Roots Test', '1.0.0')
+            ->setCapabilities(new ClientCapabilities(roots: true, rootsListChanged: true))
+            ->build();
+
+        $this->expectException(ConnectionException::class);
+        $this->expectExceptionMessage('Client is not connected.');
 
         $client->sendRootsListChanged();
     }

--- a/tests/Unit/Client/Handler/Request/ListRootsRequestHandlerTest.php
+++ b/tests/Unit/Client/Handler/Request/ListRootsRequestHandlerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Client\Handler\Request;
+
+use Mcp\Client\Handler\Request\ListRootsRequestHandler;
+use Mcp\Client\Handler\Request\RootsCallbackInterface;
+use Mcp\Schema\JsonRpc\Error;
+use Mcp\Schema\JsonRpc\Response;
+use Mcp\Schema\Request\ListRootsRequest;
+use Mcp\Schema\Request\PingRequest;
+use Mcp\Schema\Result\ListRootsResult;
+use Mcp\Schema\Root;
+use PHPUnit\Framework\TestCase;
+
+final class ListRootsRequestHandlerTest extends TestCase
+{
+    public function testSupportsListRootsRequest(): void
+    {
+        $handler = new ListRootsRequestHandler($this->createCallback(new ListRootsResult([])));
+
+        $this->assertTrue($handler->supports(new ListRootsRequest()));
+    }
+
+    public function testDoesNotSupportOtherRequests(): void
+    {
+        $handler = new ListRootsRequestHandler($this->createCallback(new ListRootsResult([])));
+
+        $this->assertFalse($handler->supports(new PingRequest()));
+    }
+
+    public function testHandleReturnsRootsFromCallback(): void
+    {
+        $result = new ListRootsResult([
+            new Root('file:///home/user/project', 'project'),
+            new Root('file:///tmp'),
+        ]);
+
+        $handler = new ListRootsRequestHandler($this->createCallback($result));
+
+        $request = (new ListRootsRequest())->withId('req-1');
+        $response = $handler->handle($request);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('req-1', $response->getId());
+        $this->assertSame($result, $response->result);
+    }
+
+    public function testHandleReturnsErrorWhenCallbackThrows(): void
+    {
+        $handler = new ListRootsRequestHandler(new class implements RootsCallbackInterface {
+            public function __invoke(ListRootsRequest $request): ListRootsResult
+            {
+                throw new \RuntimeException('boom');
+            }
+        });
+
+        $request = (new ListRootsRequest())->withId('req-2');
+        $response = $handler->handle($request);
+
+        $this->assertInstanceOf(Error::class, $response);
+        $this->assertSame('req-2', $response->getId());
+        $this->assertSame('Error while listing roots', $response->message);
+    }
+
+    private function createCallback(ListRootsResult $result): RootsCallbackInterface
+    {
+        return new class($result) implements RootsCallbackInterface {
+            public function __construct(private readonly ListRootsResult $result)
+            {
+            }
+
+            public function __invoke(ListRootsRequest $request): ListRootsResult
+            {
+                return $this->result;
+            }
+        };
+    }
+}

--- a/tests/Unit/Client/Handler/Request/ListRootsRequestHandlerTest.php
+++ b/tests/Unit/Client/Handler/Request/ListRootsRequestHandlerTest.php
@@ -13,6 +13,7 @@ namespace Mcp\Tests\Unit\Client\Handler\Request;
 
 use Mcp\Client\Handler\Request\ListRootsRequestHandler;
 use Mcp\Client\Handler\Request\RootsCallbackInterface;
+use Mcp\Exception\RootsException;
 use Mcp\Schema\JsonRpc\Error;
 use Mcp\Schema\JsonRpc\Response;
 use Mcp\Schema\Request\ListRootsRequest;
@@ -69,6 +70,23 @@ final class ListRootsRequestHandlerTest extends TestCase
         $this->assertInstanceOf(Error::class, $response);
         $this->assertSame('req-2', $response->getId());
         $this->assertSame('Error while listing roots', $response->message);
+    }
+
+    public function testHandleForwardsRootsExceptionMessage(): void
+    {
+        $handler = new ListRootsRequestHandler(new class implements RootsCallbackInterface {
+            public function __invoke(ListRootsRequest $request): ListRootsResult
+            {
+                throw new RootsException('permission denied');
+            }
+        });
+
+        $request = (new ListRootsRequest())->withId('req-3');
+        $response = $handler->handle($request);
+
+        $this->assertInstanceOf(Error::class, $response);
+        $this->assertSame('req-3', $response->getId());
+        $this->assertSame('permission denied', $response->message);
     }
 
     private function createCallback(ListRootsResult $result): RootsCallbackInterface

--- a/tests/Unit/Client/Handler/Request/ListRootsRequestHandlerTest.php
+++ b/tests/Unit/Client/Handler/Request/ListRootsRequestHandlerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Client\Handler\Request;
+
+use Mcp\Client\Handler\Request\ListRootsRequestHandler;
+use Mcp\Client\Handler\Request\RootsCallbackInterface;
+use Mcp\Exception\RootsException;
+use Mcp\Schema\JsonRpc\Error;
+use Mcp\Schema\JsonRpc\Response;
+use Mcp\Schema\Request\ListRootsRequest;
+use Mcp\Schema\Request\PingRequest;
+use Mcp\Schema\Result\ListRootsResult;
+use Mcp\Schema\Root;
+use PHPUnit\Framework\TestCase;
+
+final class ListRootsRequestHandlerTest extends TestCase
+{
+    public function testSupportsListRootsRequest(): void
+    {
+        $handler = new ListRootsRequestHandler($this->createCallback(new ListRootsResult([])));
+
+        $this->assertTrue($handler->supports(new ListRootsRequest()));
+    }
+
+    public function testDoesNotSupportOtherRequests(): void
+    {
+        $handler = new ListRootsRequestHandler($this->createCallback(new ListRootsResult([])));
+
+        $this->assertFalse($handler->supports(new PingRequest()));
+    }
+
+    public function testHandleReturnsRootsFromCallback(): void
+    {
+        $result = new ListRootsResult([
+            new Root('file:///home/user/project', 'project'),
+            new Root('file:///tmp'),
+        ]);
+
+        $handler = new ListRootsRequestHandler($this->createCallback($result));
+
+        $request = (new ListRootsRequest())->withId('req-1');
+        $response = $handler->handle($request);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('req-1', $response->getId());
+        $this->assertSame($result, $response->result);
+    }
+
+    public function testHandleReturnsErrorWhenCallbackThrows(): void
+    {
+        $handler = new ListRootsRequestHandler(new class implements RootsCallbackInterface {
+            public function __invoke(ListRootsRequest $request): ListRootsResult
+            {
+                throw new \RuntimeException('boom');
+            }
+        });
+
+        $request = (new ListRootsRequest())->withId('req-2');
+        $response = $handler->handle($request);
+
+        $this->assertInstanceOf(Error::class, $response);
+        $this->assertSame('req-2', $response->getId());
+        $this->assertSame('Error while listing roots', $response->message);
+    }
+
+    public function testHandleForwardsRootsExceptionMessage(): void
+    {
+        $handler = new ListRootsRequestHandler(new class implements RootsCallbackInterface {
+            public function __invoke(ListRootsRequest $request): ListRootsResult
+            {
+                throw new RootsException('permission denied');
+            }
+        });
+
+        $request = (new ListRootsRequest())->withId('req-3');
+        $response = $handler->handle($request);
+
+        $this->assertInstanceOf(Error::class, $response);
+        $this->assertSame('req-3', $response->getId());
+        $this->assertSame('permission denied', $response->message);
+    }
+
+    private function createCallback(ListRootsResult $result): RootsCallbackInterface
+    {
+        return new class($result) implements RootsCallbackInterface {
+            public function __construct(private readonly ListRootsResult $result)
+            {
+            }
+
+            public function __invoke(ListRootsRequest $request): ListRootsResult
+            {
+                return $this->result;
+            }
+        };
+    }
+}

--- a/tests/Unit/Schema/ClientCapabilitiesTest.php
+++ b/tests/Unit/Schema/ClientCapabilitiesTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema;
+
+use Mcp\Schema\ClientCapabilities;
+use PHPUnit\Framework\TestCase;
+
+class ClientCapabilitiesTest extends TestCase
+{
+    public function testSerializesRootsWithoutListChanged(): void
+    {
+        $capabilities = new ClientCapabilities(roots: true);
+
+        $data = json_decode(json_encode($capabilities), true);
+
+        $this->assertArrayHasKey('roots', $data);
+        $this->assertSame([], $data['roots']);
+    }
+
+    public function testSerializesRootsWithListChanged(): void
+    {
+        $capabilities = new ClientCapabilities(roots: true, rootsListChanged: true);
+
+        $data = json_decode(json_encode($capabilities), true);
+
+        $this->assertSame(['listChanged' => true], $data['roots']);
+    }
+
+    public function testSerializesEmptyCapabilitiesAsObject(): void
+    {
+        $capabilities = new ClientCapabilities();
+
+        $this->assertSame('{}', json_encode($capabilities));
+    }
+
+    public function testFromArrayReadsRootsListChanged(): void
+    {
+        $capabilities = ClientCapabilities::fromArray(['roots' => ['listChanged' => true]]);
+
+        $this->assertTrue($capabilities->roots);
+        $this->assertTrue($capabilities->rootsListChanged);
+    }
+
+    public function testFromArrayRootsWithoutListChanged(): void
+    {
+        $capabilities = ClientCapabilities::fromArray(['roots' => []]);
+
+        $this->assertTrue($capabilities->roots);
+        $this->assertNull($capabilities->rootsListChanged);
+    }
+
+    public function testRoundTripPreservesRootsListChanged(): void
+    {
+        $capabilities = new ClientCapabilities(roots: true, rootsListChanged: true);
+
+        $data = json_decode(json_encode($capabilities), true);
+        $restored = ClientCapabilities::fromArray($data);
+
+        $this->assertTrue($restored->roots);
+        $this->assertTrue($restored->rootsListChanged);
+    }
+}

--- a/tests/Unit/Schema/Result/ListRootsResultTest.php
+++ b/tests/Unit/Schema/Result/ListRootsResultTest.php
@@ -63,6 +63,17 @@ final class ListRootsResultTest extends TestCase
         ListRootsResult::fromArray([]);
     }
 
+    public function testFromArrayWithNonArrayRoot(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid root in ListRootsResult data, expected an array.');
+
+        /* @phpstan-ignore argument.type */
+        ListRootsResult::fromArray([
+            'roots' => ['file:///tmp'],
+        ]);
+    }
+
     public function testFromArrayRejectsNonFileUri(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Schema/Result/ListRootsResultTest.php
+++ b/tests/Unit/Schema/Result/ListRootsResultTest.php
@@ -63,6 +63,16 @@ final class ListRootsResultTest extends TestCase
         ListRootsResult::fromArray([]);
     }
 
+    public function testFromArrayRejectsNonFileUri(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must start with "file://"');
+
+        ListRootsResult::fromArray([
+            'roots' => [['uri' => 'https://example.com']],
+        ]);
+    }
+
     public function testFromArrayRoundTrip(): void
     {
         $data = [

--- a/tests/Unit/Schema/Result/ListRootsResultTest.php
+++ b/tests/Unit/Schema/Result/ListRootsResultTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema\Result;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\Result\ListRootsResult;
+use Mcp\Schema\Root;
+use PHPUnit\Framework\TestCase;
+
+final class ListRootsResultTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $roots = [new Root('file:///home/user/project', 'project')];
+        $result = new ListRootsResult($roots);
+
+        $this->assertSame($roots, $result->roots);
+        $this->assertNull($result->meta);
+    }
+
+    public function testFromArray(): void
+    {
+        $result = ListRootsResult::fromArray([
+            'roots' => [
+                ['uri' => 'file:///home/user/project', 'name' => 'project'],
+                ['uri' => 'file:///tmp'],
+            ],
+        ]);
+
+        $this->assertCount(2, $result->roots);
+        $this->assertSame('file:///home/user/project', $result->roots[0]->uri);
+        $this->assertSame('project', $result->roots[0]->name);
+        $this->assertSame('file:///tmp', $result->roots[1]->uri);
+        $this->assertNull($result->roots[1]->name);
+        $this->assertNull($result->meta);
+    }
+
+    public function testFromArrayWithMeta(): void
+    {
+        $result = ListRootsResult::fromArray([
+            'roots' => [['uri' => 'file:///tmp']],
+            '_meta' => ['requestId' => 'abc'],
+        ]);
+
+        $this->assertSame(['requestId' => 'abc'], $result->meta);
+    }
+
+    public function testFromArrayWithMissingRoots(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing or invalid "roots"');
+
+        /* @phpstan-ignore argument.type */
+        ListRootsResult::fromArray([]);
+    }
+
+    public function testFromArrayRoundTrip(): void
+    {
+        $data = [
+            'roots' => [
+                ['uri' => 'file:///home/user/project', 'name' => 'project'],
+                ['uri' => 'file:///tmp'],
+            ],
+            '_meta' => ['foo' => 'bar'],
+        ];
+
+        $result = ListRootsResult::fromArray($data);
+
+        $this->assertSame($data, json_decode(json_encode($result), true));
+    }
+
+    public function testJsonSerializeWithoutMeta(): void
+    {
+        $result = new ListRootsResult([new Root('file:///tmp')]);
+
+        $this->assertSame([
+            'roots' => [['uri' => 'file:///tmp']],
+        ], json_decode(json_encode($result), true));
+    }
+}

--- a/tests/Unit/Schema/Result/ListRootsResultTest.php
+++ b/tests/Unit/Schema/Result/ListRootsResultTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Schema\Result;
+
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\Result\ListRootsResult;
+use Mcp\Schema\Root;
+use PHPUnit\Framework\TestCase;
+
+final class ListRootsResultTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $roots = [new Root('file:///home/user/project', 'project')];
+        $result = new ListRootsResult($roots);
+
+        $this->assertSame($roots, $result->roots);
+        $this->assertNull($result->meta);
+    }
+
+    public function testFromArray(): void
+    {
+        $result = ListRootsResult::fromArray([
+            'roots' => [
+                ['uri' => 'file:///home/user/project', 'name' => 'project'],
+                ['uri' => 'file:///tmp'],
+            ],
+        ]);
+
+        $this->assertCount(2, $result->roots);
+        $this->assertSame('file:///home/user/project', $result->roots[0]->uri);
+        $this->assertSame('project', $result->roots[0]->name);
+        $this->assertSame('file:///tmp', $result->roots[1]->uri);
+        $this->assertNull($result->roots[1]->name);
+        $this->assertNull($result->meta);
+    }
+
+    public function testFromArrayWithMeta(): void
+    {
+        $result = ListRootsResult::fromArray([
+            'roots' => [['uri' => 'file:///tmp']],
+            '_meta' => ['requestId' => 'abc'],
+        ]);
+
+        $this->assertSame(['requestId' => 'abc'], $result->meta);
+    }
+
+    public function testFromArrayWithMissingRoots(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing or invalid "roots"');
+
+        /* @phpstan-ignore argument.type */
+        ListRootsResult::fromArray([]);
+    }
+
+    public function testFromArrayRejectsNonFileUri(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must start with "file://"');
+
+        ListRootsResult::fromArray([
+            'roots' => [['uri' => 'https://example.com']],
+        ]);
+    }
+
+    public function testFromArrayRoundTrip(): void
+    {
+        $data = [
+            'roots' => [
+                ['uri' => 'file:///home/user/project', 'name' => 'project'],
+                ['uri' => 'file:///tmp'],
+            ],
+            '_meta' => ['foo' => 'bar'],
+        ];
+
+        $result = ListRootsResult::fromArray($data);
+
+        $this->assertSame($data, json_decode(json_encode($result), true));
+    }
+
+    public function testJsonSerializeWithoutMeta(): void
+    {
+        $result = new ListRootsResult([new Root('file:///tmp')]);
+
+        $this->assertSame([
+            'roots' => [['uri' => 'file:///tmp']],
+        ], json_decode(json_encode($result), true));
+    }
+}

--- a/tests/Unit/Server/ClientGatewayTest.php
+++ b/tests/Unit/Server/ClientGatewayTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Server;
+
+use Mcp\Exception\ClientException;
+use Mcp\Schema\JsonRpc\Error;
+use Mcp\Schema\JsonRpc\Response;
+use Mcp\Schema\Request\ListRootsRequest;
+use Mcp\Schema\Result\ListRootsResult;
+use Mcp\Server\ClientGateway;
+use Mcp\Server\Session\SessionInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class ClientGatewayTest extends TestCase
+{
+    public function testSupportsRootsReturnsTrueWhenAdvertised(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('get')->with('client_capabilities', [])->willReturn(['roots' => []]);
+
+        $gateway = new ClientGateway($session);
+
+        $this->assertTrue($gateway->supportsRoots());
+    }
+
+    public function testSupportsRootsReturnsFalseWhenNotAdvertised(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('get')->with('client_capabilities', [])->willReturn(['sampling' => []]);
+
+        $gateway = new ClientGateway($session);
+
+        $this->assertFalse($gateway->supportsRoots());
+    }
+
+    public function testListRootsReturnsRootsFromClient(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('getId')->willReturn(Uuid::v4());
+
+        $gateway = new ClientGateway($session);
+
+        $response = $this->response([
+            'roots' => [
+                ['uri' => 'file:///home/user/project', 'name' => 'project'],
+            ],
+        ]);
+
+        $result = $this->runInFiber(static fn (): ListRootsResult => $gateway->listRoots(), $response);
+
+        $this->assertInstanceOf(ListRootsResult::class, $result);
+        $this->assertCount(1, $result->roots);
+        $this->assertSame('file:///home/user/project', $result->roots[0]->uri);
+    }
+
+    public function testListRootsThrowsClientExceptionOnError(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('getId')->willReturn(Uuid::v4());
+
+        $gateway = new ClientGateway($session);
+
+        $error = Error::forInternalError('nope', '1');
+
+        $this->expectException(ClientException::class);
+
+        $this->runInFiber(static fn (): ListRootsResult => $gateway->listRoots(), $error);
+    }
+
+    /**
+     * Runs the gateway call inside a Fiber, asserts it suspends with a roots/list
+     * request, then resumes it with the given client response.
+     *
+     * @param Response<array<string, mixed>>|Error $response
+     */
+    private function runInFiber(\Closure $call, Response|Error $response): mixed
+    {
+        $fiber = new \Fiber($call);
+        $suspend = $fiber->start();
+
+        $this->assertIsArray($suspend);
+        $this->assertSame('request', $suspend['type']);
+        $this->assertInstanceOf(ListRootsRequest::class, $suspend['request']);
+
+        $fiber->resume($response);
+
+        return $fiber->getReturn();
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     *
+     * @return Response<array<string, mixed>>
+     */
+    private function response(array $result): Response
+    {
+        return new Response('1', $result);
+    }
+}


### PR DESCRIPTION
Adds support for the MCP **Roots** capability, letting a client expose `file://` "workspace folders" that the server is allowed to operate on.

### Client side
- `ListRootsRequestHandler` + `RootsCallbackInterface` — answer server `roots/list` requests from a user-provided callback (mirrors the existing `SamplingRequestHandler` / `SamplingCallbackInterface` pattern).
- `Client::sendRootsListChanged()` — send `notifications/roots/list_changed`. Guarded: it throws unless the client advertised the `roots.listChanged` capability, so a misconfigured client can't emit an undeclared notification.
- `Mcp\Exception\RootsException` — thrown from a roots callback, its message is forwarded to the server (same contract as `SamplingException`); any other throwable is logged and returned as a generic internal error.

### Server side
- `ClientGateway::listRoots()` — request the client's roots (returns `ListRootsResult`, throws `ClientException` on an error response).
- `ClientGateway::supportsRoots()` — capability-gating helper alongside `supportsElicitation()`.

### Schema
- `ListRootsResult::fromArray()` — parse the client's response; `Root` continues to enforce the `file://` URI scheme required by the spec.

### Docs / examples / tests
- README + `docs/client.md` sections and a runnable `examples/client/stdio_roots.php`.
- Unit tests covering the handler, result parsing (incl. non-`file://` rejection), capability serialization/round-trip, `sendRootsListChanged()` gating, and the `ClientGateway` roots methods.
- CHANGELOG entry under `0.7.0`.

### Conformance notes
- Root URIs are restricted to `file://` per the current spec.
- `roots` capability presence gates `roots/list`; `roots.listChanged` gates the `list_changed` notification.
