### PR TITLE
[Tests] Pin that protected resource metadata advertises no scope of its own

### DIFF
--- a/tests/Unit/Server/Transport/Http/OAuth/ProtectedResourceMetadataTest.php
+++ b/tests/Unit/Server/Transport/Http/OAuth/ProtectedResourceMetadataTest.php
@@ -83,4 +83,33 @@ class ProtectedResourceMetadataTest extends TestCase
 
         new ProtectedResourceMetadata([]);
     }
+
+    #[TestDox('the SDK advertises exactly the scopes it was given, and never adds offline_access')]
+    public function testScopesAreOperatorSuppliedOnly(): void
+    {
+        // SEP-2207: `offline_access` is a refresh-token scope, not something a
+        // resource requires. Nothing in the SDK injects it — this pins that, so
+        // a future default cannot quietly start advertising one.
+        $metadata = new ProtectedResourceMetadata(
+            resource: 'https://api.example.com/mcp',
+            authorizationServers: ['https://auth.example.com'],
+            scopesSupported: ['mcp:read', 'mcp:write'],
+        );
+
+        $data = $metadata->jsonSerialize();
+
+        $this->assertSame(['mcp:read', 'mcp:write'], $data['scopes_supported']);
+        $this->assertNotContains('offline_access', $data['scopes_supported']);
+    }
+
+    #[TestDox('no scopes given means no scopes_supported member at all')]
+    public function testNoScopesMeansNoMember(): void
+    {
+        $metadata = new ProtectedResourceMetadata(
+            resource: 'https://api.example.com/mcp',
+            authorizationServers: ['https://auth.example.com'],
+        );
+
+        $this->assertArrayNotHasKey('scopes_supported', $metadata->jsonSerialize());
+    }
 }


### PR DESCRIPTION
SEP-2207 (#364) says a resource server must not advertise `offline_access` as a required scope.

There is nothing to fix: `ProtectedResourceMetadata::$scopesSupported` is entirely operator-supplied, and nothing in `src/` writes `offline_access` anywhere. But there was also nothing stopping a future default from quietly starting to advertise one, so this pins the behaviour with a regression test.

Test only — no production code changes.
