### PR TITLE
fix: specify closure handler signature

### DIFF
--- a/src/Capability/Registry/ElementReference.php
+++ b/src/Capability/Registry/ElementReference.php
@@ -12,7 +12,7 @@
 namespace Mcp\Capability\Registry;
 
 /**
- * @phpstan-type Handler \Closure|array{0: object|string, 1: string}|string
+ * @phpstan-type Handler (\Closure(mixed...): mixed)|array{0: object|string, 1: string}|string
  *
  * @author Kyrian Obikwelu <koshnawaza@gmail.com>
  */


### PR DESCRIPTION
## Summary

- give the registry handler `Closure` alias an explicit variadic signature
- allow strict PHPStan users to decorate `RegistryInterface` without a missing callable signature error

## Root cause

The `Handler` PHPStan alias used a bare `\Closure`, so consumers inheriting the alias received `missingType.callable` under strict analysis.

## Current validation status

- consumer-only minimal PHPStan reproducer: fails before and passes with the proposed alias
- `ReferenceHandlerTest`: 4 tests, 9 assertions pass
- `git diff --check`: passes

Upstream CI exposed a variance conflict that the isolated reproducer missed: the proposed `Closure(mixed...): mixed` type rejects the repository's valid handlers with narrower required parameter lists. The full PHPStan job reports 29 `argument.type` errors introduced by this alias. The PR is therefore intentionally Draft while the correct way to represent an arbitrary Closure signature is discussed; the current commit should not be merged as-is.

Related to #468 — design spike; current commit is not merge-ready.