### PR TITLE
[Capability] Apply a parameter's complete schema definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `mcp/sdk` will be documented in this file.
 0.8.0
 -----
 
+* Fix `#[Schema(definition: …)]` on a parameter being merged as an ordinary key instead of replacing the schema, so the property reached clients carrying a literal `definition` member with everything inside it lost. Fixed on the plain and the variadic path; the signature default survives a definition that states none.
 * [BC Break] Drop the SDK-only name pattern on `ResourceDefinition`/`ResourceTemplate` `$name` — the spec allows any string (its own examples use `main.rs` and `Project Files`). URI/URI-template validation is unchanged.
 * Add `ClientGateway::supportsExtension()`, `Client\Builder::enableExtension()`, and `ClientCapabilities::withExtensions()` so clients can negotiate and check protocol extensions (e.g. MCP Apps) the same way servers already do. [BC Break] `ServerExtensionInterface` is replaced by the side-agnostic `Mcp\Schema\Extension\ExtensionInterface`.
 * Deprecate Roots, Sampling and Logging per SEP-2577 (protocol revision `2026-07-28`, earliest removal `2027-07-28`). They keep working but using them now triggers a deprecation notice — migrate to tool arguments/resource URIs, a direct LLM provider API, and stderr/OpenTelemetry respectively.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to `mcp/sdk` will be documented in this file.
 0.8.0
 -----
 
-* Fix `#[Schema(definition: …)]` on a parameter being merged as an ordinary key instead of replacing the schema, so the property reached clients carrying a literal `definition` member with everything inside it lost. Fixed on the plain and the variadic path; the signature default survives a definition that states none.
 * [BC Break] Drop the SDK-only name pattern on `ResourceDefinition`/`ResourceTemplate` `$name` — the spec allows any string (its own examples use `main.rs` and `Project Files`). URI/URI-template validation is unchanged.
 * Add `ClientGateway::supportsExtension()`, `Client\Builder::enableExtension()`, and `ClientCapabilities::withExtensions()` so clients can negotiate and check protocol extensions (e.g. MCP Apps) the same way servers already do. [BC Break] `ServerExtensionInterface` is replaced by the side-agnostic `Mcp\Schema\Extension\ExtensionInterface`.
 * Deprecate Roots, Sampling and Logging per SEP-2577 (protocol revision `2026-07-28`, earliest removal `2027-07-28`). They keep working but using them now triggers a deprecation notice — migrate to tool arguments/resource URIs, a direct LLM provider API, and stderr/OpenTelemetry respectively.

--- a/src/Capability/Discovery/SchemaGenerator.php
+++ b/src/Capability/Discovery/SchemaGenerator.php
@@ -334,6 +334,12 @@ final class SchemaGenerator implements SchemaGeneratorInterface
     {
         $paramSchema = ['type' => 'array'];
 
+        // Add description from docblock before parameter-level schema is merged in,
+        // so a definition's own description takes precedence (matches buildParameterSchema).
+        if ($paramInfo['description']) {
+            $paramSchema['description'] = $paramInfo['description'];
+        }
+
         // Apply parameter-level Schema attributes first
         if (!empty($paramInfo['parameter_schema'])) {
             $parameterLevelSchema = $paramInfo['parameter_schema'];
@@ -344,10 +350,6 @@ final class SchemaGenerator implements SchemaGeneratorInterface
 
             // Ensure type is always array for variadic
             $paramSchema['type'] = 'array';
-        }
-
-        if ($paramInfo['description']) {
-            $paramSchema['description'] = $paramInfo['description'];
         }
 
         // If no items specified by Schema attribute, infer from type

--- a/src/Capability/Discovery/SchemaGenerator.php
+++ b/src/Capability/Discovery/SchemaGenerator.php
@@ -237,7 +237,17 @@ final class SchemaGenerator implements SchemaGeneratorInterface
         // Parameter-level takes highest precedence
         $parameterLevelSchema = $paramInfo['parameter_schema'];
         if (!empty($parameterLevelSchema)) {
-            $mergedSchema = array_merge($mergedSchema, $parameterLevelSchema);
+            // A complete definition replaces the schema, as it does at method level.
+            if (isset($parameterLevelSchema['definition']) && \is_array($parameterLevelSchema['definition'])) {
+                $mergedSchema = $parameterLevelSchema['definition'];
+
+                // The default comes from the signature, not from the schema.
+                if (!\array_key_exists('default', $mergedSchema) && \array_key_exists('default', $inferredSchema)) {
+                    $mergedSchema['default'] = $inferredSchema['default'];
+                }
+            } else {
+                $mergedSchema = array_merge($mergedSchema, $parameterLevelSchema);
+            }
         }
 
         // Run after all merges so that when a Schema attribute reshapes the parameter
@@ -326,7 +336,12 @@ final class SchemaGenerator implements SchemaGeneratorInterface
 
         // Apply parameter-level Schema attributes first
         if (!empty($paramInfo['parameter_schema'])) {
-            $paramSchema = array_merge($paramSchema, $paramInfo['parameter_schema']);
+            $parameterLevelSchema = $paramInfo['parameter_schema'];
+
+            $paramSchema = isset($parameterLevelSchema['definition']) && \is_array($parameterLevelSchema['definition'])
+                ? $parameterLevelSchema['definition']
+                : array_merge($paramSchema, $parameterLevelSchema);
+
             // Ensure type is always array for variadic
             $paramSchema['type'] = 'array';
         }

--- a/tests/Unit/Capability/Discovery/SchemaGeneratorFixture.php
+++ b/tests/Unit/Capability/Discovery/SchemaGeneratorFixture.php
@@ -131,6 +131,30 @@ class SchemaGeneratorFixture
     // ===== PARAMETER-LEVEL SCHEMA SCENARIOS =====
 
     /**
+     * Parameter-level Schema with complete definition.
+     */
+    public function parameterLevelCompleteDefinition(
+        #[Schema(definition: [
+            'type' => 'string',
+            'description' => 'The region to query.',
+            'x-mcp-header' => 'Region',
+        ])]
+        string $region = 'eu',
+        #[Schema(definition: ['type' => 'integer', 'minimum' => 1, 'maximum' => 10])]
+        int $limit = 3,
+    ): void {
+    }
+
+    /**
+     * Parameter-level definition that reshapes the parameter's type.
+     */
+    public function definitionReshapingTheParameter(
+        #[Schema(definition: ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]])]
+        string $payload = '{}',
+    ): void {
+    }
+
+    /**
      * Parameter-level Schema attributes only.
      */
     public function parameterLevelOnly(
@@ -325,6 +349,15 @@ class SchemaGeneratorFixture
     }
 
     // ===== VARIADIC SCENARIOS =====
+
+    /**
+     * Variadic parameter with a complete definition.
+     */
+    public function variadicCompleteDefinition(
+        #[Schema(definition: ['type' => 'array', 'description' => 'Tags to apply.', 'items' => ['type' => 'string']])]
+        string ...$tags,
+    ): void {
+    }
 
     /**
      * Variadic parameter scenarios.

--- a/tests/Unit/Capability/Discovery/SchemaGeneratorFixture.php
+++ b/tests/Unit/Capability/Discovery/SchemaGeneratorFixture.php
@@ -360,6 +360,18 @@ class SchemaGeneratorFixture
     }
 
     /**
+     * Variadic parameter with both a docblock description and a complete definition;
+     * the definition's own description must win.
+     *
+     * @param string ...$tags Docblock description that must lose to the definition's own
+     */
+    public function variadicCompleteDefinitionWithDocblockDescription(
+        #[Schema(definition: ['type' => 'array', 'description' => 'Tags to apply.', 'items' => ['type' => 'string']])]
+        string ...$tags,
+    ): void {
+    }
+
+    /**
      * Variadic parameter scenarios.
      *
      * @param string ...$items Variadic strings

--- a/tests/Unit/Capability/Discovery/SchemaGeneratorTest.php
+++ b/tests/Unit/Capability/Discovery/SchemaGeneratorTest.php
@@ -92,6 +92,50 @@ final class SchemaGeneratorTest extends TestCase
         ], $schema);
     }
 
+    public function testUsesCompleteSchemaDefinitionFromParameterLevelSchemaAttribute(): void
+    {
+        $method = new \ReflectionMethod(SchemaGeneratorFixture::class, 'parameterLevelCompleteDefinition');
+        $schema = $this->schemaGenerator->generate($method);
+
+        $this->assertEquals([
+            'type' => 'string',
+            'description' => 'The region to query.',
+            'x-mcp-header' => 'Region',
+            'default' => 'eu',
+        ], $schema['properties']['region']);
+
+        $this->assertEquals([
+            'type' => 'integer',
+            'minimum' => 1,
+            'maximum' => 10,
+            'default' => 3,
+        ], $schema['properties']['limit']);
+
+        $this->assertArrayNotHasKey('required', $schema);
+    }
+
+    public function testUsesCompleteSchemaDefinitionFromVariadicParameter(): void
+    {
+        $method = new \ReflectionMethod(SchemaGeneratorFixture::class, 'variadicCompleteDefinition');
+        $schema = $this->schemaGenerator->generate($method);
+
+        // The array type is forced: a variadic always arrives as one.
+        $this->assertEquals([
+            'type' => 'array',
+            'description' => 'Tags to apply.',
+            'items' => ['type' => 'string'],
+        ], $schema['properties']['tags']);
+    }
+
+    public function testKeepsTheSignatureDefaultWhenADefinitionReshapesTheParameter(): void
+    {
+        $method = new \ReflectionMethod(SchemaGeneratorFixture::class, 'definitionReshapingTheParameter');
+        $schema = $this->schemaGenerator->generate($method);
+
+        $this->assertSame('{}', $schema['properties']['payload']['default']);
+        $this->assertSame('object', $schema['properties']['payload']['type']);
+    }
+
     public function testGeneratesSchemaFromMethodLevelSchemaAttributeWithProperties(): void
     {
         $method = new \ReflectionMethod(SchemaGeneratorFixture::class, 'methodLevelWithProperties');

--- a/tests/Unit/Capability/Discovery/SchemaGeneratorTest.php
+++ b/tests/Unit/Capability/Discovery/SchemaGeneratorTest.php
@@ -127,6 +127,14 @@ final class SchemaGeneratorTest extends TestCase
         ], $schema['properties']['tags']);
     }
 
+    public function testDefinitionDescriptionWinsOverDocblockOnVariadicParameter(): void
+    {
+        $method = new \ReflectionMethod(SchemaGeneratorFixture::class, 'variadicCompleteDefinitionWithDocblockDescription');
+        $schema = $this->schemaGenerator->generate($method);
+
+        $this->assertSame('Tags to apply.', $schema['properties']['tags']['description']);
+    }
+
     public function testKeepsTheSignatureDefaultWhenADefinitionReshapesTheParameter(): void
     {
         $method = new \ReflectionMethod(SchemaGeneratorFixture::class, 'definitionReshapingTheParameter');


### PR DESCRIPTION
`#[Schema(definition: …)]` is documented as taking precedence over the individual keywords, and `generate()` unwraps it that way at method level. At parameter level it was merged as an ordinary key instead, in both the plain and the variadic path, so the property reached clients carrying a literal `definition` member — not JSON Schema, read by nothing, and everything inside it lost.

`x-mcp-header` feels it worst: having no representation on the attribute other than `definition:` nested, the server never learns an argument is mirrored, so it never checks the header against the body.

Both paths now replace the schema with the definition. The variadic one still forces `type: array` afterwards, since a variadic arrives as an array however the definition describes it, and the signature default survives a definition that states none — it is what the handler receives when the argument is omitted, and `default` is an annotation rather than a constraint.
