### PR TITLE
Fix 'notifcation' typo in docs

### DIFF
--- a/docs/server-client-communication.md
+++ b/docs/server-client-communication.md
@@ -51,7 +51,7 @@ The `sample` method accepts four arguments:
 ## Logging
 
 The [Logging](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/logging) utility enables servers
-to send structured log messages as notifcation to clients:
+to send structured log messages as notification to clients:
 
 ```php
 use Mcp\Schema\Enum\LoggingLevel;


### PR DESCRIPTION
Minor documentation typo: `notifcation` should be `notification` (`docs/server-client-communication.md`). No content change.
