### PR TITLE
[Tests] Bump MCP Inspector to 2.2.0

### DIFF
--- a/tests/Inspector/InspectorSnapshotTestCase.php
+++ b/tests/Inspector/InspectorSnapshotTestCase.php
@@ -18,7 +18,7 @@ use Symfony\Component\Process\Process;
 
 abstract class InspectorSnapshotTestCase extends TestCase
 {
-    private const INSPECTOR_VERSION = '0.22.0';
+    private const INSPECTOR_VERSION = '2.2.0';
 
     /** @param array<string, mixed> $options */
     #[DataProvider('provideMethods')]


### PR DESCRIPTION
Bumps the pinned Inspector version used by the inspector test suite from 0.22.0 to 2.2.0. All snapshots pass unchanged.