### PR TITLE
[Schema] Serialize a settingless extension as an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to `mcp/sdk` will be documented in this file.
 0.8.0
 -----
 
-* Fix an extension with no settings being advertised as `[]` rather than `{}` in `ServerCapabilities` and `ClientCapabilities`, which the wire schema rejects.
 * [BC Break] Drop the SDK-only name pattern on `ResourceDefinition`/`ResourceTemplate` `$name` — the spec allows any string (its own examples use `main.rs` and `Project Files`). URI/URI-template validation is unchanged.
 * Add `ClientGateway::supportsExtension()`, `Client\Builder::enableExtension()`, and `ClientCapabilities::withExtensions()` so clients can negotiate and check protocol extensions (e.g. MCP Apps) the same way servers already do. [BC Break] `ServerExtensionInterface` is replaced by the side-agnostic `Mcp\Schema\Extension\ExtensionInterface`.
 * Deprecate Roots, Sampling and Logging per SEP-2577 (protocol revision `2026-07-28`, earliest removal `2027-07-28`). They keep working but using them now triggers a deprecation notice — migrate to tool arguments/resource URIs, a direct LLM provider API, and stderr/OpenTelemetry respectively.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `mcp/sdk` will be documented in this file.
 0.8.0
 -----
 
+* Fix an extension with no settings being advertised as `[]` rather than `{}` in `ServerCapabilities` and `ClientCapabilities`, which the wire schema rejects.
 * [BC Break] Drop the SDK-only name pattern on `ResourceDefinition`/`ResourceTemplate` `$name` — the spec allows any string (its own examples use `main.rs` and `Project Files`). URI/URI-template validation is unchanged.
 * Add `ClientGateway::supportsExtension()`, `Client\Builder::enableExtension()`, and `ClientCapabilities::withExtensions()` so clients can negotiate and check protocol extensions (e.g. MCP Apps) the same way servers already do. [BC Break] `ServerExtensionInterface` is replaced by the side-agnostic `Mcp\Schema\Extension\ExtensionInterface`.
 * Deprecate Roots, Sampling and Logging per SEP-2577 (protocol revision `2026-07-28`, earliest removal `2027-07-28`). They keep working but using them now triggers a deprecation notice — migrate to tool arguments/resource URIs, a direct LLM provider API, and stderr/OpenTelemetry respectively.

--- a/src/Schema/ClientCapabilities.php
+++ b/src/Schema/ClientCapabilities.php
@@ -188,7 +188,10 @@ class ClientCapabilities implements \JsonSerializable
         }
 
         if ($this->extensions) {
-            $data['extensions'] = (object) $this->extensions;
+            $data['extensions'] = (object) array_map(
+                static fn (mixed $settings): mixed => \is_array($settings) ? (object) $settings : $settings,
+                $this->extensions,
+            );
         }
 
         return $data ?: new \stdClass();

--- a/src/Schema/ServerCapabilities.php
+++ b/src/Schema/ServerCapabilities.php
@@ -189,7 +189,12 @@ class ServerCapabilities implements \JsonSerializable
         }
 
         if ($this->extensions) {
-            $data['extensions'] = (object) $this->extensions;
+            // Each entry is a settings *object*; an extension with no settings
+            // declares `{}`, and an empty PHP array would serialize as `[]`.
+            $data['extensions'] = (object) array_map(
+                static fn (mixed $settings): mixed => \is_array($settings) ? (object) $settings : $settings,
+                $this->extensions,
+            );
         }
 
         return $data;

--- a/tests/Unit/Schema/Extension/CapabilitiesExtensionsTest.php
+++ b/tests/Unit/Schema/Extension/CapabilitiesExtensionsTest.php
@@ -57,6 +57,24 @@ class CapabilitiesExtensionsTest extends TestCase
         $this->assertObjectHasProperty(McpApps::EXTENSION_ID, $json['extensions']);
     }
 
+    public function testServerCapabilitiesSerializeSettinglessExtensionAsObject(): void
+    {
+        $caps = new ServerCapabilities(tools: true, extensions: ['acme/thing' => []]);
+
+        $json = json_encode($caps->jsonSerialize(), \JSON_UNESCAPED_SLASHES);
+
+        $this->assertStringContainsString('"acme/thing":{}', (string) $json);
+    }
+
+    public function testClientCapabilitiesSerializeSettinglessExtensionAsObject(): void
+    {
+        $caps = new ClientCapabilities(elicitation: true, extensions: ['acme/thing' => []]);
+
+        $json = json_encode($caps->jsonSerialize(), \JSON_UNESCAPED_SLASHES);
+
+        $this->assertStringContainsString('"acme/thing":{}', (string) $json);
+    }
+
     public function testServerCapabilitiesJsonSerializeWithoutExtensions(): void
     {
         $caps = new ServerCapabilities(tools: true);


### PR DESCRIPTION
An extension declaring support with no settings was advertised as `[]`, an empty JSON array, which the wire schema rejects — `extensions` maps an id to a settings *object*.

Both `ServerCapabilities` and `ClientCapabilities` now cast each entry, so it goes out as `{}`.
