### PR TITLE
[Schema] Support PHPStan/Psalm integer range types

### DIFF
--- a/src/Capability/Discovery/SchemaGenerator.php
+++ b/src/Capability/Discovery/SchemaGenerator.php
@@ -677,7 +677,12 @@ final class SchemaGenerator implements SchemaGeneratorInterface
             return ['array'];
         }
 
-        // PRIORITY 3: Handle unions (recursive)
+        // PRIORITY 3: Treat PHPStan/Psalm integer ranges as their base type
+        if (preg_match('/^int\s*<\s*[^<>]+\s*>$/i', $normalizedType)) {
+            return ['integer'];
+        }
+
+        // PRIORITY 4: Handle unions (recursive)
         if (str_contains($normalizedType, '|')) {
             $types = explode('|', $normalizedType);
             $jsonTypes = [];
@@ -689,7 +694,7 @@ final class SchemaGenerator implements SchemaGeneratorInterface
             return array_values(array_unique($jsonTypes));
         }
 
-        // PRIORITY 4: Handle simple built-in types
+        // PRIORITY 5: Handle simple built-in types
         return match ($normalizedType) {
             'string', 'scalar' => ['string'],
             '?string' => ['null', 'string'],

--- a/tests/Unit/Capability/Discovery/SchemaGeneratorFixture.php
+++ b/tests/Unit/Capability/Discovery/SchemaGeneratorFixture.php
@@ -226,6 +226,21 @@ class SchemaGeneratorFixture
     ): void {
     }
 
+    /**
+     * PHPStan/Psalm integer ranges should keep their base integer type.
+     *
+     * @param int<0, max>  $offset   Positive offset
+     * @param int<min, -1> $negative Negative value
+     * @param int<-5, 10>  $bounded  Bounded value
+     */
+    public function integerRangeTypes(
+        #[Schema(minimum: 0)]
+        int $offset,
+        int $negative,
+        int $bounded,
+    ): void {
+    }
+
     // ===== ENUM SCENARIOS =====
 
     /**

--- a/tests/Unit/Capability/Discovery/SchemaGeneratorTest.php
+++ b/tests/Unit/Capability/Discovery/SchemaGeneratorTest.php
@@ -190,6 +190,16 @@ final class SchemaGeneratorTest extends TestCase
         $this->assertEqualsCanonicalizing(['username', 'priority'], $schema['required']);
     }
 
+    public function testMapsPhpStanAndPsalmIntegerRangesToBaseIntegerType(): void
+    {
+        $method = new \ReflectionMethod(SchemaGeneratorFixture::class, 'integerRangeTypes');
+        $schema = $this->schemaGenerator->generate($method);
+
+        $this->assertEquals(['type' => 'integer', 'description' => 'Positive offset', 'minimum' => 0], $schema['properties']['offset']);
+        $this->assertEquals(['type' => 'integer', 'description' => 'Negative value'], $schema['properties']['negative']);
+        $this->assertEquals(['type' => 'integer', 'description' => 'Bounded value'], $schema['properties']['bounded']);
+    }
+
     public function testGeneratesCorrectSchemaForEnumParameters(): void
     {
         $method = new \ReflectionMethod(SchemaGeneratorFixture::class, 'enumParameters');


### PR DESCRIPTION
## Summary

- Treat PHPStan/Psalm `int<...>` PHPDoc ranges as the base JSON Schema `integer` type.
- Keep `minimum` and `maximum` under explicit `#[Schema]` control rather than deriving them from PHPDoc.
- Add regression coverage for numeric, `min`, and `max` interval bounds.

The generator gives a non-generic PHPDoc type precedence over the native `int` type. Since `int<...>` was not recognized by the mapper, it fell through to the `object` fallback.

Fixes #397

## Test plan

- [x] `vendor/bin/phpunit` (1,254 tests, 3,502 assertions, 7 skipped)
- [x] `vendor/bin/phpstan analyse --memory-limit=-1`
- [x] `vendor/bin/php-cs-fixer fix --dry-run`
- [x] `composer validate --strict`
- [x] Targeted regression test with `phpdocumentor/reflection-docblock` 5.6.0
