### PR TITLE
[Server] Fail when discovery dependency is missing

### DIFF
--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -69,7 +69,6 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Psr\SimpleCache\CacheInterface;
-use Symfony\Component\Finder\Finder;
 
 /**
  * @phpstan-import-type Handler from ElementReference
@@ -1033,12 +1032,8 @@ final class Builder
         ];
 
         if (null !== $this->discoveryBasePath) {
-            if (null !== $this->discoverer || class_exists(Finder::class)) {
-                $discoverer = $this->discoverer ?? $this->createDiscoverer($logger);
-                $loaders[] = new DiscoveryLoader($this->discoveryBasePath, $this->discoveryScanDirs, $this->discoveryExcludeDirs, $discoverer, $this->discoveryNamePatterns, $logger);
-            } else {
-                $logger->warning('File-based discovery requires symfony/finder. Skipping automatic discovery. Run: composer require symfony/finder');
-            }
+            $discoverer = $this->discoverer ?? $this->createDiscoverer($logger);
+            $loaders[] = new DiscoveryLoader($this->discoveryBasePath, $this->discoveryScanDirs, $this->discoveryExcludeDirs, $discoverer, $this->discoveryNamePatterns, $logger);
         }
 
         $chainLoader = new ChainLoader($loaders);

--- a/tests/Unit/Server/BuilderTest.php
+++ b/tests/Unit/Server/BuilderTest.php
@@ -11,12 +11,16 @@
 
 namespace Mcp\Tests\Unit\Server;
 
+use Composer\Autoload\ClassLoader;
+use Mcp\Capability\Discovery\Discoverer;
+use Mcp\Capability\Discovery\DiscovererInterface;
 use Mcp\Capability\Registry;
 use Mcp\Capability\Registry\ElementReference;
 use Mcp\Capability\Registry\Loader\LoaderInterface;
 use Mcp\Capability\Registry\ReferenceHandlerInterface;
 use Mcp\Exception\InvalidArgumentException;
 use Mcp\Exception\LogicException;
+use Mcp\Exception\RuntimeException;
 use Mcp\Schema\Content\TextContent;
 use Mcp\Schema\Enum\ProtocolVersion;
 use Mcp\Schema\Extension\Apps\McpApps;
@@ -35,11 +39,19 @@ use Mcp\Server\Stateless\StatelessProtocol;
 use Mcp\Tests\Unit\Server\Extension\ThingExtension;
 use Mcp\Tests\Unit\Server\Extension\ThingListHandler;
 use Mcp\Tests\Unit\Server\Extension\ThingListRequest;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+use Symfony\Component\Finder\Finder;
 
 final class BuilderTest extends TestCase
 {
+    private const DISCOVERY_DEPENDENCY_ERROR = 'File-based discovery requires symfony/finder. Run: composer require symfony/finder';
+    private const FINDER_LOADED_ERROR = 'Symfony Finder was loaded after Composer autoloaders were disabled.';
+    private const TEST_SERVER_NAME = 'test';
+    private const TEST_SERVER_VERSION = '1.0.0';
+
     #[TestDox('setReferenceHandler() returns the builder for fluent chaining')]
     public function testSetReferenceHandlerReturnsSelf(): void
     {
@@ -72,6 +84,48 @@ final class BuilderTest extends TestCase
             ->build();
 
         $this->assertInstanceOf(Server::class, $server);
+    }
+
+    #[RunInSeparateProcess]
+    #[TestDox('build() fails when file-based discovery is configured without Symfony Finder')]
+    public function testBuildFailsWhenDiscoveryDependencyIsMissing(): void
+    {
+        Server::builder()->setServerInfo(self::TEST_SERVER_NAME, self::TEST_SERVER_VERSION)->build();
+        Server::builder()
+            ->setServerInfo(self::TEST_SERVER_NAME, self::TEST_SERVER_VERSION)
+            ->setDiscovery(__DIR__)
+            ->setDiscoverer($this->createStub(DiscovererInterface::class))
+            ->build();
+        class_exists(Discoverer::class);
+        class_exists(RuntimeException::class);
+        class_exists(LogLevel::class);
+
+        $autoloaders = array_values(array_filter(
+            spl_autoload_functions(),
+            static fn (mixed $autoloader): bool => \is_array($autoloader) && $autoloader[0] instanceof ClassLoader,
+        ));
+        $this->assertNotEmpty($autoloaders);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(self::DISCOVERY_DEPENDENCY_ERROR);
+
+        foreach ($autoloaders as $autoloader) {
+            $autoloader[0]->unregister();
+        }
+
+        try {
+            if (class_exists(Finder::class)) {
+                throw new LogicException(self::FINDER_LOADED_ERROR);
+            }
+
+            Server::builder()
+                ->setServerInfo(self::TEST_SERVER_NAME, self::TEST_SERVER_VERSION)
+                ->setDiscovery(__DIR__)
+                ->build();
+        } finally {
+            foreach ($autoloaders as $autoloader) {
+                $autoloader[0]->register(true);
+            }
+        }
     }
 
     #[TestDox('Custom ReferenceHandler is used when calling a tool')]


### PR DESCRIPTION
## Summary

- fail immediately when file-based discovery is configured without `symfony/finder`
- preserve custom discoverers, which do not require Finder
- cover the missing optional dependency in an isolated regression test

Fixes #398.

## Test verification (RED → GREEN)

Reproduced on unmodified `main` with production-only dependencies:

```text
BUG: build succeeded with Mcp\Server
```

With the regression test present and the production fix reverted (RED):

```text
Failed asserting that exception of type "Mcp\Exception\RuntimeException" is thrown.
FAILURES!
Tests: 1, Assertions: 2, Failures: 1.
```

With the fix applied (GREEN):

```text
OK (1 test, 3 assertions)
```

Full local validation:

```text
Composer validation: passed
PHP CS Fixer: passed
PHPStan: passed
PHPUnit unit + integration: OK (1237 tests, 3384 assertions)
phpDocumentor: passed
Changed executable line coverage: 2/2
```
