### PR TITLE
Fail loudly when discovery is configured but symfony/finder is missing

### DIFF
--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -29,6 +29,7 @@ use Mcp\Capability\Registry\ReferenceHandlerInterface;
 use Mcp\Capability\RegistryInterface;
 use Mcp\Exception\InvalidArgumentException;
 use Mcp\Exception\LogicException;
+use Mcp\Exception\RuntimeException;
 use Mcp\JsonRpc\MessageFactory;
 use Mcp\Schema\Annotations;
 use Mcp\Schema\Enum\ProtocolVersion;
@@ -1037,7 +1038,13 @@ final class Builder
                 $discoverer = $this->discoverer ?? $this->createDiscoverer($logger);
                 $loaders[] = new DiscoveryLoader($this->discoveryBasePath, $this->discoveryScanDirs, $this->discoveryExcludeDirs, $discoverer, $this->discoveryNamePatterns, $logger);
             } else {
-                $logger->warning('File-based discovery requires symfony/finder. Skipping automatic discovery. Run: composer require symfony/finder');
+                // Warning-and-skip here used to route around the identical guard in
+                // Discoverer::__construct(), turning a configured-but-impossible feature
+                // into a silent no-op: build() succeeds, initialize succeeds, and
+                // tools/list quietly returns an empty array with no actionable signal
+                // beyond a single log line. setDiscovery() is an explicit request for
+                // file-based discovery, so failing to honor it must fail loudly.
+                throw new RuntimeException('File-based discovery requires symfony/finder. Run: composer require symfony/finder');
             }
         }
 


### PR DESCRIPTION
## Summary

`Builder::build()` routed around `Discoverer::__construct()`'s own `class_exists(Finder::class)` guard: instead of throwing, it logged a single warning and silently skipped the `DiscoveryLoader`. The result is the worst failure mode available — the server builds successfully, `initialize` succeeds, and `tools/list` quietly returns an empty array, with no actionable signal beyond one log line the operator may never see.

`setDiscovery()` is an explicit request for file-based discovery; if that request can't be honored, `build()` should fail immediately with the same `RuntimeException` and message `Discoverer` already throws for the identical condition, rather than downgrading a configured-but-impossible feature to a whisper.

Fixes #398

## Test plan

- [x] `vendor/bin/phpunit --testsuite=unit` — 1513 tests, 3919 assertions, all passing
- [x] `vendor/bin/phpunit --testsuite=integration` — 64 tests, 145 assertions, all passing
- [x] `vendor/bin/phpstan analyse` (full repo, level 6 per `phpstan.dist.neon`) — no errors