### PR TITLE
fix: normalize empty tool schema properties

### DIFF
--- a/src/Schema/Tool.php
+++ b/src/Schema/Tool.php
@@ -21,8 +21,8 @@ use Mcp\Exception\InvalidArgumentException;
  *
  * @phpstan-type ToolInputSchema array{
  *     type: 'object',
- *     properties: array<string, mixed>,
- *     required: string[]|null
+ *     properties?: array<string, mixed>,
+ *     required?: string[]|null
  * }
  * @phpstan-type ToolOutputSchema array{
  *     type: 'object',

--- a/src/Schema/Tool.php
+++ b/src/Schema/Tool.php
@@ -169,7 +169,7 @@ class Tool implements \JsonSerializable
         }
 
         foreach ($schema as $key => $value) {
-            if ($key !== 'properties' && \is_array($value)) {
+            if ('properties' !== $key && \is_array($value)) {
                 $schema[$key] = self::normalizeSchemaProperties($value);
             }
         }

--- a/src/Schema/Tool.php
+++ b/src/Schema/Tool.php
@@ -127,7 +127,7 @@ class Tool implements \JsonSerializable
         if (null !== $this->title) {
             $data['title'] = $this->title;
         }
-        $data['inputSchema'] = $this->inputSchema;
+        $data['inputSchema'] = self::normalizeSchemaProperties($this->inputSchema);
         if (null !== $this->description) {
             $data['description'] = $this->description;
         }
@@ -141,14 +141,14 @@ class Tool implements \JsonSerializable
             $data['_meta'] = $this->meta;
         }
         if (null !== $this->outputSchema) {
-            $data['outputSchema'] = $this->outputSchema;
+            $data['outputSchema'] = self::normalizeSchemaProperties($this->outputSchema);
         }
 
         return $data;
     }
 
     /**
-     * Normalize schema properties: convert an empty properties array to stdClass.
+     * Normalize schema properties: convert an empty properties array to stdClass recursively.
      *
      * @param array<string, mixed> $schema
      *
@@ -156,8 +156,22 @@ class Tool implements \JsonSerializable
      */
     private static function normalizeSchemaProperties(array $schema): array
     {
-        if (isset($schema['properties']) && \is_array($schema['properties']) && empty($schema['properties'])) {
-            $schema['properties'] = new \stdClass();
+        if (isset($schema['properties']) && \is_array($schema['properties'])) {
+            if (empty($schema['properties'])) {
+                $schema['properties'] = new \stdClass();
+            } else {
+                foreach ($schema['properties'] as $key => $propSchema) {
+                    if (\is_array($propSchema)) {
+                        $schema['properties'][$key] = self::normalizeSchemaProperties($propSchema);
+                    }
+                }
+            }
+        }
+
+        foreach ($schema as $key => $value) {
+            if ($key !== 'properties' && \is_array($value)) {
+                $schema[$key] = self::normalizeSchemaProperties($value);
+            }
         }
 
         return $schema;

--- a/tests/Unit/Schema/ToolTest.php
+++ b/tests/Unit/Schema/ToolTest.php
@@ -97,4 +97,146 @@ class ToolTest extends TestCase
         $this->assertSame($original->name, $restored->name);
         $this->assertSame($original->description, $restored->description);
     }
+
+    public function testEmptyPropertiesNormalizationOnDirectConstruction(): void
+    {
+        $tool = new Tool(
+            name: 'test',
+            title: null,
+            inputSchema: [
+                'type' => 'object',
+                'properties' => [],
+            ],
+            description: null,
+            annotations: null,
+        );
+        $serialized = $tool->jsonSerialize();
+        $this->assertInstanceOf(\stdClass::class, $serialized['inputSchema']['properties']);
+        $this->assertSame('{"name":"test","inputSchema":{"type":"object","properties":{}}}', json_encode($serialized));
+    }
+
+    public function testEmptyPropertiesNormalizationOnFromArray(): void
+    {
+        $tool = Tool::fromArray([
+            'name' => 'test',
+            'inputSchema' => [
+                'type' => 'object',
+                'properties' => [],
+            ],
+        ]);
+        $serialized = $tool->jsonSerialize();
+        $this->assertInstanceOf(\stdClass::class, $serialized['inputSchema']['properties']);
+        $this->assertSame('{"name":"test","inputSchema":{"type":"object","properties":{}}}', json_encode($serialized));
+    }
+
+    public function testJsonRoundTripPreservesEmptyPropertiesObject(): void
+    {
+        $json = '{"type":"object","properties":{}}';
+        $schema = json_decode($json, true);
+        $tool = new Tool('test', null, $schema, null, null);
+        $serialized = $tool->jsonSerialize();
+
+        $this->assertInstanceOf(\stdClass::class, $serialized['inputSchema']['properties']);
+        $this->assertSame('{"name":"test","inputSchema":{"type":"object","properties":{}}}', json_encode($serialized));
+    }
+
+    public function testNestedObjectEmptyPropertiesNormalization(): void
+    {
+        $tool = new Tool(
+            name: 'test',
+            title: null,
+            inputSchema: [
+                'type' => 'object',
+                'properties' => [
+                    'filter' => [
+                        'type' => 'object',
+                        'properties' => [],
+                    ],
+                ],
+            ],
+            description: null,
+            annotations: null,
+        );
+        $serialized = $tool->jsonSerialize();
+        $this->assertInstanceOf(\stdClass::class, $serialized['inputSchema']['properties']['filter']['properties']);
+        $this->assertSame('{"name":"test","inputSchema":{"type":"object","properties":{"filter":{"type":"object","properties":{}}}}}', json_encode($serialized));
+    }
+
+    public function testExistingNonEmptyPropertiesUnchanged(): void
+    {
+        $tool = new Tool(
+            name: 'test',
+            title: null,
+            inputSchema: [
+                'type' => 'object',
+                'properties' => [
+                    'name' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+            description: null,
+            annotations: null,
+        );
+        $serialized = $tool->jsonSerialize();
+        $this->assertIsArray($serialized['inputSchema']['properties']);
+        $this->assertArrayHasKey('name', $serialized['inputSchema']['properties']);
+        $this->assertSame('{"name":"test","inputSchema":{"type":"object","properties":{"name":{"type":"string"}}}}', json_encode($serialized));
+    }
+
+    public function testValidArraysAreNotTransformed(): void
+    {
+        $tool = new Tool(
+            name: 'test',
+            title: null,
+            inputSchema: [
+                'type' => 'object',
+                'properties' => [
+                    'tags' => [
+                        'type' => 'array',
+                        'items' => [
+                            'type' => 'string'
+                        ],
+                    ],
+                    'status' => [
+                        'type' => 'string',
+                        'enum' => [],
+                    ],
+                ],
+                'required' => [],
+            ],
+            description: null,
+            annotations: null,
+        );
+        $serialized = $tool->jsonSerialize();
+        $this->assertIsArray($serialized['inputSchema']['required']);
+        $this->assertEmpty($serialized['inputSchema']['required']);
+        $this->assertIsArray($serialized['inputSchema']['properties']['tags']);
+        $this->assertIsArray($serialized['inputSchema']['properties']['status']['enum']);
+        $this->assertEmpty($serialized['inputSchema']['properties']['status']['enum']);
+        $this->assertSame('{"name":"test","inputSchema":{"type":"object","properties":{"tags":{"type":"array","items":{"type":"string"}},"status":{"type":"string","enum":[]}},"required":[]}}', json_encode($serialized));
+    }
+
+    public function testOutputSchemaEmptyPropertiesNormalization(): void
+    {
+        $tool = new Tool(
+            name: 'test',
+            title: null,
+            inputSchema: [
+                'type' => 'object',
+                'properties' => ['q' => ['type' => 'string']],
+            ],
+            description: null,
+            annotations: null,
+            icons: null,
+            meta: null,
+            outputSchema: [
+                'type' => 'object',
+                'properties' => [],
+            ]
+        );
+        $serialized = $tool->jsonSerialize();
+        $this->assertInstanceOf(\stdClass::class, $serialized['outputSchema']['properties']);
+        $this->assertSame('{"name":"test","inputSchema":{"type":"object","properties":{"q":{"type":"string"}}},"outputSchema":{"type":"object","properties":{}}}', json_encode($serialized));
+    }
 }

--- a/tests/Unit/Schema/ToolTest.php
+++ b/tests/Unit/Schema/ToolTest.php
@@ -132,7 +132,7 @@ class ToolTest extends TestCase
     public function testJsonRoundTripPreservesEmptyPropertiesObject(): void
     {
         $json = '{"type":"object","properties":{}}';
-        $schema = json_decode($json, true);
+        $schema = (array) json_decode($json, true);
         $tool = new Tool('test', null, $schema, null, null);
         $serialized = $tool->jsonSerialize();
 
@@ -195,7 +195,7 @@ class ToolTest extends TestCase
                     'tags' => [
                         'type' => 'array',
                         'items' => [
-                            'type' => 'string'
+                            'type' => 'string',
                         ],
                     ],
                     'status' => [
@@ -233,7 +233,7 @@ class ToolTest extends TestCase
             outputSchema: [
                 'type' => 'object',
                 'properties' => [],
-            ]
+            ],
         );
         $serialized = $tool->jsonSerialize();
         $this->assertInstanceOf(\stdClass::class, $serialized['outputSchema']['properties']);


### PR DESCRIPTION
## Summary

Fixes #405.

PHP serializes empty arrays as `[]`, which causes an empty JSON Schema `properties` object to be serialized as an array instead of the required JSON object `{}`.

This can cause strict MCP clients to reject otherwise valid tool definitions.

### Changes

* Recursively normalize empty `properties` arrays to `\stdClass`.
* Apply schema normalization during `Tool::jsonSerialize()` so directly constructed `Tool` instances are handled correctly despite readonly schema properties.
* Apply the same normalization to both `inputSchema` and `outputSchema`.
* Preserve legitimate JSON Schema arrays such as `required` and `enum`.
* Retain the existing `Tool::fromArray()` normalization behavior.

### Test coverage

Added regression coverage for:

* Direct `Tool` construction with empty `properties`.
* `Tool::fromArray()` with empty `properties`.
* JSON decode → Tool construction → serialization.
* Nested object schemas.
* Existing non-empty `properties`.
* Legitimate `required` and `enum` arrays.
* `outputSchema` with empty `properties`.

### Validation

* `git diff --check` passes.
* PHPUnit could not be executed locally because PHP/Composer are unavailable in the development environment.

The implementation is intentionally limited to the schema normalization and regression tests required for #405.
