### PR TITLE
[Client] Parse CRLF- and CR-delimited SSE events

### DIFF
--- a/src/Client/Transport/HttpTransport.php
+++ b/src/Client/Transport/HttpTransport.php
@@ -230,16 +230,19 @@ class HttpTransport extends BaseTransport
             }
         }
 
-        while (false !== ($pos = strpos($this->sseBuffer, "\n\n"))) {
-            $event = substr($this->sseBuffer, 0, $pos);
-            $this->sseBuffer = substr($this->sseBuffer, $pos + 2);
-
+        while (null !== ($event = $this->extractSSEEvent())) {
             if (!empty(trim($event))) {
                 $this->processSSEEvent($event);
             }
         }
 
-        if ($this->activeStream->eof() && empty($this->sseBuffer)) {
+        if ($this->activeStream->eof()) {
+            // The stream ended without a trailing blank line: dispatch what is left.
+            if (!empty(trim($this->sseBuffer))) {
+                $this->processSSEEvent($this->sseBuffer);
+            }
+
+            $this->sseBuffer = '';
             $this->activeStream = null;
         }
     }
@@ -274,13 +277,44 @@ class HttpTransport extends BaseTransport
     }
 
     /**
+     * Take the next complete event off the buffer, or null if none is complete yet.
+     *
+     * Per the SSE specification, lines are terminated by CRLF, LF or CR, so an
+     * event is delimited by any pair of those. Servers built on sse-starlette
+     * (the MCP Python SDK) use CRLF.
+     */
+    private function extractSSEEvent(): ?string
+    {
+        $position = null;
+        $length = 0;
+
+        foreach (["\r\n\r\n", "\n\n", "\r\r"] as $delimiter) {
+            $found = strpos($this->sseBuffer, $delimiter);
+
+            if (false !== $found && (null === $position || $found < $position)) {
+                $position = $found;
+                $length = \strlen($delimiter);
+            }
+        }
+
+        if (null === $position) {
+            return null;
+        }
+
+        $event = substr($this->sseBuffer, 0, $position);
+        $this->sseBuffer = substr($this->sseBuffer, $position + $length);
+
+        return $event;
+    }
+
+    /**
      * Parse a single SSE event and handle the message.
      */
     private function processSSEEvent(string $event): void
     {
         $data = '';
 
-        foreach (explode("\n", $event) as $line) {
+        foreach (preg_split("/\r\n|\r|\n/", $event) ?: [] as $line) {
             if (str_starts_with($line, 'data:')) {
                 $data .= trim(substr($line, 5));
             }

--- a/tests/Unit/Client/Transport/HttpTransportTest.php
+++ b/tests/Unit/Client/Transport/HttpTransportTest.php
@@ -11,14 +11,19 @@
 
 namespace Mcp\Tests\Unit\Client\Transport;
 
+use Mcp\Client;
 use Mcp\Client\State\ClientState;
 use Mcp\Client\Transport\HttpTransport;
 use Mcp\Exception\InvalidArgumentException;
 use Mcp\Schema\JsonRpc\Error;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
 final class HttpTransportTest extends TestCase
@@ -28,6 +33,65 @@ final class HttpTransportTest extends TestCase
     protected function setUp(): void
     {
         $this->factory = new Psr17Factory();
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function frameProvider(): iterable
+    {
+        yield 'LF line endings' => ["event: message\ndata: %s\n\n"];
+        // sse-starlette (and therefore every MCP Python SDK server) defaults to CRLF.
+        yield 'CRLF line endings' => ["event: message\r\ndata: %s\r\n\r\n"];
+        yield 'CR line endings' => ["event: message\rdata: %s\r\r"];
+        yield 'with an id field' => ["id: 1\r\nevent: message\r\ndata: %s\r\n\r\n"];
+        yield 'no trailing blank line' => ["event: message\ndata: %s\n"];
+        yield 'preceded by a comment' => [": ping\n\nevent: message\ndata: %s\n\n"];
+    }
+
+    #[DataProvider('frameProvider')]
+    #[TestDox('initialization succeeds for an SSE response framed as: $_dataName')]
+    public function testInitializeParsesSseFraming(string $frame): void
+    {
+        $httpClient = new class($frame) implements ClientInterface {
+            public function __construct(private readonly string $frame)
+            {
+            }
+
+            public function sendRequest(RequestInterface $request): ResponseInterface
+            {
+                $decoded = json_decode((string) $request->getBody(), true);
+
+                if ('initialize' !== ($decoded['method'] ?? null)) {
+                    return new Response(202);
+                }
+
+                $payload = json_encode([
+                    'jsonrpc' => '2.0',
+                    'id' => $decoded['id'],
+                    'result' => [
+                        'protocolVersion' => '2025-11-25',
+                        'capabilities' => ['tools' => ['listChanged' => false]],
+                        'serverInfo' => ['name' => 'test-server', 'version' => '1.0.0'],
+                    ],
+                ]);
+
+                return new Response(200, [
+                    'Content-Type' => 'text/event-stream',
+                    'Mcp-Session-Id' => 'abc123',
+                ], \sprintf($this->frame, $payload));
+            }
+        };
+
+        $client = Client::builder()
+            ->setClientInfo('test-client', '1.0.0')
+            ->setInitTimeout(1)
+            ->build();
+
+        $client->connect(new HttpTransport('http://localhost/mcp', [], $httpClient, $this->factory, $this->factory));
+
+        $this->assertTrue($client->isConnected());
+        $this->assertSame('test-server', $client->getServerInfo()?->name);
     }
 
     #[TestDox('SSE stream is aborted before the buffer can exceed the configured cap')]


### PR DESCRIPTION
## The bug

`HttpTransport` finds SSE event boundaries with `strpos($this->sseBuffer, "\n\n")` and splits event lines on `"\n"`. A server that terminates SSE lines with **CRLF** therefore never produces a recognised event: the response accumulates in `sseBuffer`, `handleMessage()` is never called, no response is ever stored for the pending request, and after `initTimeout` the fiber is resumed with an error:

```
Mcp\Exception\ConnectionException: Initialization failed: Request timed out
```

thrown from `Client::connect()`.

## Why it has not been noticed

This repository's own server emits LF (`Server/Transport/StreamableHttpTransport.php`), so client and server agree throughout the test suite — while disagreeing with most servers in the wild.

Every MCP server built on the **Python** SDK is affected. `FastMCP.streamable_http_app()` returns `sse_starlette`'s `EventSourceResponse` without a `sep` argument, and `sse_starlette`'s `DEFAULT_SEPARATOR` is `"\r\n"`. Hexdump of an `initialize` response from `mcp` 1.28.1:

```
6576 656e 743a 206d 6573 7361 6765 0d0a   event: message\r\n
6461 7461 3a20 7b22 6a73 6f6e ...  0d0a   data: {"jsonrpc"...\r\n
0d0a                                      \r\n
```

There is no `"\n\n"` substring anywhere in that payload.

The [SSE specification](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) requires a parser to accept CRLF, LF **or** CR, so the previous behaviour was non-compliant rather than merely unlucky.

## The fix

- Event extraction accepts `\r\n\r\n`, `\n\n` and `\r\r`, choosing whichever occurs **first** so a buffer split mid-sequence is handled correctly. None of the three is a substring of another, so a partial terminator at the end of a read simply waits for more data.
- Line splitting within an event uses the same set.
- A stream that reaches EOF with a trailing partial event now dispatches it rather than discarding it. Previously `activeStream` was only cleared when the buffer was empty, so a stream ending without a blank line also hung.

## Tests

Adds `tests/Unit/Client/Transport/HttpTransportTest.php` — the first tests for `src/Client/Transport/`. It drives `Client::connect()` through a stub PSR-18 client across six framings: LF, CRLF, CR, an `id:` field, a comment preamble, and a missing trailing blank line.

Without the fix, four of the six fail with the timeout above. With it, all pass.

Verification on my machine:

- `vendor/bin/phpunit tests/Unit` → `OK (823 tests, 2464 assertions)`
- `vendor/bin/phpstan analyse src/Client/Transport/HttpTransport.php` → `[OK] No errors`
- `vendor/bin/php-cs-fixer fix --dry-run --diff` on the changed file → clean
- Full suite: 32 errors before, 28 after — the difference is exactly the four new tests. The remaining failures are pre-existing on `main` (`tests/Inspector`) and unrelated to this change.
- End to end against a live `mcp` 1.28.1 server (`nextcloud-mcp-server`): `connect()`, `tools/list` and `tools/call` all succeed, with both a streaming PSR-18 client (`Symfony\Component\HttpClient\Psr18Client`) and a fully-buffered one. Before the fix both fail.

## Notes

I have not touched `CHANGELOG.md`, since there is no `Unreleased` section and I did not want to guess at your release process — happy to add an entry wherever you prefer.

---

_This PR was generated with the help of AI, and reviewed by a Human_
