### PR TITLE
[Server] Reject JSON-RPC batch requests

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -259,22 +259,21 @@ When the request stream advertises a size, the transport rejects it up-front. Ot
 unknown size) the body is read incrementally and aborted as soon as it crosses the cap, so an unbounded stream cannot
 exhaust memory. A value below `1` throws `InvalidArgumentException`.
 
-### JSON-RPC Batch Size Limit
+### JSON-RPC Batch Requests
 
-A JSON-RPC batch (top-level array) is capped at 100 messages by default. Oversized batches are rejected before any
-message is constructed, so a single small request cannot amplify into arbitrarily many operations. The cap lives on
-`MessageFactory`:
+The MCP protocol does not support JSON-RPC batch requests: a POST body must be a single JSON-RPC message. A
+top-level JSON array is rejected by `MessageFactory` as invalid input, so no element of a batch is ever
+hydrated or processed:
 
 ```php
 use Mcp\JsonRpc\MessageFactory;
 
-$factory = MessageFactory::make(maxBatchSize: 50);
+$results = MessageFactory::make()->create('[{...}, {...}]'); // [InvalidInputMessageException]
 ```
 
-Single-message vs batch is determined from the decoded JSON type — a JSON object is a single message, a JSON array
-is a batch. Scalars, empty payloads, and non-object batch elements are returned as `InvalidInputMessageException`
-entries (the existing per-message error contract), not parse errors or crashes. A `maxBatchSize` below `1` throws
-`InvalidArgumentException`.
+Single-message vs batch is determined from the decoded JSON type — a JSON object is a single message, a JSON
+array is a batch and is rejected wholesale with an `InvalidInputMessageException` entry. Scalars and empty
+payloads are rejected the same way.
 
 ### Custom PSR-15 Middleware
 

--- a/src/JsonRpc/MessageFactory.php
+++ b/src/JsonRpc/MessageFactory.php
@@ -120,7 +120,7 @@ final class MessageFactory
         // A list is a batch array. MCP removed JSON-RPC batches from the
         // protocol, so the whole payload is invalid rather than a set of messages.
         if (array_is_list($data)) {
-            return [new InvalidInputMessageException('JSON-RPC batch requests are not supported; send a single JSON-RPC message.')];
+            return [new InvalidInputMessageException('JSON-RPC batch requests are not supported anymore since specification release 2025-06-18; send a single JSON-RPC message.')];
         }
 
         try {

--- a/src/JsonRpc/MessageFactory.php
+++ b/src/JsonRpc/MessageFactory.php
@@ -69,23 +69,11 @@ final class MessageFactory
     ];
 
     /**
-     * Upper bound on the number of messages accepted in a single batch, guarding
-     * against amplification where one small request expands into many operations.
-     */
-    public const DEFAULT_MAX_BATCH_SIZE = 100;
-
-    /**
      * @param list<class-string<Request>|class-string<Notification>> $registeredMessages
-     * @param int                                                    $maxBatchSize       Maximum number of messages accepted in a single JSON-RPC batch
      */
     public function __construct(
         private readonly array $registeredMessages,
-        private readonly int $maxBatchSize = self::DEFAULT_MAX_BATCH_SIZE,
     ) {
-        if ($this->maxBatchSize < 1) {
-            throw new InvalidArgumentException('maxBatchSize must be at least 1.');
-        }
-
         foreach ($this->registeredMessages as $messageClass) {
             if (!is_subclass_of($messageClass, Request::class) && !is_subclass_of($messageClass, Notification::class)) {
                 throw new InvalidArgumentException(\sprintf('Message classes must extend %s or %s.', Request::class, Notification::class));
@@ -96,16 +84,18 @@ final class MessageFactory
     /**
      * Creates a new Factory instance with all the protocol's default messages.
      */
-    public static function make(int $maxBatchSize = self::DEFAULT_MAX_BATCH_SIZE): self
+    public static function make(): self
     {
-        return new self(self::REGISTERED_MESSAGES, $maxBatchSize);
+        return new self(self::REGISTERED_MESSAGES);
     }
 
     /**
-     * Creates message objects from JSON input.
+     * Creates a message object from JSON input.
      *
-     * Supports both single messages and batch requests. Returns an array containing
-     * MessageInterface objects or InvalidInputMessageException instances for invalid messages.
+     * Accepts a single JSON-RPC message only; the MCP protocol no longer supports
+     * JSON-RPC batch requests, so a top-level array is rejected as invalid input.
+     * Returns an array containing a MessageInterface object or an
+     * InvalidInputMessageException instance for invalid messages.
      *
      * @return array<MessageInterface|InvalidInputMessageException>
      *
@@ -115,44 +105,29 @@ final class MessageFactory
     {
         $data = json_decode($input, true, flags: \JSON_THROW_ON_ERROR);
 
-        // A JSON-RPC payload is a single message (JSON object) or a batch (JSON
-        // array). Anything else (scalar, null) is invalid input rather than a
-        // parse error, and must not reach the per-message loop below.
+        // A JSON-RPC payload is a single message (JSON object). Anything else
+        // (scalar, null) is invalid input rather than a parse error.
         if (!\is_array($data)) {
-            return [new InvalidInputMessageException('A JSON-RPC message must be a JSON object or a batch array.')];
+            return [new InvalidInputMessageException('A JSON-RPC message must be a JSON object.')];
         }
 
-        // json_decode(assoc: true) maps both objects and arrays to PHP arrays. A
-        // list is a batch; a non-list (string keys) is a single message. An empty
-        // array is ambiguous ({} vs []) and invalid as either, so reject it.
+        // json_decode(assoc: true) maps both objects and arrays to PHP arrays. An
+        // empty array is ambiguous ({} vs []) and invalid as either, so reject it.
         if ([] === $data) {
             return [new InvalidInputMessageException('A JSON-RPC message must not be empty.')];
         }
 
+        // A list is a batch array. MCP removed JSON-RPC batches from the
+        // protocol, so the whole payload is invalid rather than a set of messages.
         if (array_is_list($data)) {
-            if (\count($data) > $this->maxBatchSize) {
-                return [new InvalidInputMessageException(\sprintf('JSON-RPC batch size %d exceeds the maximum allowed batch size of %d.', \count($data), $this->maxBatchSize))];
-            }
-
-            $batch = $data;
-        } else {
-            $batch = [$data];
+            return [new InvalidInputMessageException('JSON-RPC batch requests are not supported; send a single JSON-RPC message.')];
         }
 
-        $messages = [];
-        foreach ($batch as $message) {
-            try {
-                if (!\is_array($message)) {
-                    throw new InvalidInputMessageException('A JSON-RPC message must be a JSON object.');
-                }
-
-                $messages[] = $this->createMessage($message);
-            } catch (InvalidInputMessageException $e) {
-                $messages[] = $e;
-            }
+        try {
+            return [$this->createMessage($data)];
+        } catch (InvalidInputMessageException $e) {
+            return [$e];
         }
-
-        return $messages;
     }
 
     /**

--- a/tests/Unit/JsonRpc/MalformedInputTest.php
+++ b/tests/Unit/JsonRpc/MalformedInputTest.php
@@ -69,15 +69,15 @@ final class MalformedInputTest extends TestCase
         $this->assertInstanceOf(InvalidInputMessageException::class, $results[0]);
     }
 
-    #[TestDox('A malformed message in a batch does not discard the valid ones')]
-    public function testMalformedMessageInBatchDoesNotDiscardValidMessages(): void
+    #[TestDox('A batch payload is rejected as a whole, without hydrating any entry')]
+    public function testBatchPayloadIsRejectedAsAWhole(): void
     {
         $payload = '[{"jsonrpc":"2.0","id":1,"method":"tools/list"},{"jsonrpc":"2.0","id":2,"method":{}}]';
 
         $results = MessageFactory::make()->create($payload);
 
-        $this->assertCount(2, $results);
-        $this->assertInstanceOf(\Mcp\Schema\Request\ListToolsRequest::class, $results[0]);
-        $this->assertInstanceOf(InvalidInputMessageException::class, $results[1]);
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(InvalidInputMessageException::class, $results[0]);
+        $this->assertStringContainsString('batch', $results[0]->getMessage());
     }
 }

--- a/tests/Unit/JsonRpc/MessageFactoryTest.php
+++ b/tests/Unit/JsonRpc/MessageFactoryTest.php
@@ -11,7 +11,6 @@
 
 namespace Mcp\Tests\Unit\JsonRpc;
 
-use Mcp\Exception\InvalidArgumentException;
 use Mcp\Exception\InvalidInputMessageException;
 use Mcp\JsonRpc\MessageFactory;
 use Mcp\Schema\JsonRpc\Error;
@@ -167,7 +166,7 @@ final class MessageFactoryTest extends TestCase
         $this->assertEquals(['details' => 'Something went wrong'], $result->data);
     }
 
-    public function testBatchRequests(): void
+    public function testBatchRequestsAreRejected(): void
     {
         $json = '[
             {"jsonrpc": "2.0", "method": "ping", "id": 1},
@@ -177,13 +176,12 @@ final class MessageFactoryTest extends TestCase
 
         $results = $this->factory->create($json);
 
-        $this->assertCount(3, $results);
-        $this->assertInstanceOf(PingRequest::class, $results[0]);
-        $this->assertInstanceOf(GetPromptRequest::class, $results[1]);
-        $this->assertInstanceOf(InitializedNotification::class, $results[2]);
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(InvalidInputMessageException::class, $results[0]);
+        $this->assertStringContainsString('batch', $results[0]->getMessage());
     }
 
-    public function testBatchWithMixedMessages(): void
+    public function testBatchWithMixedMessagesIsRejected(): void
     {
         $json = '[
             {"jsonrpc": "2.0", "method": "ping", "id": 1},
@@ -194,11 +192,9 @@ final class MessageFactoryTest extends TestCase
 
         $results = $this->factory->create($json);
 
-        $this->assertCount(4, $results);
-        $this->assertInstanceOf(PingRequest::class, $results[0]);
-        $this->assertInstanceOf(Response::class, $results[1]);
-        $this->assertInstanceOf(Error::class, $results[2]);
-        $this->assertInstanceOf(InitializedNotification::class, $results[3]);
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(InvalidInputMessageException::class, $results[0]);
+        $this->assertStringContainsString('batch', $results[0]->getMessage());
     }
 
     public function testInvalidJson(): void
@@ -309,7 +305,7 @@ final class MessageFactoryTest extends TestCase
         $this->assertStringContainsString('message', $results[0]->getMessage());
     }
 
-    public function testBatchWithErrors(): void
+    public function testBatchWithErrorsIsRejected(): void
     {
         $json = '[
             {"jsonrpc": "2.0", "method": "ping", "id": 1},
@@ -320,11 +316,9 @@ final class MessageFactoryTest extends TestCase
 
         $results = $this->factory->create($json);
 
-        $this->assertCount(4, $results);
-        $this->assertInstanceOf(PingRequest::class, $results[0]);
-        $this->assertInstanceOf(InvalidInputMessageException::class, $results[1]);
-        $this->assertInstanceOf(InvalidInputMessageException::class, $results[2]);
-        $this->assertInstanceOf(InitializedNotification::class, $results[3]);
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(InvalidInputMessageException::class, $results[0]);
+        $this->assertStringContainsString('batch', $results[0]->getMessage());
     }
 
     public function testMakeFactoryWithDefaultMessages(): void
@@ -444,13 +438,13 @@ final class MessageFactoryTest extends TestCase
         $this->assertInstanceOf(InvalidInputMessageException::class, $results[0]);
     }
 
-    public function testBatchElementMustBeObject(): void
+    public function testBatchWithNonObjectElementsIsRejected(): void
     {
         $results = $this->factory->create('[1, 2]');
 
-        $this->assertCount(2, $results);
+        $this->assertCount(1, $results);
         $this->assertInstanceOf(InvalidInputMessageException::class, $results[0]);
-        $this->assertInstanceOf(InvalidInputMessageException::class, $results[1]);
+        $this->assertStringContainsString('batch', $results[0]->getMessage());
     }
 
     /**
@@ -474,20 +468,6 @@ final class MessageFactoryTest extends TestCase
         $this->assertStringContainsString('"method" must be a string', $results[0]->getMessage());
     }
 
-    public function testBatchWithNonStringMethodStillYieldsTheValidMessages(): void
-    {
-        $json = '[
-            {"jsonrpc": "2.0", "method": "ping", "id": 1},
-            {"jsonrpc": "2.0", "method": {}, "id": 2}
-        ]';
-
-        $results = $this->factory->create($json);
-
-        $this->assertCount(2, $results);
-        $this->assertInstanceOf(PingRequest::class, $results[0]);
-        $this->assertInstanceOf(InvalidInputMessageException::class, $results[1]);
-    }
-
     public function testLeadingWhitespaceObjectIsParsedAsSingleMessage(): void
     {
         $json = "  \n  {\"jsonrpc\": \"2.0\", \"method\": \"ping\", \"id\": 1}";
@@ -496,43 +476,5 @@ final class MessageFactoryTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertInstanceOf(PingRequest::class, $results[0]);
-    }
-
-    public function testBatchSizeExceedingMaxIsRejected(): void
-    {
-        $factory = new MessageFactory([PingRequest::class], maxBatchSize: 2);
-        $json = '[
-            {"jsonrpc": "2.0", "method": "ping", "id": 1},
-            {"jsonrpc": "2.0", "method": "ping", "id": 2},
-            {"jsonrpc": "2.0", "method": "ping", "id": 3}
-        ]';
-
-        $results = $factory->create($json);
-
-        $this->assertCount(1, $results);
-        $this->assertInstanceOf(InvalidInputMessageException::class, $results[0]);
-        $this->assertStringContainsString('batch', $results[0]->getMessage());
-    }
-
-    public function testBatchSizeWithinMaxIsAccepted(): void
-    {
-        $factory = new MessageFactory([PingRequest::class], maxBatchSize: 2);
-        $json = '[
-            {"jsonrpc": "2.0", "method": "ping", "id": 1},
-            {"jsonrpc": "2.0", "method": "ping", "id": 2}
-        ]';
-
-        $results = $factory->create($json);
-
-        $this->assertCount(2, $results);
-        $this->assertInstanceOf(PingRequest::class, $results[0]);
-        $this->assertInstanceOf(PingRequest::class, $results[1]);
-    }
-
-    public function testNonPositiveMaxBatchSizeThrows(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        new MessageFactory([PingRequest::class], maxBatchSize: 0);
     }
 }

--- a/tests/Unit/Server/ProtocolTest.php
+++ b/tests/Unit/Server/ProtocolTest.php
@@ -176,20 +176,29 @@ final class ProtocolTest extends TestCase
         );
     }
 
-    #[TestDox('Initialize request must not be part of a batch')]
-    public function testInitializeRequestInBatchReturnsError(): void
+    #[TestDox('A JSON-RPC batch is rejected as invalid input without hydrating its entries')]
+    public function testBatchInputIsRejected(): void
     {
-        $this->transport->expects($this->once())
-            ->method('send')
-            ->with(
-                $this->callback(static function ($data) {
-                    $decoded = json_decode($data, true);
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('getId')->willReturn(Uuid::v4());
 
-                    return isset($decoded['error'])
-                        && str_contains($decoded['error']['message'], 'MUST NOT be part of a batch');
-                }),
-                $this->anything()
-            );
+        $queue = [];
+        $session->method('get')->willReturnCallback(static function ($key, $default = null) use (&$queue) {
+            if ('_mcp.outgoing_queue' === $key) {
+                return $queue;
+            }
+
+            return $default;
+        });
+
+        $session->method('set')->willReturnCallback(static function ($key, $value) use (&$queue) {
+            if ('_mcp.outgoing_queue' === $key) {
+                $queue = $value;
+            }
+        });
+
+        $this->sessionManager->method('createWithId')->willReturn($session);
+        $this->sessionManager->method('exists')->willReturn(true);
 
         $protocol = new Protocol(
             requestHandlers: [],
@@ -198,11 +207,19 @@ final class ProtocolTest extends TestCase
             sessionManager: $this->sessionManager,
         );
 
+        $sessionId = Uuid::v4();
         $protocol->processInput(
             $this->transport,
             '[{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"}}}, {"jsonrpc": "2.0", "method": "ping", "id": 2}]',
-            null
+            $sessionId
         );
+
+        $outgoing = $protocol->consumeOutgoingMessages($sessionId);
+        $this->assertCount(1, $outgoing);
+
+        $decoded = json_decode($outgoing[0]['message'], true);
+        $this->assertSame(Error::INVALID_REQUEST, $decoded['error']['code']);
+        $this->assertStringContainsString('batch', $decoded['error']['message']);
     }
 
     #[TestDox('Non-initialize requests require a session ID')]
@@ -380,13 +397,29 @@ final class ProtocolTest extends TestCase
         $this->assertStringNotContainsString('must not leak', $decoded['error']['message']);
     }
 
-    #[TestDox('A batch that fails to hydrate is answered once, under the empty id')]
-    public function testBatchThatFailsToHydrateIsAnsweredOnce(): void
+    #[TestDox('A batch containing a throwing request is rejected wholesale, never hydrating it')]
+    public function testBatchContainingThrowingRequestIsRejectedWholesale(): void
     {
-        $sent = [];
-        $this->transport->method('send')->willReturnCallback(static function ($data) use (&$sent) {
-            $sent[] = $data;
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('getId')->willReturn(Uuid::v4());
+
+        $queue = [];
+        $session->method('get')->willReturnCallback(static function ($key, $default = null) use (&$queue) {
+            if ('_mcp.outgoing_queue' === $key) {
+                return $queue;
+            }
+
+            return $default;
         });
+
+        $session->method('set')->willReturnCallback(static function ($key, $value) use (&$queue) {
+            if ('_mcp.outgoing_queue' === $key) {
+                $queue = $value;
+            }
+        });
+
+        $this->sessionManager->method('createWithId')->willReturn($session);
+        $this->sessionManager->method('exists')->willReturn(true);
 
         $protocol = new Protocol(
             requestHandlers: [],
@@ -395,42 +428,19 @@ final class ProtocolTest extends TestCase
             sessionManager: $this->sessionManager,
         );
 
+        $sessionId = Uuid::v4();
         $protocol->processInput(
             $this->transport,
             '[{"jsonrpc": "2.0", "id": 1, "method": "ping"}, {"jsonrpc": "2.0", "id": 2, "method": "test/throwing"}]',
-            Uuid::v4()
+            $sessionId
         );
 
-        $this->assertCount(1, $sent);
+        $outgoing = $protocol->consumeOutgoingMessages($sessionId);
+        $this->assertCount(1, $outgoing);
 
-        $decoded = json_decode($sent[0], true);
-        $this->assertSame(Error::INTERNAL_ERROR, $decoded['error']['code']);
-        $this->assertSame('', $decoded['id'], 'The failure cannot be attributed to one request of the batch.');
-    }
-
-    #[TestDox('A batch holding only notifications is not answered when processing fails')]
-    public function testBatchOfNotificationsIsNotAnsweredWhenProcessingFails(): void
-    {
-        $session = $this->createMock(SessionInterface::class);
-        $session->method('save')->willThrowException(new \RuntimeException('storage is gone'));
-
-        $this->sessionManager->method('createWithId')->willReturn($session);
-        $this->sessionManager->method('exists')->willReturn(true);
-
-        $this->transport->expects($this->never())->method('send');
-
-        $protocol = new Protocol(
-            requestHandlers: [],
-            notificationHandlers: [],
-            messageFactory: MessageFactory::make(),
-            sessionManager: $this->sessionManager,
-        );
-
-        $protocol->processInput(
-            $this->transport,
-            '[{"jsonrpc": "2.0", "method": "notifications/initialized"}]',
-            Uuid::v4()
-        );
+        $decoded = json_decode($outgoing[0]['message'], true);
+        $this->assertSame(Error::INVALID_REQUEST, $decoded['error']['code']);
+        $this->assertStringContainsString('batch', $decoded['error']['message']);
     }
 
     #[TestDox('An unexpected throwable while saving the session does not answer a notification')]
@@ -758,69 +768,6 @@ final class ProtocolTest extends TestCase
         $message = json_decode($outgoing[0]['message'], true);
         $this->assertArrayHasKey('result', $message);
         $this->assertEquals(['status' => 'ok'], $message['result']);
-    }
-
-    #[TestDox('Batch requests are processed and send multiple responses')]
-    public function testBatchRequestsAreProcessed(): void
-    {
-        $handlerA = $this->createMock(RequestHandlerInterface::class);
-        $handlerA->method('supports')->willReturn(true);
-        $handlerA->method('handle')->willReturnCallback(static function ($request) {
-            return Response::fromArray([
-                'jsonrpc' => '2.0',
-                'id' => $request->getId(),
-                'result' => ['method' => $request::getMethod()],
-            ]);
-        });
-
-        $session = $this->createMock(SessionInterface::class);
-        $session->method('getId')->willReturn(Uuid::v4());
-
-        // Configure session mock for queue operations
-        $queue = [];
-        $session->method('get')->willReturnCallback(static function ($key, $default = null) use (&$queue) {
-            if ('_mcp.outgoing_queue' === $key) {
-                return $queue;
-            }
-
-            return $default;
-        });
-
-        $session->method('set')->willReturnCallback(static function ($key, $value) use (&$queue) {
-            if ('_mcp.outgoing_queue' === $key) {
-                $queue = $value;
-            }
-        });
-
-        $this->sessionManager->method('createWithId')->willReturn($session);
-        $this->sessionManager->method('exists')->willReturn(true);
-
-        // The protocol now queues responses instead of sending them directly
-        $session->expects($this->exactly(2))
-            ->method('save');
-
-        $protocol = new Protocol(
-            requestHandlers: [$handlerA],
-            notificationHandlers: [],
-            messageFactory: MessageFactory::make(),
-            sessionManager: $this->sessionManager,
-        );
-
-        $sessionId = Uuid::v4();
-        $protocol->processInput(
-            $this->transport,
-            '[{"jsonrpc": "2.0", "method": "tools/list", "id": 1}, {"jsonrpc": "2.0", "method": "prompts/list", "id": 2}]',
-            $sessionId
-        );
-
-        // Check that both responses were queued in the session
-        $outgoing = $protocol->consumeOutgoingMessages($sessionId);
-        $this->assertCount(2, $outgoing);
-
-        foreach ($outgoing as $outgoingMessage) {
-            $message = json_decode($outgoingMessage['message'], true);
-            $this->assertArrayHasKey('result', $message);
-        }
     }
 
     #[TestDox('Session is saved after processing')]


### PR DESCRIPTION
MCP no longer supports JSON-RPC batches: a POST body must be a single JSON-RPC message. `MessageFactory` currently accepts top-level arrays and hydrates each entry, so a batch is processed as a set of messages instead of being refused outright.

This change rejects any top-level array as invalid input before any entry is hydrated, returning a single `InvalidInputMessageException` (the existing per-message error contract) instead of processing the batch. The now-dead `maxBatchSize` cap, its constructor parameter, and `DEFAULT_MAX_BATCH_SIZE` are removed.

Tests:
- `MessageFactoryTest`: batch payloads (valid, mixed, and error-containing) are asserted to be rejected wholesale; obsolete `maxBatchSize` tests removed.
- `MalformedInputTest`: a batch payload is asserted to be rejected without hydrating any entry.
- `Server\ProtocolTest`: batch input is asserted to produce a single Invalid Request error and to never hydrate batch entries.