### PR TITLE
Add badge linebreak and v1.0 roadmap items

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![CI](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/pipeline.yaml/badge.svg)](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/pipeline.yaml)
 [![PHP Version](https://img.shields.io/packagist/php-v/mcp/sdk.svg)](https://packagist.org/packages/mcp/sdk)
 [![License](https://img.shields.io/packagist/l/mcp/sdk.svg)](LICENSE)
+
 [![Server Conformance 2025-11-25](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/modelcontextprotocol/php-sdk/badges/server-conformance-2025-11-25.json)](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/conformance-weekly.yaml)
 [![Client Conformance 2025-11-25](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/modelcontextprotocol/php-sdk/badges/client-conformance-2025-11-25.json)](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/conformance-weekly.yaml)
 [![Server Conformance 2026-07-28](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/modelcontextprotocol/php-sdk/badges/server-conformance-2026-07-28.json)](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/conformance-weekly.yaml)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,6 +10,12 @@ This roadmap is a living document that outlines the planned features and improve
 - **Client**
 - [x] Implement client-side support
 - [x] Implement client examples and documentation
+- [ ] Implement OAuth2 authentication for client
 - **Schema**
 - [ ] Implement schema generation based on TS or JSON Schema
+- [ ] Achieve full spec conformance
+- **Extensions**
+- [ ] Implement the Tasks extension
+- **Architecture**
+- [ ] Split the SDK into multiple packages
 


### PR DESCRIPTION
Splits the README badges into two rows and fills in the missing v1.0 roadmap items (client auth, full conformance, Tasks extension, multi-package split).