### PR TITLE
[Server] Handle malformed JSON-RPC input graceful

### DIFF
--- a/src/JsonRpc/MessageFactory.php
+++ b/src/JsonRpc/MessageFactory.php
@@ -177,6 +177,10 @@ final class MessageFactory
                 throw new InvalidInputMessageException('Invalid JSON-RPC message: missing "method", "result", or "error" field.');
             }
 
+            if (!\is_string($data['method'])) {
+                throw new InvalidInputMessageException('Invalid JSON-RPC message: "method" must be a string.');
+            }
+
             $messageClass = $this->findMessageClassByMethod($data['method']);
 
             return $messageClass::fromArray($data);

--- a/src/Schema/Annotations.php
+++ b/src/Schema/Annotations.php
@@ -60,13 +60,44 @@ class Annotations implements \JsonSerializable
     {
         $audience = null;
         if (isset($data['audience']) && \is_array($data['audience'])) {
-            $audience = array_map(static fn (string $r) => Role::from($r), $data['audience']);
+            $audience = array_map(
+                static function (mixed $role): Role {
+                    if (!\is_string($role) || null === $case = Role::tryFrom($role)) {
+                        throw new InvalidArgumentException('Each entry in "audience" must be a valid role.');
+                    }
+
+                    return $case;
+                },
+                $data['audience'],
+            );
+        }
+
+        if (isset($data['priority']) && !\is_float($data['priority']) && !\is_int($data['priority'])) {
+            throw new InvalidArgumentException('Invalid "priority" in Annotations data; expected a number.');
         }
 
         return new self(
             $audience,
             isset($data['priority']) ? (float) $data['priority'] : null
         );
+    }
+
+    /**
+     * Hydrates an optional "annotations" field, rejecting a value that is present but not an object.
+     *
+     * @param string $context the surrounding schema type, used for the error message
+     */
+    public static function tryFromArray(mixed $data, string $context): ?self
+    {
+        if (null === $data) {
+            return null;
+        }
+
+        if (!\is_array($data)) {
+            throw new InvalidArgumentException(\sprintf('Invalid "annotations" in %s data; expected an array.', $context));
+        }
+
+        return self::fromArray($data);
     }
 
     /**

--- a/src/Schema/Content/AudioContent.php
+++ b/src/Schema/Content/AudioContent.php
@@ -44,14 +44,17 @@ class AudioContent extends Content
      */
     public static function fromArray(array $data): self
     {
-        if (!isset($data['data']) || !isset($data['mimeType'])) {
-            throw new InvalidArgumentException('Invalid or missing "data" or "mimeType" in AudioContent data.');
+        if (!isset($data['data']) || !\is_string($data['data'])) {
+            throw new InvalidArgumentException('Missing or invalid "data" in AudioContent data.');
+        }
+        if (!isset($data['mimeType']) || !\is_string($data['mimeType'])) {
+            throw new InvalidArgumentException('Missing or invalid "mimeType" in AudioContent data.');
         }
 
         return new self(
             $data['data'],
             $data['mimeType'],
-            isset($data['annotations']) ? Annotations::fromArray($data['annotations']) : null
+            Annotations::tryFromArray($data['annotations'] ?? null, 'AudioContent')
         );
     }
 

--- a/src/Schema/Content/BlobResourceContents.php
+++ b/src/Schema/Content/BlobResourceContents.php
@@ -54,6 +54,13 @@ class BlobResourceContents extends ResourceContents
             throw new InvalidArgumentException('Missing or invalid "blob" for BlobResourceContents.');
         }
 
+        if (isset($data['mimeType']) && !\is_string($data['mimeType'])) {
+            throw new InvalidArgumentException('Invalid "mimeType" for BlobResourceContents.');
+        }
+        if (isset($data['_meta']) && !\is_array($data['_meta'])) {
+            throw new InvalidArgumentException('Invalid "_meta" for BlobResourceContents.');
+        }
+
         return new self($data['uri'], $data['mimeType'] ?? null, $data['blob'], $data['_meta'] ?? null);
     }
 

--- a/src/Schema/Content/EmbeddedResource.php
+++ b/src/Schema/Content/EmbeddedResource.php
@@ -62,7 +62,7 @@ class EmbeddedResource extends Content
 
         return new self(
             $resourceInstance,
-            isset($data['annotations']) ? Annotations::fromArray($data['annotations']) : null,
+            Annotations::tryFromArray($data['annotations'] ?? null, 'EmbeddedResource'),
         );
     }
 

--- a/src/Schema/Content/PromptMessage.php
+++ b/src/Schema/Content/PromptMessage.php
@@ -58,6 +58,9 @@ class PromptMessage extends Content
 
         $contentData = $data['content'];
         $contentType = $contentData['type'] ?? null;
+        if (!\is_string($contentType)) {
+            throw new InvalidArgumentException('Missing or invalid content "type" for PromptMessage.');
+        }
 
         $content = match ($contentType) {
             'text' => TextContent::fromArray($contentData),
@@ -67,7 +70,11 @@ class PromptMessage extends Content
             default => throw new InvalidArgumentException(\sprintf('Invalid content type "%s" for PromptMessage.', $contentType)),
         };
 
-        return new self(Role::from($data['role']), $content);
+        if (null === $role = Role::tryFrom($data['role'])) {
+            throw new InvalidArgumentException(\sprintf('Invalid "role" value "%s" in PromptMessage data.', $data['role']));
+        }
+
+        return new self($role, $content);
     }
 
     /**

--- a/src/Schema/Content/SamplingMessage.php
+++ b/src/Schema/Content/SamplingMessage.php
@@ -45,9 +45,15 @@ class SamplingMessage extends Content
             throw new InvalidArgumentException('Missing or invalid "content" in SamplingMessage data.');
         }
 
-        $role = Role::from($data['role']);
+        if (null === $role = Role::tryFrom($data['role'])) {
+            throw new InvalidArgumentException(\sprintf('Invalid "role" value "%s" in SamplingMessage data.', $data['role']));
+        }
+
         $contentData = $data['content'];
         $contentType = $contentData['type'] ?? null;
+        if (!\is_string($contentType)) {
+            throw new InvalidArgumentException('Missing or invalid content "type" for SamplingMessage.');
+        }
 
         $contentInstance = match ($contentType) {
             'text' => TextContent::fromArray($contentData),

--- a/src/Schema/Content/TextContent.php
+++ b/src/Schema/Content/TextContent.php
@@ -56,7 +56,7 @@ class TextContent extends Content
 
         return new self(
             $data['text'],
-            isset($data['annotations']) ? Annotations::fromArray($data['annotations']) : null
+            Annotations::tryFromArray($data['annotations'] ?? null, 'TextContent')
         );
     }
 

--- a/src/Schema/Content/TextResourceContents.php
+++ b/src/Schema/Content/TextResourceContents.php
@@ -54,6 +54,13 @@ class TextResourceContents extends ResourceContents
             throw new InvalidArgumentException('Missing or invalid "text" for TextResourceContents.');
         }
 
+        if (isset($data['mimeType']) && !\is_string($data['mimeType'])) {
+            throw new InvalidArgumentException('Invalid "mimeType" for TextResourceContents.');
+        }
+        if (isset($data['_meta']) && !\is_array($data['_meta'])) {
+            throw new InvalidArgumentException('Invalid "_meta" for TextResourceContents.');
+        }
+
         return new self($data['uri'], $data['mimeType'] ?? null, $data['text'], $data['_meta'] ?? null);
     }
 

--- a/src/Schema/Elicitation/ElicitationSchema.php
+++ b/src/Schema/Elicitation/ElicitationSchema.php
@@ -35,6 +35,9 @@ final class ElicitationSchema implements \JsonSerializable
         }
 
         foreach ($required as $name) {
+            if (!\is_string($name)) {
+                throw new InvalidArgumentException('Each entry in "required" must be a string.');
+            }
             if (!\array_key_exists($name, $properties)) {
                 throw new InvalidArgumentException(\sprintf('Required property "%s" is not defined in properties.', $name));
             }
@@ -66,6 +69,10 @@ final class ElicitationSchema implements \JsonSerializable
                 throw new InvalidArgumentException(\sprintf('Property "%s" must be an array.', $name));
             }
             $properties[$name] = self::createSchemaDefinition($propertyData);
+        }
+
+        if (isset($data['required']) && !\is_array($data['required'])) {
+            throw new InvalidArgumentException('Invalid "required" for elicitation schema; expected an array.');
         }
 
         return new self(

--- a/src/Schema/Extension/Apps/UiResourceContentMeta.php
+++ b/src/Schema/Extension/Apps/UiResourceContentMeta.php
@@ -11,6 +11,8 @@
 
 namespace Mcp\Schema\Extension\Apps;
 
+use Mcp\Exception\InvalidArgumentException;
+
 /**
  * Metadata for the _meta.ui field on resource content in a resources/read response.
  *
@@ -43,6 +45,19 @@ final class UiResourceContentMeta implements \JsonSerializable
      */
     public static function fromArray(array $data): self
     {
+        if (isset($data['csp']) && !\is_array($data['csp'])) {
+            throw new InvalidArgumentException('Invalid "csp" in UiResourceContentMeta data; expected an array.');
+        }
+        if (isset($data['permissions']) && !\is_array($data['permissions'])) {
+            throw new InvalidArgumentException('Invalid "permissions" in UiResourceContentMeta data; expected an array.');
+        }
+        if (isset($data['domain']) && !\is_string($data['domain'])) {
+            throw new InvalidArgumentException('Invalid "domain" in UiResourceContentMeta data.');
+        }
+        if (isset($data['prefersBorder']) && !\is_bool($data['prefersBorder'])) {
+            throw new InvalidArgumentException('Invalid "prefersBorder" in UiResourceContentMeta data.');
+        }
+
         return new self(
             csp: isset($data['csp']) ? UiResourceCsp::fromArray($data['csp']) : null,
             permissions: isset($data['permissions']) ? UiResourcePermissions::fromArray($data['permissions']) : null,

--- a/src/Schema/Extension/Apps/UiResourceCsp.php
+++ b/src/Schema/Extension/Apps/UiResourceCsp.php
@@ -11,6 +11,8 @@
 
 namespace Mcp\Schema\Extension\Apps;
 
+use Mcp\Exception\InvalidArgumentException;
+
 /**
  * Content Security Policy configuration for MCP App resources.
  *
@@ -47,6 +49,12 @@ final class UiResourceCsp implements \JsonSerializable
      */
     public static function fromArray(array $data): self
     {
+        foreach (['connectDomains', 'resourceDomains', 'frameDomains', 'baseUriDomains'] as $key) {
+            if (isset($data[$key]) && !\is_array($data[$key])) {
+                throw new InvalidArgumentException(\sprintf('Invalid "%s" in UiResourceCsp data; expected an array.', $key));
+            }
+        }
+
         return new self(
             connectDomains: $data['connectDomains'] ?? null,
             resourceDomains: $data['resourceDomains'] ?? null,

--- a/src/Schema/Extension/Apps/UiToolMeta.php
+++ b/src/Schema/Extension/Apps/UiToolMeta.php
@@ -11,6 +11,8 @@
 
 namespace Mcp\Schema\Extension\Apps;
 
+use Mcp\Exception\InvalidArgumentException;
+
 /**
  * Metadata for the _meta.ui field on a Tool, linking it to a UI resource.
  *
@@ -39,9 +41,25 @@ final class UiToolMeta implements \JsonSerializable
      */
     public static function fromArray(array $data): self
     {
+        if (isset($data['resourceUri']) && !\is_string($data['resourceUri'])) {
+            throw new InvalidArgumentException('Invalid "resourceUri" in UiToolMeta data.');
+        }
+        if (isset($data['visibility']) && !\is_array($data['visibility'])) {
+            throw new InvalidArgumentException('Invalid "visibility" in UiToolMeta data; expected an array.');
+        }
+
         return new self(
             resourceUri: $data['resourceUri'] ?? null,
-            visibility: isset($data['visibility']) ? array_map(ToolVisibility::from(...), $data['visibility']) : null,
+            visibility: isset($data['visibility']) ? array_map(
+                static function (mixed $entry): ToolVisibility {
+                    if (!\is_string($entry) || null === $case = ToolVisibility::tryFrom($entry)) {
+                        throw new InvalidArgumentException('Each entry in "visibility" of UiToolMeta data must be a valid tool visibility.');
+                    }
+
+                    return $case;
+                },
+                $data['visibility'],
+            ) : null,
         );
     }
 

--- a/src/Schema/Icon.php
+++ b/src/Schema/Icon.php
@@ -65,8 +65,36 @@ class Icon implements \JsonSerializable
         if (empty($data['src']) || !\is_string($data['src'])) {
             throw new InvalidArgumentException('Invalid or missing "src" in Icon data.');
         }
+        if (isset($data['mimeType']) && !\is_string($data['mimeType'])) {
+            throw new InvalidArgumentException('Invalid "mimeType" in Icon data.');
+        }
+        if (isset($data['sizes']) && !\is_array($data['sizes'])) {
+            throw new InvalidArgumentException('Invalid "sizes" in Icon data.');
+        }
 
-        return new self($data['src'], $data['mimeTypes'] ?? null, $data['sizes'] ?? null);
+        return new self($data['src'], $data['mimeType'] ?? null, $data['sizes'] ?? null);
+    }
+
+    /**
+     * Hydrates an "icons" list, rejecting entries that are not objects.
+     *
+     * @param array<mixed> $icons
+     * @param string       $context the surrounding schema type, used for the error message
+     *
+     * @return self[]
+     */
+    public static function listFromArray(array $icons, string $context): array
+    {
+        return array_map(
+            static function (mixed $icon) use ($context): self {
+                if (!\is_array($icon)) {
+                    throw new InvalidArgumentException(\sprintf('Each entry in "icons" of %s data must be an array.', $context));
+                }
+
+                return self::fromArray($icon);
+            },
+            $icons,
+        );
     }
 
     /**

--- a/src/Schema/Implementation.php
+++ b/src/Schema/Implementation.php
@@ -57,7 +57,14 @@ class Implementation implements \JsonSerializable
                 throw new InvalidArgumentException('Invalid "icons" in Implementation data; expected an array.');
             }
 
-            $data['icons'] = array_map(Icon::fromArray(...), $data['icons']);
+            $data['icons'] = Icon::listFromArray($data['icons'], 'Implementation');
+        }
+
+        if (isset($data['description']) && !\is_string($data['description'])) {
+            throw new InvalidArgumentException('Invalid "description" in Implementation data.');
+        }
+        if (isset($data['websiteUrl']) && !\is_string($data['websiteUrl'])) {
+            throw new InvalidArgumentException('Invalid "websiteUrl" in Implementation data.');
         }
 
         return new self(

--- a/src/Schema/ModelPreferences.php
+++ b/src/Schema/ModelPreferences.php
@@ -11,6 +11,8 @@
 
 namespace Mcp\Schema;
 
+use Mcp\Exception\InvalidArgumentException;
+
 /**
  * The server's preferences for model selection, requested of the client during sampling.
  *
@@ -61,12 +63,33 @@ class ModelPreferences implements \JsonSerializable
      */
     public static function fromArray(array $preferences): self
     {
+        if (isset($preferences['hints']) && !\is_array($preferences['hints'])) {
+            throw new InvalidArgumentException('Invalid "hints" in ModelPreferences data.');
+        }
+
         return new self(
             $preferences['hints'] ?? null,
-            $preferences['costPriority'] ?? null,
-            $preferences['speedPriority'] ?? null,
-            $preferences['intelligencePriority'] ?? null,
+            self::priority($preferences, 'costPriority'),
+            self::priority($preferences, 'speedPriority'),
+            self::priority($preferences, 'intelligencePriority'),
         );
+    }
+
+    /**
+     * @param array<string, mixed> $preferences
+     */
+    private static function priority(array $preferences, string $key): ?float
+    {
+        if (!isset($preferences[$key])) {
+            return null;
+        }
+
+        // JSON numbers decode to int when they have no fractional part.
+        if (!\is_float($preferences[$key]) && !\is_int($preferences[$key])) {
+            throw new InvalidArgumentException(\sprintf('Invalid "%s" in ModelPreferences data; expected a number.', $key));
+        }
+
+        return (float) $preferences[$key];
     }
 
     /**

--- a/src/Schema/Notification/CancelledNotification.php
+++ b/src/Schema/Notification/CancelledNotification.php
@@ -48,6 +48,10 @@ class CancelledNotification extends Notification
             throw new InvalidArgumentException('Invalid or missing "requestId" parameter for "notifications/cancelled" notification.');
         }
 
+        if (isset($params['reason']) && !\is_string($params['reason'])) {
+            throw new InvalidArgumentException('Invalid "reason" parameter for "notifications/cancelled" notification.');
+        }
+
         return new self($params['requestId'], $params['reason'] ?? null);
     }
 

--- a/src/Schema/Notification/LoggingMessageNotification.php
+++ b/src/Schema/Notification/LoggingMessageNotification.php
@@ -47,7 +47,14 @@ class LoggingMessageNotification extends Notification
             throw new InvalidArgumentException('Missing "data" parameter for "notifications/message" notification.');
         }
 
-        $level = LoggingLevel::from($params['level']);
+        if (null === $level = LoggingLevel::tryFrom($params['level'])) {
+            throw new InvalidArgumentException(\sprintf('Invalid "level" parameter "%s" for "notifications/message" notification.', $params['level']));
+        }
+
+        if (isset($params['logger']) && !\is_string($params['logger'])) {
+            throw new InvalidArgumentException('Invalid "logger" parameter for "notifications/message" notification.');
+        }
+
         $data = \is_string($params['data']) ? $params['data'] : json_encode($params['data']);
 
         return new self($level, $data, $params['logger'] ?? null);

--- a/src/Schema/Notification/ProgressNotification.php
+++ b/src/Schema/Notification/ProgressNotification.php
@@ -44,18 +44,27 @@ class ProgressNotification extends Notification
 
     protected static function fromParams(?array $params): Notification
     {
-        if (!isset($params['progressToken']) || !\is_string($params['progressToken'])) {
+        // JSON numbers decode to int when they have no fractional part.
+        if (!isset($params['progressToken']) || !\is_string($params['progressToken']) && !\is_int($params['progressToken'])) {
             throw new InvalidArgumentException('Missing or invalid "progressToken" parameter for "notifications/progress" notification.');
         }
 
-        if (!isset($params['progress']) || !\is_float($params['progress'])) {
+        if (!isset($params['progress']) || !\is_float($params['progress']) && !\is_int($params['progress'])) {
             throw new InvalidArgumentException('Missing or invalid "progress" parameter for "notifications/progress" notification.');
+        }
+
+        if (isset($params['total']) && !\is_float($params['total']) && !\is_int($params['total'])) {
+            throw new InvalidArgumentException('Invalid "total" parameter for "notifications/progress" notification.');
+        }
+
+        if (isset($params['message']) && !\is_string($params['message'])) {
+            throw new InvalidArgumentException('Invalid "message" parameter for "notifications/progress" notification.');
         }
 
         return new self(
             $params['progressToken'],
-            $params['progress'],
-            $params['total'] ?? null,
+            (float) $params['progress'],
+            isset($params['total']) ? (float) $params['total'] : null,
             $params['message'] ?? null,
         );
     }

--- a/src/Schema/Prompt.php
+++ b/src/Schema/Prompt.php
@@ -67,11 +67,26 @@ class Prompt implements \JsonSerializable
         }
         $arguments = null;
         if (isset($data['arguments']) && \is_array($data['arguments'])) {
-            $arguments = array_map(static fn (array $argData) => PromptArgument::fromArray($argData), $data['arguments']);
+            $arguments = array_map(
+                static function (mixed $argData): PromptArgument {
+                    if (!\is_array($argData)) {
+                        throw new InvalidArgumentException('Each entry in "arguments" of Prompt data must be an array.');
+                    }
+
+                    return PromptArgument::fromArray($argData);
+                },
+                $data['arguments'],
+            );
         }
 
-        if (!empty($data['_meta']) && !\is_array($data['_meta'])) {
+        if (isset($data['_meta']) && !\is_array($data['_meta'])) {
             throw new InvalidArgumentException('Invalid "_meta" in Prompt data.');
+        }
+        if (isset($data['title']) && !\is_string($data['title'])) {
+            throw new InvalidArgumentException('Invalid "title" in Prompt data.');
+        }
+        if (isset($data['description']) && !\is_string($data['description'])) {
+            throw new InvalidArgumentException('Invalid "description" in Prompt data.');
         }
 
         return new self(
@@ -79,7 +94,7 @@ class Prompt implements \JsonSerializable
             title: $data['title'] ?? null,
             description: $data['description'] ?? null,
             arguments: $arguments,
-            icons: isset($data['icons']) && \is_array($data['icons']) ? array_map(Icon::fromArray(...), $data['icons']) : null,
+            icons: isset($data['icons']) && \is_array($data['icons']) ? Icon::listFromArray($data['icons'], 'Prompt') : null,
             meta: isset($data['_meta']) ? $data['_meta'] : null
         );
     }

--- a/src/Schema/PromptArgument.php
+++ b/src/Schema/PromptArgument.php
@@ -47,6 +47,13 @@ class PromptArgument implements \JsonSerializable
             throw new InvalidArgumentException('Invalid or missing "name" in PromptArgument data.');
         }
 
+        if (isset($data['description']) && !\is_string($data['description'])) {
+            throw new InvalidArgumentException('Invalid "description" in PromptArgument data.');
+        }
+        if (isset($data['required']) && !\is_bool($data['required'])) {
+            throw new InvalidArgumentException('Invalid "required" in PromptArgument data.');
+        }
+
         return new self(
             name: $data['name'],
             description: $data['description'] ?? null,

--- a/src/Schema/Request/CompletionCompleteRequest.php
+++ b/src/Schema/Request/CompletionCompleteRequest.php
@@ -45,8 +45,8 @@ final class CompletionCompleteRequest extends Request
         }
 
         $ref = match ($params['ref']['type'] ?? null) {
-            'ref/prompt' => new PromptReference($params['ref']['name']),
-            'ref/resource' => new ResourceReference($params['ref']['uri']),
+            'ref/prompt' => new PromptReference(self::refString($params['ref'], 'name')),
+            'ref/resource' => new ResourceReference(self::refString($params['ref'], 'uri')),
             default => throw new InvalidArgumentException('Invalid "ref" parameter for completion/complete.'),
         };
 
@@ -55,6 +55,18 @@ final class CompletionCompleteRequest extends Request
         }
 
         return new self($ref, $params['argument']);
+    }
+
+    /**
+     * @param array<mixed> $ref
+     */
+    private static function refString(array $ref, string $key): string
+    {
+        if (!isset($ref[$key]) || !\is_string($ref[$key])) {
+            throw new InvalidArgumentException(\sprintf('Missing or invalid "ref.%s" parameter for completion/complete.', $key));
+        }
+
+        return $ref[$key];
     }
 
     /**

--- a/src/Schema/Request/CreateSamplingMessageRequest.php
+++ b/src/Schema/Request/CreateSamplingMessageRequest.php
@@ -87,6 +87,9 @@ final class CreateSamplingMessageRequest extends Request
 
         $preferences = null;
         if (isset($params['preferences'])) {
+            if (!\is_array($params['preferences'])) {
+                throw new InvalidArgumentException('Invalid "preferences" parameter for sampling/createMessage.');
+            }
             $preferences = ModelPreferences::fromArray($params['preferences']);
         }
 
@@ -95,13 +98,37 @@ final class CreateSamplingMessageRequest extends Request
             $includeContext = SamplingContext::tryFrom($params['includeContext']);
         }
 
+        if (isset($params['systemPrompt']) && !\is_string($params['systemPrompt'])) {
+            throw new InvalidArgumentException('Invalid "systemPrompt" parameter for sampling/createMessage.');
+        }
+
+        if (isset($params['temperature']) && !\is_float($params['temperature']) && !\is_int($params['temperature'])) {
+            throw new InvalidArgumentException('Invalid "temperature" parameter for sampling/createMessage.');
+        }
+
+        if (isset($params['stopSequences'])) {
+            if (!\is_array($params['stopSequences'])) {
+                throw new InvalidArgumentException('Invalid "stopSequences" parameter for sampling/createMessage.');
+            }
+
+            foreach ($params['stopSequences'] as $stopSequence) {
+                if (!\is_string($stopSequence)) {
+                    throw new InvalidArgumentException('Each entry in "stopSequences" must be a string for sampling/createMessage.');
+                }
+            }
+        }
+
+        if (isset($params['metadata']) && !\is_array($params['metadata'])) {
+            throw new InvalidArgumentException('Invalid "metadata" parameter for sampling/createMessage.');
+        }
+
         return new self(
             $messages,
             $params['maxTokens'],
             $preferences,
             $params['systemPrompt'] ?? null,
             $includeContext,
-            $params['temperature'] ?? null,
+            isset($params['temperature']) ? (float) $params['temperature'] : null,
             $params['stopSequences'] ?? null,
             $params['metadata'] ?? null,
         );

--- a/src/Schema/Request/InitializeRequest.php
+++ b/src/Schema/Request/InitializeRequest.php
@@ -42,17 +42,17 @@ final class InitializeRequest extends Request
 
     protected static function fromParams(?array $params): static
     {
-        if (!isset($params['protocolVersion'])) {
-            throw new InvalidArgumentException('protocolVersion is required');
+        if (!isset($params['protocolVersion']) || !\is_string($params['protocolVersion'])) {
+            throw new InvalidArgumentException('Missing or invalid "protocolVersion" parameter for initialize.');
         }
 
-        if (!isset($params['capabilities'])) {
-            throw new InvalidArgumentException('capabilities is required');
+        if (!isset($params['capabilities']) || !\is_array($params['capabilities'])) {
+            throw new InvalidArgumentException('Missing or invalid "capabilities" parameter for initialize.');
         }
         $capabilities = ClientCapabilities::fromArray($params['capabilities']);
 
-        if (!isset($params['clientInfo'])) {
-            throw new InvalidArgumentException('clientInfo is required');
+        if (!isset($params['clientInfo']) || !\is_array($params['clientInfo'])) {
+            throw new InvalidArgumentException('Missing or invalid "clientInfo" parameter for initialize.');
         }
         $clientInfo = Implementation::fromArray($params['clientInfo']);
 

--- a/src/Schema/Request/ListPromptsRequest.php
+++ b/src/Schema/Request/ListPromptsRequest.php
@@ -11,6 +11,7 @@
 
 namespace Mcp\Schema\Request;
 
+use Mcp\Exception\InvalidArgumentException;
 use Mcp\Schema\JsonRpc\Request;
 
 /**
@@ -37,6 +38,10 @@ final class ListPromptsRequest extends Request
 
     protected static function fromParams(?array $params): static
     {
+        if (isset($params['cursor']) && !\is_string($params['cursor'])) {
+            throw new InvalidArgumentException('Invalid "cursor" parameter for prompts/list.');
+        }
+
         return new self($params['cursor'] ?? null);
     }
 

--- a/src/Schema/Request/ListResourceTemplatesRequest.php
+++ b/src/Schema/Request/ListResourceTemplatesRequest.php
@@ -11,6 +11,7 @@
 
 namespace Mcp\Schema\Request;
 
+use Mcp\Exception\InvalidArgumentException;
 use Mcp\Schema\JsonRpc\Request;
 
 /**
@@ -37,6 +38,10 @@ final class ListResourceTemplatesRequest extends Request
 
     protected static function fromParams(?array $params): static
     {
+        if (isset($params['cursor']) && !\is_string($params['cursor'])) {
+            throw new InvalidArgumentException('Invalid "cursor" parameter for resources/templates/list.');
+        }
+
         return new self($params['cursor'] ?? null);
     }
 

--- a/src/Schema/Request/ListResourcesRequest.php
+++ b/src/Schema/Request/ListResourcesRequest.php
@@ -11,6 +11,7 @@
 
 namespace Mcp\Schema\Request;
 
+use Mcp\Exception\InvalidArgumentException;
 use Mcp\Schema\JsonRpc\Request;
 
 /**
@@ -37,6 +38,10 @@ final class ListResourcesRequest extends Request
 
     protected static function fromParams(?array $params): static
     {
+        if (isset($params['cursor']) && !\is_string($params['cursor'])) {
+            throw new InvalidArgumentException('Invalid "cursor" parameter for resources/list.');
+        }
+
         return new self($params['cursor'] ?? null);
     }
 

--- a/src/Schema/Request/ListToolsRequest.php
+++ b/src/Schema/Request/ListToolsRequest.php
@@ -11,6 +11,7 @@
 
 namespace Mcp\Schema\Request;
 
+use Mcp\Exception\InvalidArgumentException;
 use Mcp\Schema\JsonRpc\Request;
 
 /**
@@ -37,6 +38,10 @@ final class ListToolsRequest extends Request
 
     protected static function fromParams(?array $params): static
     {
+        if (isset($params['cursor']) && !\is_string($params['cursor'])) {
+            throw new InvalidArgumentException('Invalid "cursor" parameter for tools/list.');
+        }
+
         return new self($params['cursor'] ?? null);
     }
 

--- a/src/Schema/Request/SetLogLevelRequest.php
+++ b/src/Schema/Request/SetLogLevelRequest.php
@@ -43,7 +43,11 @@ final class SetLogLevelRequest extends Request
             throw new InvalidArgumentException('Missing or invalid "level" parameter for "logging/setLevel".');
         }
 
-        return new self(LoggingLevel::from($params['level']));
+        if (null === $level = LoggingLevel::tryFrom($params['level'])) {
+            throw new InvalidArgumentException(\sprintf('Invalid "level" parameter "%s" for "logging/setLevel".', $params['level']));
+        }
+
+        return new self($level);
     }
 
     /**

--- a/src/Schema/ResourceDefinition.php
+++ b/src/Schema/ResourceDefinition.php
@@ -88,8 +88,17 @@ class ResourceDefinition implements \JsonSerializable
             throw new InvalidArgumentException('Invalid or missing "name" in ResourceDefinition data.');
         }
 
-        if (!empty($data['_meta']) && !\is_array($data['_meta'])) {
+        if (isset($data['_meta']) && !\is_array($data['_meta'])) {
             throw new InvalidArgumentException('Invalid "_meta" in ResourceDefinition data.');
+        }
+        if (isset($data['description']) && !\is_string($data['description'])) {
+            throw new InvalidArgumentException('Invalid "description" in ResourceDefinition data.');
+        }
+        if (isset($data['mimeType']) && !\is_string($data['mimeType'])) {
+            throw new InvalidArgumentException('Invalid "mimeType" in ResourceDefinition data.');
+        }
+        if (isset($data['size']) && !\is_int($data['size'])) {
+            throw new InvalidArgumentException('Invalid "size" in ResourceDefinition data; expected an integer.');
         }
 
         return new self(
@@ -98,9 +107,9 @@ class ResourceDefinition implements \JsonSerializable
             title: isset($data['title']) && \is_string($data['title']) ? $data['title'] : null,
             description: $data['description'] ?? null,
             mimeType: $data['mimeType'] ?? null,
-            annotations: isset($data['annotations']) ? Annotations::fromArray($data['annotations']) : null,
-            size: isset($data['size']) ? (int) $data['size'] : null,
-            icons: isset($data['icons']) && \is_array($data['icons']) ? array_map(Icon::fromArray(...), $data['icons']) : null,
+            annotations: Annotations::tryFromArray($data['annotations'] ?? null, 'ResourceDefinition'),
+            size: $data['size'] ?? null,
+            icons: isset($data['icons']) && \is_array($data['icons']) ? Icon::listFromArray($data['icons'], 'ResourceDefinition') : null,
             meta: isset($data['_meta']) ? $data['_meta'] : null
         );
     }

--- a/src/Schema/ResourceTemplate.php
+++ b/src/Schema/ResourceTemplate.php
@@ -81,8 +81,14 @@ class ResourceTemplate implements \JsonSerializable
             throw new InvalidArgumentException('Invalid or missing "name" in ResourceTemplate data.');
         }
 
-        if (!empty($data['_meta']) && !\is_array($data['_meta'])) {
+        if (isset($data['_meta']) && !\is_array($data['_meta'])) {
             throw new InvalidArgumentException('Invalid "_meta" in ResourceTemplate data.');
+        }
+        if (isset($data['description']) && !\is_string($data['description'])) {
+            throw new InvalidArgumentException('Invalid "description" in ResourceTemplate data.');
+        }
+        if (isset($data['mimeType']) && !\is_string($data['mimeType'])) {
+            throw new InvalidArgumentException('Invalid "mimeType" in ResourceTemplate data.');
         }
 
         return new self(
@@ -91,7 +97,7 @@ class ResourceTemplate implements \JsonSerializable
             title: isset($data['title']) && \is_string($data['title']) ? $data['title'] : null,
             description: $data['description'] ?? null,
             mimeType: $data['mimeType'] ?? null,
-            annotations: isset($data['annotations']) ? Annotations::fromArray($data['annotations']) : null,
+            annotations: Annotations::tryFromArray($data['annotations'] ?? null, 'ResourceTemplate'),
             meta: isset($data['_meta']) ? $data['_meta'] : null
         );
     }

--- a/src/Schema/Result/CallToolResult.php
+++ b/src/Schema/Result/CallToolResult.php
@@ -95,13 +95,28 @@ class CallToolResult implements ResultInterface
         $contents = [];
 
         foreach ($data['content'] as $item) {
-            $contents[] = match ($item['type'] ?? null) {
+            $type = \is_array($item) ? $item['type'] ?? null : null;
+            if (!\is_string($type)) {
+                throw new InvalidArgumentException('Missing or invalid content "type" in CallToolResult data.');
+            }
+
+            $contents[] = match ($type) {
                 'text' => TextContent::fromArray($item),
                 'image' => ImageContent::fromArray($item),
                 'audio' => AudioContent::fromArray($item),
                 'resource' => EmbeddedResource::fromArray($item),
-                default => throw new InvalidArgumentException(\sprintf('Invalid content type in CallToolResult data: "%s".', $item['type'] ?? null)),
+                default => throw new InvalidArgumentException(\sprintf('Invalid content type in CallToolResult data: "%s".', $type)),
             };
+        }
+
+        if (isset($data['isError']) && !\is_bool($data['isError'])) {
+            throw new InvalidArgumentException('Invalid "isError" in CallToolResult data.');
+        }
+        if (isset($data['structuredContent']) && !\is_array($data['structuredContent'])) {
+            throw new InvalidArgumentException('Invalid "structuredContent" in CallToolResult data.');
+        }
+        if (isset($data['_meta']) && !\is_array($data['_meta'])) {
+            throw new InvalidArgumentException('Invalid "_meta" in CallToolResult data.');
         }
 
         return new self(

--- a/src/Schema/Result/CompletionCompleteResult.php
+++ b/src/Schema/Result/CompletionCompleteResult.php
@@ -67,6 +67,18 @@ class CompletionCompleteResult implements ResultInterface
     public static function fromArray(array $data): self
     {
         $completion = $data['completion'] ?? [];
+        if (!\is_array($completion)) {
+            throw new InvalidArgumentException('Invalid "completion" in CompletionCompleteResult data.');
+        }
+        if (isset($completion['values']) && !\is_array($completion['values'])) {
+            throw new InvalidArgumentException('Invalid "completion.values" in CompletionCompleteResult data.');
+        }
+        if (isset($completion['total']) && !\is_int($completion['total'])) {
+            throw new InvalidArgumentException('Invalid "completion.total" in CompletionCompleteResult data.');
+        }
+        if (isset($completion['hasMore']) && !\is_bool($completion['hasMore'])) {
+            throw new InvalidArgumentException('Invalid "completion.hasMore" in CompletionCompleteResult data.');
+        }
 
         return new self(
             $completion['values'] ?? [],

--- a/src/Schema/Result/CreateSamplingMessageResult.php
+++ b/src/Schema/Result/CreateSamplingMessageResult.php
@@ -58,7 +58,10 @@ class CreateSamplingMessageResult implements ResultInterface
             throw new InvalidArgumentException('Missing or invalid "model" in CreateSamplingMessageResult data.');
         }
 
-        $role = Role::from($data['role']);
+        if (null === $role = Role::tryFrom($data['role'])) {
+            throw new InvalidArgumentException(\sprintf('Invalid "role" value "%s" in CreateSamplingMessageResult data.', $data['role']));
+        }
+
         $contentPayload = $data['content'];
 
         $content = self::hydrateContent($contentPayload);

--- a/src/Schema/Result/ElicitResult.php
+++ b/src/Schema/Result/ElicitResult.php
@@ -44,7 +44,10 @@ final class ElicitResult implements ResultInterface
             throw new InvalidArgumentException('Missing or invalid "action" in ElicitResult data.');
         }
 
-        $action = ElicitAction::from($data['action']);
+        if (null === $action = ElicitAction::tryFrom($data['action'])) {
+            throw new InvalidArgumentException(\sprintf('Invalid "action" value "%s" in ElicitResult data.', $data['action']));
+        }
+
         $content = isset($data['content']) && \is_array($data['content']) ? $data['content'] : null;
 
         if (ElicitAction::Accept === $action && null === $content) {

--- a/src/Schema/Result/GetPromptResult.php
+++ b/src/Schema/Result/GetPromptResult.php
@@ -51,8 +51,16 @@ class GetPromptResult implements ResultInterface
             throw new InvalidArgumentException('Missing or invalid "messages" array in GetPromptResult data.');
         }
 
+        if (isset($data['description']) && !\is_string($data['description'])) {
+            throw new InvalidArgumentException('Invalid "description" in GetPromptResult data.');
+        }
+
         $messages = [];
         foreach ($data['messages'] as $message) {
+            if (!\is_array($message)) {
+                throw new InvalidArgumentException('Each entry in "messages" of GetPromptResult data must be an array.');
+            }
+
             $messages[] = PromptMessage::fromArray($message);
         }
 

--- a/src/Schema/Result/InitializeResult.php
+++ b/src/Schema/Result/InitializeResult.php
@@ -64,6 +64,13 @@ class InitializeResult implements ResultInterface
             throw new InvalidArgumentException('Missing or invalid "serverInfo".');
         }
 
+        if (isset($data['instructions']) && !\is_string($data['instructions'])) {
+            throw new InvalidArgumentException('Invalid "instructions" in InitializeResult data.');
+        }
+        if (isset($data['_meta']) && !\is_array($data['_meta'])) {
+            throw new InvalidArgumentException('Invalid "_meta" in InitializeResult data.');
+        }
+
         return new self(
             ServerCapabilities::fromArray($data['capabilities']),
             Implementation::fromArray($data['serverInfo']),

--- a/src/Schema/Result/ListPromptsResult.php
+++ b/src/Schema/Result/ListPromptsResult.php
@@ -49,8 +49,21 @@ class ListPromptsResult implements ResultInterface
             throw new InvalidArgumentException('Missing or invalid "prompts" array in ListPromptsResult data.');
         }
 
+        if (isset($data['nextCursor']) && !\is_string($data['nextCursor'])) {
+            throw new InvalidArgumentException('Invalid "nextCursor" in ListPromptsResult data.');
+        }
+
         return new self(
-            array_map(static fn (array $prompt) => Prompt::fromArray($prompt), $data['prompts']),
+            array_map(
+                static function (mixed $entry): Prompt {
+                    if (!\is_array($entry)) {
+                        throw new InvalidArgumentException('Each entry in "prompts" of ListPromptsResult data must be an array.');
+                    }
+
+                    return Prompt::fromArray($entry);
+                },
+                $data['prompts'],
+            ),
             $data['nextCursor'] ?? null
         );
     }

--- a/src/Schema/Result/ListResourceTemplatesResult.php
+++ b/src/Schema/Result/ListResourceTemplatesResult.php
@@ -49,8 +49,21 @@ class ListResourceTemplatesResult implements ResultInterface
             throw new InvalidArgumentException('Missing or invalid "resourceTemplates" array in ListResourceTemplatesResult data.');
         }
 
+        if (isset($data['nextCursor']) && !\is_string($data['nextCursor'])) {
+            throw new InvalidArgumentException('Invalid "nextCursor" in ListResourceTemplatesResult data.');
+        }
+
         return new self(
-            array_map(static fn (array $resourceTemplate) => ResourceTemplate::fromArray($resourceTemplate), $data['resourceTemplates']),
+            array_map(
+                static function (mixed $entry): ResourceTemplate {
+                    if (!\is_array($entry)) {
+                        throw new InvalidArgumentException('Each entry in "resourceTemplates" of ListResourceTemplatesResult data must be an array.');
+                    }
+
+                    return ResourceTemplate::fromArray($entry);
+                },
+                $data['resourceTemplates'],
+            ),
             $data['nextCursor'] ?? null
         );
     }

--- a/src/Schema/Result/ListResourcesResult.php
+++ b/src/Schema/Result/ListResourcesResult.php
@@ -49,8 +49,21 @@ class ListResourcesResult implements ResultInterface
             throw new InvalidArgumentException('Missing or invalid "resources" array in ListResourcesResult data.');
         }
 
+        if (isset($data['nextCursor']) && !\is_string($data['nextCursor'])) {
+            throw new InvalidArgumentException('Invalid "nextCursor" in ListResourcesResult data.');
+        }
+
         return new self(
-            array_map(static fn (array $resource) => ResourceDefinition::fromArray($resource), $data['resources']),
+            array_map(
+                static function (mixed $entry): ResourceDefinition {
+                    if (!\is_array($entry)) {
+                        throw new InvalidArgumentException('Each entry in "resources" of ListResourcesResult data must be an array.');
+                    }
+
+                    return ResourceDefinition::fromArray($entry);
+                },
+                $data['resources'],
+            ),
             $data['nextCursor'] ?? null
         );
     }

--- a/src/Schema/Result/ListToolsResult.php
+++ b/src/Schema/Result/ListToolsResult.php
@@ -49,8 +49,21 @@ class ListToolsResult implements ResultInterface
             throw new InvalidArgumentException('Missing or invalid "tools" array in ListToolsResult data.');
         }
 
+        if (isset($data['nextCursor']) && !\is_string($data['nextCursor'])) {
+            throw new InvalidArgumentException('Invalid "nextCursor" in ListToolsResult data.');
+        }
+
         return new self(
-            array_map(static fn (array $tool) => Tool::fromArray($tool), $data['tools']),
+            array_map(
+                static function (mixed $entry): Tool {
+                    if (!\is_array($entry)) {
+                        throw new InvalidArgumentException('Each entry in "tools" of ListToolsResult data must be an array.');
+                    }
+
+                    return Tool::fromArray($entry);
+                },
+                $data['tools'],
+            ),
             $data['nextCursor'] ?? null
         );
     }

--- a/src/Schema/Root.php
+++ b/src/Schema/Root.php
@@ -54,6 +54,10 @@ class Root implements \JsonSerializable
             throw new InvalidArgumentException('Invalid or missing "uri" in Root data.');
         }
 
+        if (isset($data['name']) && !\is_string($data['name'])) {
+            throw new InvalidArgumentException('Invalid "name" in Root data.');
+        }
+
         return new self($data['uri'], $data['name'] ?? null);
     }
 

--- a/src/Schema/Tool.php
+++ b/src/Schema/Tool.php
@@ -103,7 +103,7 @@ class Tool implements \JsonSerializable
             inputSchema: $inputSchema,
             description: isset($data['description']) && \is_string($data['description']) ? $data['description'] : null,
             annotations: isset($data['annotations']) && \is_array($data['annotations']) ? ToolAnnotations::fromArray($data['annotations']) : null,
-            icons: isset($data['icons']) && \is_array($data['icons']) ? array_map(Icon::fromArray(...), $data['icons']) : null,
+            icons: isset($data['icons']) && \is_array($data['icons']) ? Icon::listFromArray($data['icons'], 'Tool') : null,
             meta: isset($data['_meta']) && \is_array($data['_meta']) ? $data['_meta'] : null,
             outputSchema: $outputSchema,
         );

--- a/src/Schema/ToolAnnotations.php
+++ b/src/Schema/ToolAnnotations.php
@@ -11,6 +11,8 @@
 
 namespace Mcp\Schema;
 
+use Mcp\Exception\InvalidArgumentException;
+
 /**
  * Additional properties describing a Tool to clients.
  * NOTE: all properties in ToolAnnotations are hints.
@@ -48,6 +50,16 @@ class ToolAnnotations implements \JsonSerializable
      */
     public static function fromArray(array $data): self
     {
+        if (isset($data['title']) && !\is_string($data['title'])) {
+            throw new InvalidArgumentException('Invalid "title" in ToolAnnotations data.');
+        }
+
+        foreach (['readOnlyHint', 'destructiveHint', 'idempotentHint', 'openWorldHint'] as $hint) {
+            if (isset($data[$hint]) && !\is_bool($data[$hint])) {
+                throw new InvalidArgumentException(\sprintf('Invalid "%s" in ToolAnnotations data; expected a boolean.', $hint));
+            }
+        }
+
         return new self(
             $data['title'] ?? null,
             $data['readOnlyHint'] ?? null,

--- a/src/Server/Protocol.php
+++ b/src/Server/Protocol.php
@@ -62,6 +62,12 @@ class Protocol
     public const SESSION_LOGGING_LEVEL = '_mcp.logging_level';
 
     /**
+     * Deliberately generic: unexpected throwables carry internal details such as file paths, class
+     * names and argument types, which must not be handed to the peer. The full exception is logged.
+     */
+    private const INTERNAL_ERROR_MESSAGE = 'Internal server error.';
+
+    /**
      * @param array<int, RequestHandlerInterface<ResultInterface|array<string, mixed>>> $requestHandlers
      * @param array<int, NotificationHandlerInterface>                                  $notificationHandlers
      */
@@ -108,6 +114,66 @@ class Protocol
      */
     public function processInput(TransportInterface $transport, string $input, ?Uuid $sessionId): void
     {
+        // Last line of defense: a malformed message must never escape as a PHP error and take the
+        // server process down.
+        try {
+            $this->doProcessInput($transport, $input, $sessionId);
+        } catch (\Throwable $e) {
+            $this->logger->error(\sprintf('Uncaught exception while processing input: %s', $e->getMessage()), ['exception' => $e]);
+
+            // Only a request may be answered. Replying to a notification would violate JSON-RPC,
+            // and the failure has already been logged.
+            if (null === $id = self::findResponseId($input)) {
+                return;
+            }
+
+            try {
+                $this->sendResponse($transport, Error::forInternalError(self::INTERNAL_ERROR_MESSAGE, $id), null);
+            } catch (\Throwable $e) {
+                $this->logger->error(\sprintf('Failed to send internal error response: %s', $e->getMessage()), ['exception' => $e]);
+            }
+        }
+    }
+
+    /**
+     * Determines the id an unprocessable input has to be answered under.
+     *
+     * Returns null when the input carries no request at all, in which case it consists of
+     * notifications only and JSON-RPC forbids answering it. A batch resolves to the empty id
+     * because its failure cannot be attributed to one of its requests.
+     */
+    private static function findResponseId(string $input): string|int|null
+    {
+        try {
+            $data = json_decode($input, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        if (!\is_array($data)) {
+            return null;
+        }
+
+        if (!array_is_list($data)) {
+            $id = $data['id'] ?? null;
+
+            return \is_string($id) || \is_int($id) ? $id : null;
+        }
+
+        foreach ($data as $message) {
+            if (\is_array($message) && isset($message['id'])) {
+                return '';
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param TransportInterface<mixed> $transport
+     */
+    private function doProcessInput(TransportInterface $transport, string $input, ?Uuid $sessionId): void
+    {
         $this->logger->info('Received message to process.', ['message' => $input]);
 
         $this->sessionManager->gc();
@@ -128,14 +194,25 @@ class Protocol
         }
 
         foreach ($messages as $message) {
-            if ($message instanceof InvalidInputMessageException) {
-                $this->handleInvalidMessage($transport, $message, $session);
-            } elseif ($message instanceof Request) {
-                $this->handleRequest($transport, $message, $session);
-            } elseif ($message instanceof Response || $message instanceof Error) {
-                $this->handleResponse($message, $session);
-            } elseif ($message instanceof Notification) {
-                $this->handleNotification($message, $session);
+            // Guarded per message so one faulty message cannot suppress the rest of a batch.
+            try {
+                if ($message instanceof InvalidInputMessageException) {
+                    $this->handleInvalidMessage($transport, $message, $session);
+                } elseif ($message instanceof Request) {
+                    $this->handleRequest($transport, $message, $session);
+                } elseif ($message instanceof Response || $message instanceof Error) {
+                    $this->handleResponse($message, $session);
+                } elseif ($message instanceof Notification) {
+                    $this->handleNotification($message, $session);
+                }
+            } catch (\Throwable $e) {
+                $this->logger->error(\sprintf('Uncaught exception while handling message: %s', $e->getMessage()), ['exception' => $e]);
+
+                // Only a request may be answered; a notification or a response must not produce one.
+                if ($message instanceof Request) {
+                    $error = Error::forInternalError(self::INTERNAL_ERROR_MESSAGE, $message->getId());
+                    $this->sendResponse($transport, $error, $session);
+                }
             }
         }
 

--- a/src/Server/Protocol.php
+++ b/src/Server/Protocol.php
@@ -313,7 +313,7 @@ class Protocol
             } catch (\Throwable $e) {
                 $this->logger->error(\sprintf('Uncaught exception: %s', $e->getMessage()), ['exception' => $e]);
 
-                $error = Error::forInternalError($e->getMessage(), $request->getId());
+                $error = Error::forInternalError(self::INTERNAL_ERROR_MESSAGE, $request->getId());
                 $errorEvent = $this->dispatchEvent(new ErrorEvent($error, $request, $session, $e));
                 $error = $errorEvent->getError();
 

--- a/tests/Unit/Fixtures/ThrowingRequest.php
+++ b/tests/Unit/Fixtures/ThrowingRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Fixtures;
+
+use Mcp\Schema\JsonRpc\Request;
+
+/**
+ * Stands in for a message class that fails with an unexpected throwable instead of a proper
+ * InvalidInputMessageException, e.g. through a PHP TypeError caused by an unvalidated payload.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class ThrowingRequest extends Request
+{
+    public static function getMethod(): string
+    {
+        return 'test/throwing';
+    }
+
+    protected static function fromParams(?array $params): static
+    {
+        throw new \TypeError('Internal detail that must not leak to the client.');
+    }
+
+    protected function getParams(): ?array
+    {
+        return null;
+    }
+}

--- a/tests/Unit/JsonRpc/MalformedInputTest.php
+++ b/tests/Unit/JsonRpc/MalformedInputTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\JsonRpc;
+
+use Mcp\Exception\InvalidInputMessageException;
+use Mcp\JsonRpc\MessageFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Type-confused payloads must be reported as invalid input, never as a PHP TypeError, ValueError or
+ * warning. Those escape every catch on the way out of the protocol and kill the server process.
+ *
+ * @author Christopher Hertel <mail@christopher-hertel.de>
+ */
+final class MalformedInputTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideMalformedPayloads(): iterable
+    {
+        yield 'method is an object' => ['{"jsonrpc":"2.0","id":1,"method":{"evil":true}}'];
+        yield 'method is an array' => ['{"jsonrpc":"2.0","id":1,"method":[1,2,3]}'];
+
+        yield 'initialize with array protocolVersion' => ['{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":[1],"capabilities":{},"clientInfo":{"name":"x","version":"1"}}}'];
+        yield 'initialize with string capabilities' => ['{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":"x","clientInfo":{"name":"x","version":"1"}}}'];
+        yield 'initialize with string clientInfo' => ['{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":"x"}}'];
+        yield 'initialize with non-array icons entry' => ['{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"x","version":"1","icons":["x"]}}}'];
+
+        yield 'completion ref/prompt with array name' => ['{"jsonrpc":"2.0","id":1,"method":"completion/complete","params":{"ref":{"type":"ref/prompt","name":[1]},"argument":{"name":"x","value":"y"}}}'];
+        yield 'completion ref/prompt without name' => ['{"jsonrpc":"2.0","id":1,"method":"completion/complete","params":{"ref":{"type":"ref/prompt"},"argument":{"name":"x","value":"y"}}}'];
+        yield 'completion ref/resource with object uri' => ['{"jsonrpc":"2.0","id":1,"method":"completion/complete","params":{"ref":{"type":"ref/resource","uri":{}},"argument":{"name":"x","value":"y"}}}'];
+
+        yield 'setLevel with unknown enum value' => ['{"jsonrpc":"2.0","id":1,"method":"logging/setLevel","params":{"level":"not-a-real-level"}}'];
+        yield 'logging notification with unknown enum value' => ['{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"nope","data":"x"}}'];
+
+        yield 'tools/list with array cursor' => ['{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"cursor":[1]}}'];
+        yield 'cancelled notification with array reason' => ['{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1,"reason":[1]}}'];
+        yield 'progress notification with array total' => ['{"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"t","progress":1,"total":[1]}}'];
+
+        yield 'sampling with string preferences' => ['{"jsonrpc":"2.0","id":1,"method":"sampling/createMessage","params":{"messages":[],"maxTokens":1,"preferences":"x"}}'];
+        yield 'sampling with array systemPrompt' => ['{"jsonrpc":"2.0","id":1,"method":"sampling/createMessage","params":{"messages":[],"maxTokens":1,"systemPrompt":[1]}}'];
+        yield 'sampling with unknown role' => ['{"jsonrpc":"2.0","id":1,"method":"sampling/createMessage","params":{"messages":[{"role":"nope","content":{"type":"text","text":"x"}}],"maxTokens":1}}'];
+        yield 'sampling with array content type' => ['{"jsonrpc":"2.0","id":1,"method":"sampling/createMessage","params":{"messages":[{"role":"user","content":{"type":[1],"text":"x"}}],"maxTokens":1}}'];
+        yield 'sampling with non-string stopSequence' => ['{"jsonrpc":"2.0","id":1,"method":"sampling/createMessage","params":{"messages":[],"maxTokens":1,"stopSequences":[[]]}}'];
+
+        yield 'elicitation with string required' => ['{"jsonrpc":"2.0","id":1,"method":"elicitation/create","params":{"message":"m","requestedSchema":{"type":"object","properties":{"a":{"type":"string","title":"T"}},"required":"a"}}}'];
+        yield 'elicitation with array in required' => ['{"jsonrpc":"2.0","id":1,"method":"elicitation/create","params":{"message":"m","requestedSchema":{"type":"object","properties":{"a":{"type":"string","title":"T"}},"required":[[]]}}}'];
+    }
+
+    #[DataProvider('provideMalformedPayloads')]
+    #[TestDox('Malformed payload is reported as invalid input: $_dataName')]
+    public function testMalformedPayloadIsReportedAsInvalidInput(string $payload): void
+    {
+        $results = MessageFactory::make()->create($payload);
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(InvalidInputMessageException::class, $results[0]);
+    }
+
+    #[TestDox('A malformed message in a batch does not discard the valid ones')]
+    public function testMalformedMessageInBatchDoesNotDiscardValidMessages(): void
+    {
+        $payload = '[{"jsonrpc":"2.0","id":1,"method":"tools/list"},{"jsonrpc":"2.0","id":2,"method":{}}]';
+
+        $results = MessageFactory::make()->create($payload);
+
+        $this->assertCount(2, $results);
+        $this->assertInstanceOf(\Mcp\Schema\Request\ListToolsRequest::class, $results[0]);
+        $this->assertInstanceOf(InvalidInputMessageException::class, $results[1]);
+    }
+}

--- a/tests/Unit/JsonRpc/MessageFactoryTest.php
+++ b/tests/Unit/JsonRpc/MessageFactoryTest.php
@@ -21,6 +21,7 @@ use Mcp\Schema\Notification\InitializedNotification;
 use Mcp\Schema\Request\ElicitRequest;
 use Mcp\Schema\Request\GetPromptRequest;
 use Mcp\Schema\Request\PingRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class MessageFactoryTest extends TestCase
@@ -449,6 +450,41 @@ final class MessageFactoryTest extends TestCase
 
         $this->assertCount(2, $results);
         $this->assertInstanceOf(InvalidInputMessageException::class, $results[0]);
+        $this->assertInstanceOf(InvalidInputMessageException::class, $results[1]);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideNonStringMethods(): iterable
+    {
+        yield 'object' => ['{"evil": true}'];
+        yield 'array' => ['[1, 2, 3]'];
+        yield 'int' => ['5'];
+        yield 'bool' => ['true'];
+    }
+
+    #[DataProvider('provideNonStringMethods')]
+    public function testNonStringMethodIsRejected(string $method): void
+    {
+        $results = $this->factory->create(\sprintf('{"jsonrpc": "2.0", "id": 1, "method": %s}', $method));
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(InvalidInputMessageException::class, $results[0]);
+        $this->assertStringContainsString('"method" must be a string', $results[0]->getMessage());
+    }
+
+    public function testBatchWithNonStringMethodStillYieldsTheValidMessages(): void
+    {
+        $json = '[
+            {"jsonrpc": "2.0", "method": "ping", "id": 1},
+            {"jsonrpc": "2.0", "method": {}, "id": 2}
+        ]';
+
+        $results = $this->factory->create($json);
+
+        $this->assertCount(2, $results);
+        $this->assertInstanceOf(PingRequest::class, $results[0]);
         $this->assertInstanceOf(InvalidInputMessageException::class, $results[1]);
     }
 

--- a/tests/Unit/Schema/Result/ElicitResultTest.php
+++ b/tests/Unit/Schema/Result/ElicitResultTest.php
@@ -85,7 +85,8 @@ final class ElicitResultTest extends TestCase
 
     public function testFromArrayWithInvalidAction(): void
     {
-        $this->expectException(\ValueError::class);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid "action" value "invalid"');
 
         ElicitResult::fromArray(['action' => 'invalid']);
     }

--- a/tests/Unit/Server/ProtocolTest.php
+++ b/tests/Unit/Server/ProtocolTest.php
@@ -670,7 +670,8 @@ final class ProtocolTest extends TestCase
         $message = json_decode($outgoing[0]['message'], true);
         $this->assertArrayHasKey('error', $message);
         $this->assertEquals(Error::INTERNAL_ERROR, $message['error']['code']);
-        $this->assertStringContainsString('Unexpected error', $message['error']['message']);
+        $this->assertSame('Internal server error.', $message['error']['message']);
+        $this->assertStringNotContainsString('Unexpected error', $message['error']['message']);
     }
 
     #[TestDox('Notification handler exceptions are caught and logged')]

--- a/tests/Unit/Server/ProtocolTest.php
+++ b/tests/Unit/Server/ProtocolTest.php
@@ -21,12 +21,14 @@ use Mcp\Schema\JsonRpc\Error;
 use Mcp\Schema\JsonRpc\Response;
 use Mcp\Schema\Notification\LoggingMessageNotification;
 use Mcp\Schema\Request\CallToolRequest;
+use Mcp\Schema\Request\PingRequest;
 use Mcp\Server\Handler\Notification\NotificationHandlerInterface;
 use Mcp\Server\Handler\Request\RequestHandlerInterface;
 use Mcp\Server\Protocol;
 use Mcp\Server\Session\SessionInterface;
 use Mcp\Server\Session\SessionManagerInterface;
 use Mcp\Server\Transport\TransportInterface;
+use Mcp\Tests\Unit\Fixtures\ThrowingRequest;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -347,6 +349,161 @@ final class ProtocolTest extends TestCase
         $message = json_decode($outgoing[0]['message'], true);
         $this->assertArrayHasKey('error', $message);
         $this->assertEquals(Error::INVALID_REQUEST, $message['error']['code']);
+    }
+
+    #[TestDox('An unexpected throwable while creating a message returns an internal error under its id')]
+    public function testUnexpectedThrowableWhileCreatingMessagesReturnsInternalError(): void
+    {
+        $sent = null;
+        $this->transport->expects($this->once())
+            ->method('send')
+            ->willReturnCallback(static function ($data) use (&$sent) {
+                $sent = $data;
+            });
+
+        $protocol = new Protocol(
+            requestHandlers: [],
+            notificationHandlers: [],
+            messageFactory: new MessageFactory([ThrowingRequest::class]),
+            sessionManager: $this->sessionManager,
+        );
+
+        $protocol->processInput(
+            $this->transport,
+            '{"jsonrpc": "2.0", "id": 1, "method": "test/throwing"}',
+            Uuid::v4()
+        );
+
+        $decoded = json_decode((string) $sent, true);
+        $this->assertSame(Error::INTERNAL_ERROR, $decoded['error']['code']);
+        $this->assertSame(1, $decoded['id'], 'The peer must be able to correlate the failure with its request.');
+        $this->assertStringNotContainsString('must not leak', $decoded['error']['message']);
+    }
+
+    #[TestDox('A batch that fails to hydrate is answered once, under the empty id')]
+    public function testBatchThatFailsToHydrateIsAnsweredOnce(): void
+    {
+        $sent = [];
+        $this->transport->method('send')->willReturnCallback(static function ($data) use (&$sent) {
+            $sent[] = $data;
+        });
+
+        $protocol = new Protocol(
+            requestHandlers: [],
+            notificationHandlers: [],
+            messageFactory: new MessageFactory([PingRequest::class, ThrowingRequest::class]),
+            sessionManager: $this->sessionManager,
+        );
+
+        $protocol->processInput(
+            $this->transport,
+            '[{"jsonrpc": "2.0", "id": 1, "method": "ping"}, {"jsonrpc": "2.0", "id": 2, "method": "test/throwing"}]',
+            Uuid::v4()
+        );
+
+        $this->assertCount(1, $sent);
+
+        $decoded = json_decode($sent[0], true);
+        $this->assertSame(Error::INTERNAL_ERROR, $decoded['error']['code']);
+        $this->assertSame('', $decoded['id'], 'The failure cannot be attributed to one request of the batch.');
+    }
+
+    #[TestDox('A batch holding only notifications is not answered when processing fails')]
+    public function testBatchOfNotificationsIsNotAnsweredWhenProcessingFails(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('save')->willThrowException(new \RuntimeException('storage is gone'));
+
+        $this->sessionManager->method('createWithId')->willReturn($session);
+        $this->sessionManager->method('exists')->willReturn(true);
+
+        $this->transport->expects($this->never())->method('send');
+
+        $protocol = new Protocol(
+            requestHandlers: [],
+            notificationHandlers: [],
+            messageFactory: MessageFactory::make(),
+            sessionManager: $this->sessionManager,
+        );
+
+        $protocol->processInput(
+            $this->transport,
+            '[{"jsonrpc": "2.0", "method": "notifications/initialized"}]',
+            Uuid::v4()
+        );
+    }
+
+    #[TestDox('An unexpected throwable while saving the session does not answer a notification')]
+    public function testUnexpectedThrowableWhileSavingSessionDoesNotEscape(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('save')->willThrowException(new \RuntimeException('storage is gone'));
+
+        $this->sessionManager->method('createWithId')->willReturn($session);
+        $this->sessionManager->method('exists')->willReturn(true);
+
+        // JSON-RPC forbids answering a notification, so the failure is only logged.
+        $this->transport->expects($this->never())->method('send');
+
+        $protocol = new Protocol(
+            requestHandlers: [],
+            notificationHandlers: [],
+            messageFactory: MessageFactory::make(),
+            sessionManager: $this->sessionManager,
+        );
+
+        $protocol->processInput(
+            $this->transport,
+            '{"jsonrpc": "2.0", "method": "notifications/initialized"}',
+            Uuid::v4()
+        );
+    }
+
+    #[TestDox('A failing notification event listener does not produce a response')]
+    public function testFailingNotificationListenerDoesNotProduceResponse(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+
+        $this->sessionManager->method('createWithId')->willReturn($session);
+        $this->sessionManager->method('exists')->willReturn(true);
+
+        $queue = [];
+        $session->method('get')->willReturnCallback(static function ($key, $default = null) use (&$queue) {
+            return '_mcp.outgoing_queue' === $key ? $queue : $default;
+        });
+        $session->method('set')->willReturnCallback(static function ($key, $value) use (&$queue) {
+            if ('_mcp.outgoing_queue' === $key) {
+                $queue = $value;
+            }
+        });
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->method('dispatch')->willReturnCallback(static function ($event) {
+            if ($event instanceof NotificationEvent) {
+                throw new \RuntimeException('listener blew up');
+            }
+
+            return $event;
+        });
+
+        $this->transport->expects($this->never())->method('send');
+
+        $protocol = new Protocol(
+            requestHandlers: [],
+            notificationHandlers: [],
+            messageFactory: MessageFactory::make(),
+            sessionManager: $this->sessionManager,
+            eventDispatcher: $dispatcher,
+        );
+
+        $sessionId = Uuid::v4();
+        $protocol->processInput(
+            $this->transport,
+            '{"jsonrpc": "2.0", "method": "notifications/initialized"}',
+            $sessionId
+        );
+
+        $this->assertSame([], $protocol->consumeOutgoingMessages($sessionId));
     }
 
     #[TestDox('Request without handler returns method not found error')]


### PR DESCRIPTION
Malformed input could fail with a PHP `TypeError`/`ValueError` instead of an `InvalidInputMessageException`. Those escape every catch on the way out — `MessageFactory`, `Protocol::processInput()`, `BaseTransport::handleMessage()` and `Server::run()` — so the peer got a dead process instead of a JSON-RPC error.

- `Protocol::processInput()` never lets a throwable escape, reporting anything unexpected as `-32603`, and guards each message of a batch on its own.
- The schema hydration methods validate payload types, so type-confused input becomes a descriptive `-32600` instead of a PHP error.
- Unexpected handler exceptions no longer put their message in the `-32603` reply, matching what the tool, prompt, resource and completion handlers already do.

Reported by @nickelsec.