### PR TITLE
[Server] Add ClientGateway::supportsSampling()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to `mcp/sdk` will be documented in this file.
 * Prompt generators returning content as typed arrays (`['type' => 'text', ...]` etc.) no longer lose the optional fields: `annotations` on every content type, and `_meta` and an explicit `mimeType` on embedded resource contents, now carry through to the resulting `PromptMessage` instead of being silently dropped. A missing resource `mimeType` still defaults to `text/plain`/`application/octet-stream` as before.
 * Add `annotations` support to `ImageContent` (constructor, `fromArray()`, `fromFile()`, `fromString()`, `jsonSerialize()`), matching `TextContent` and `AudioContent`.
 * Add client-side `roots/list` handler (`ListRootsRequestHandler` + `RootsCallbackInterface`) and `Client::sendRootsListChanged()`, plus server-side `ClientGateway::listRoots()` / `supportsRoots()` and `ListRootsResult::fromArray()`.
+* Add `ClientGateway::supportsSampling()`, so a tool can check the client's advertised capabilities before issuing a `sampling/createMessage` request instead of asking and catching the refusal. Matches the existing `supportsRoots()` and `supportsElicitation()`.
 * Add `Mcp\Schema\Content\ResourceLink` for the spec's `resource_link` content block (protocol revision 2025-06-18+), letting tool results and prompt messages reference a resource by URI/name without embedding its contents. Accepted anywhere `resource` (`EmbeddedResource`) content is (de)serialized: `CallToolResult::fromArray()`, `PromptMessage::fromArray()`, and `PromptResultFormatter`.
 
 0.7.0

--- a/src/Server/ClientGateway.php
+++ b/src/Server/ClientGateway.php
@@ -251,6 +251,23 @@ class ClientGateway
     }
 
     /**
+     * Check if the connected client supports sampling.
+     *
+     * Sampling lets a server borrow the client's model during tool execution.
+     * This method checks the client's advertised capabilities to determine if
+     * sampling/createMessage requests are supported.
+     *
+     * @return bool True if the client supports sampling, false otherwise
+     */
+    public function supportsSampling(): bool
+    {
+        $capabilities = (array) $this->session->get('client_capabilities', []);
+
+        // MCP spec: capability presence indicates support (value is typically {} or [])
+        return \array_key_exists('sampling', $capabilities);
+    }
+
+    /**
      * Send a request to the client and wait for a response (blocking).
      *
      * This suspends the Fiber and waits for the client to respond. The transport

--- a/tests/Unit/Server/ClientGatewayTest.php
+++ b/tests/Unit/Server/ClientGatewayTest.php
@@ -43,6 +43,26 @@ final class ClientGatewayTest extends TestCase
         $this->assertFalse($gateway->supportsRoots());
     }
 
+    public function testSupportsSamplingReturnsTrueWhenAdvertised(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('get')->with('client_capabilities', [])->willReturn(['sampling' => []]);
+
+        $gateway = new ClientGateway($session);
+
+        $this->assertTrue($gateway->supportsSampling());
+    }
+
+    public function testSupportsSamplingReturnsFalseWhenNotAdvertised(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('get')->with('client_capabilities', [])->willReturn(['roots' => []]);
+
+        $gateway = new ClientGateway($session);
+
+        $this->assertFalse($gateway->supportsSampling());
+    }
+
     public function testListRootsReturnsRootsFromClient(): void
     {
         $session = $this->createMock(SessionInterface::class);


### PR DESCRIPTION
Sampling was the one client capability a tool could not check before asking.

`supportsRoots()` and `supportsElicitation()` both read the capabilities the client advertised during the handshake. Sampling is stored in that same session data — `ClientCapabilities::jsonSerialize()` emits it alongside `roots` and `elicitation` — but had no accessor, so a tool had to issue the request and catch the refusal:

```php
// before
try {
    $result = $context->getClientGateway()->sample($prompt);
} catch (ClientException) {
    // client cannot sample
}

// after
if ($context->getClientGateway()->supportsSampling()) {
    $result = $context->getClientGateway()->sample($prompt);
}
```

Four lines mirroring `supportsElicitation()`, plus unit tests matching the existing `supportsRoots` pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)