### PR TITLE
[Client] Fill elicitation defaults when accepting

### DIFF
--- a/src/Schema/Elicitation/ElicitationSchema.php
+++ b/src/Schema/Elicitation/ElicitationSchema.php
@@ -134,6 +134,26 @@ final class ElicitationSchema implements \JsonSerializable
     }
 
     /**
+     * Return the canonical response content for accepting this elicitation with its declared defaults.
+     *
+     * @return array<string, mixed>
+     */
+    public function extractDefaults(): array
+    {
+        $defaults = [];
+
+        foreach ($this->properties as $name => $property) {
+            $definition = $property->jsonSerialize();
+
+            if (\array_key_exists('default', $definition)) {
+                $defaults[$name] = $definition['default'];
+            }
+        }
+
+        return $defaults;
+    }
+
+    /**
      * @return array{
      *     type: string,
      *     properties: array<string, mixed>,

--- a/tests/Conformance/client.php
+++ b/tests/Conformance/client.php
@@ -52,10 +52,10 @@ $builder = Client::builder()
     ->setLogger($logger);
 
 /**
- * Accepts every elicitation with an empty payload.
+ * Accepts every form elicitation with its declared defaults.
  *
- * Enough for the scenarios here, which check that the client asked and echoed
- * correctly rather than what a user would have typed.
+ * ElicitationSchema::extractDefaults() is the canonical accept-with-defaults
+ * path when the user does not provide explicit field values.
  */
 $acceptElicitation = new class($logger) implements RequestHandlerInterface {
     public function __construct(private readonly Psr\Log\LoggerInterface $logger)
@@ -69,9 +69,14 @@ $acceptElicitation = new class($logger) implements RequestHandlerInterface {
 
     public function handle(Request $request): Response
     {
-        $this->logger->info('Received elicitation request, accepting with empty content');
+        if (!$request instanceof ElicitRequest || null === $request->requestedSchema) {
+            throw new RuntimeException('Expected a form elicitation request with a requested schema.');
+        }
 
-        return new Response($request->getId(), new ElicitResult(ElicitAction::Accept, []));
+        $content = $request->requestedSchema->extractDefaults();
+        $this->logger->info(sprintf('Received elicitation request, accepting with %d defaults', count($content)));
+
+        return new Response($request->getId(), new ElicitResult(ElicitAction::Accept, $content));
     }
 };
 

--- a/tests/Unit/Schema/Elicitation/ElicitationSchemaTest.php
+++ b/tests/Unit/Schema/Elicitation/ElicitationSchemaTest.php
@@ -67,6 +67,39 @@ final class ElicitationSchemaTest extends TestCase
         $this->assertInstanceOf(EnumSchemaDefinition::class, $schema->properties['rating']);
     }
 
+    public function testExtractDefaults(): void
+    {
+        $schema = ElicitationSchema::fromArray([
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string', 'title' => 'Name', 'default' => 'Ada'],
+                'age' => ['type' => 'integer', 'title' => 'Age', 'default' => 0],
+                'score' => ['type' => 'number', 'title' => 'Score', 'default' => 95.5],
+                'color' => ['type' => 'string', 'title' => 'Color', 'enum' => ['red', 'blue'], 'default' => 'blue'],
+                'plan' => [
+                    'type' => 'string',
+                    'title' => 'Plan',
+                    'oneOf' => [
+                        ['const' => 'free', 'title' => 'Free'],
+                        ['const' => 'pro', 'title' => 'Pro'],
+                    ],
+                    'default' => 'pro',
+                ],
+                'subscribe' => ['type' => 'boolean', 'title' => 'Subscribe', 'default' => false],
+                'withoutDefault' => ['type' => 'string', 'title' => 'Without default'],
+            ],
+        ]);
+
+        $this->assertSame([
+            'name' => 'Ada',
+            'age' => 0,
+            'score' => 95.5,
+            'color' => 'blue',
+            'plan' => 'pro',
+            'subscribe' => false,
+        ], $schema->extractDefaults());
+    }
+
     public function testConstructorWithEmptyProperties(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
A client accepting `elicitation/create` without explicit field values currently has to rebuild the request schema's defaults itself. The conformance client instead returned empty content, even though each supported definition already exposes `default`.

`ElicitationSchema::extractDefaults()` now provides the canonical `field => default` map, preserves falsey values such as `0` and `false`, and skips fields with no default. The conformance client uses that map when accepting. Coverage includes string, integer/number, enum, titled enum, and boolean definitions.

I left out the optional `ElicitResult::accepted()` factory because the helper and existing constructor cover the path without adding another public entry point.

The `elicitation-sep1034-client-defaults` runner still times out on current `main` before the handler runs: the server sends `elicitation/create` on the standalone SSE stream, while `HttpTransport` does not yet open the GET stream tracked by #327. Its expected-failure entry therefore stays in place. The 2026-07-28 `sep-2322-client-request-state` scenario, which exercises the same handler path, passes 5/5.

Checks:

- `vendor/bin/phpunit` — 1686 tests, 4377 assertions, 7 existing skips
- `vendor/bin/phpstan analyse --memory-limit=-1`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --verbose`
- `make docs`
- `composer validate --strict`
- `sep-2322-client-request-state` conformance — 5/5

Fixes #328
