### PR TITLE
[Client] Reject non-positive timeouts in Configuration

### DIFF
--- a/src/Client/Builder.php
+++ b/src/Client/Builder.php
@@ -77,9 +77,6 @@ final class Builder
 
     /**
      * Set initialization timeout in seconds.
-     *
-     * Must be positive; zero and negative values are rejected by
-     * {@see Configuration} when building.
      */
     public function setInitTimeout(int $seconds): self
     {
@@ -90,9 +87,6 @@ final class Builder
 
     /**
      * Set request timeout in seconds.
-     *
-     * Must be positive; zero and negative values are rejected by
-     * {@see Configuration} when building.
      */
     public function setRequestTimeout(int $seconds): self
     {

--- a/src/Client/Builder.php
+++ b/src/Client/Builder.php
@@ -77,6 +77,9 @@ final class Builder
 
     /**
      * Set initialization timeout in seconds.
+     *
+     * Must be positive; zero and negative values are rejected by
+     * {@see Configuration} when building.
      */
     public function setInitTimeout(int $seconds): self
     {
@@ -87,6 +90,9 @@ final class Builder
 
     /**
      * Set request timeout in seconds.
+     *
+     * Must be positive; zero and negative values are rejected by
+     * {@see Configuration} when building.
      */
     public function setRequestTimeout(int $seconds): self
     {

--- a/src/Client/Configuration.php
+++ b/src/Client/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Mcp\Client;
 
+use Mcp\Exception\InvalidArgumentException;
 use Mcp\Schema\ClientCapabilities;
 use Mcp\Schema\Enum\ProtocolVersion;
 use Mcp\Schema\Implementation;
@@ -30,5 +31,15 @@ class Configuration
         public readonly int $requestTimeout = 120,
         public readonly int $maxRetries = 3,
     ) {
+        // Zero is rejected along with negative values: a timeout of no seconds
+        // at all expires before any server can answer, so it would turn every
+        // request into an immediate timeout instead of disabling the timeout.
+        if ($initTimeout < 1) {
+            throw new InvalidArgumentException(\sprintf('The initialization timeout must be a positive number of seconds, got %d.', $initTimeout));
+        }
+
+        if ($requestTimeout < 1) {
+            throw new InvalidArgumentException(\sprintf('The request timeout must be a positive number of seconds, got %d.', $requestTimeout));
+        }
     }
 }

--- a/src/Client/Configuration.php
+++ b/src/Client/Configuration.php
@@ -31,9 +31,6 @@ class Configuration
         public readonly int $requestTimeout = 120,
         public readonly int $maxRetries = 3,
     ) {
-        // Zero is rejected along with negative values: a timeout of no seconds
-        // at all expires before any server can answer, so it would turn every
-        // request into an immediate timeout instead of disabling the timeout.
         if ($initTimeout < 1) {
             throw new InvalidArgumentException(\sprintf('The initialization timeout must be a positive number of seconds, got %d.', $initTimeout));
         }

--- a/tests/Unit/Client/ConfigurationTest.php
+++ b/tests/Unit/Client/ConfigurationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the official PHP MCP SDK.
+ *
+ * A collaboration between Symfony and the PHP Foundation.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mcp\Tests\Unit\Client;
+
+use Mcp\Client;
+use Mcp\Client\Configuration;
+use Mcp\Exception\InvalidArgumentException;
+use Mcp\Schema\ClientCapabilities;
+use Mcp\Schema\Implementation;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigurationTest extends TestCase
+{
+    #[TestDox('a non-positive initialization timeout of $seconds seconds is rejected')]
+    #[DataProvider('provideNonPositiveTimeouts')]
+    public function testNonPositiveInitTimeoutIsRejected(int $seconds): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('The initialization timeout must be a positive number of seconds, got %d.', $seconds));
+
+        $this->createConfiguration(initTimeout: $seconds);
+    }
+
+    #[TestDox('a non-positive request timeout of $seconds seconds is rejected')]
+    #[DataProvider('provideNonPositiveTimeouts')]
+    public function testNonPositiveRequestTimeoutIsRejected(int $seconds): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('The request timeout must be a positive number of seconds, got %d.', $seconds));
+
+        $this->createConfiguration(requestTimeout: $seconds);
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function provideNonPositiveTimeouts(): iterable
+    {
+        yield 'zero' => [0];
+        yield 'negative' => [-1];
+    }
+
+    #[TestDox('the builder rejects a non-positive initialization timeout')]
+    public function testBuilderRejectsNonPositiveInitTimeout(): void
+    {
+        $builder = Client::builder()->setInitTimeout(0);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $builder->build();
+    }
+
+    #[TestDox('the builder rejects a non-positive request timeout')]
+    public function testBuilderRejectsNonPositiveRequestTimeout(): void
+    {
+        $builder = Client::builder()->setRequestTimeout(-5);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $builder->build();
+    }
+
+    #[TestDox('positive timeouts are accepted')]
+    public function testPositiveTimeoutsAreAccepted(): void
+    {
+        $config = $this->createConfiguration(initTimeout: 1, requestTimeout: 1);
+
+        $this->assertSame(1, $config->initTimeout);
+        $this->assertSame(1, $config->requestTimeout);
+    }
+
+    private function createConfiguration(int $initTimeout = 30, int $requestTimeout = 120): Configuration
+    {
+        return new Configuration(
+            clientInfo: new Implementation('test-client', '1.0.0'),
+            capabilities: new ClientCapabilities(),
+            initTimeout: $initTimeout,
+            requestTimeout: $requestTimeout,
+        );
+    }
+}


### PR DESCRIPTION
`Client\Configuration` accepts any integer for `initTimeout` and `requestTimeout`, so `setInitTimeout(0)` or `setRequestTimeout(-5)` silently builds a client that can never succeed — the pending-request check is `time() - $timestamp >= $timeout`, which is true on the first poll, turning every request into an immediate timeout.

Both are now required to be positive, matching how `StdioTransport` and `HttpTransport` validate their buffer caps. Zero is rejected along with negatives: it reads like "no timeout" but actually means "expire immediately".

Validation lives in `Configuration` rather than the builder setters because `Configuration` is public API and `Client` accepts one directly, so the builder is not the only way in.
