### PR TITLE
[Server] Restrict FileSessionStore::gc() to owned session files

### DIFF
--- a/src/Server/Session/FileSessionStore.php
+++ b/src/Server/Session/FileSessionStore.php
@@ -128,6 +128,11 @@ class FileSessionStore implements SessionStoreInterface
                 continue;
             }
 
+            // Only delete files this store owns: sessions are named by their RFC 4122 UUID
+            if (!Uuid::isValid($entry)) {
+                continue;
+            }
+
             $path = $this->directory.\DIRECTORY_SEPARATOR.$entry;
             if (!is_file($path)) {
                 continue;
@@ -136,11 +141,7 @@ class FileSessionStore implements SessionStoreInterface
             $mtime = @filemtime($path) ?: 0;
             if (($now - $mtime) > $this->ttl) {
                 @unlink($path);
-                try {
-                    $deleted[] = Uuid::fromString($entry);
-                } catch (\Throwable) {
-                    // ignore non-UUID file names
-                }
+                $deleted[] = Uuid::fromString($entry);
             }
         }
 

--- a/tests/Unit/Server/Session/FileSessionStoreTest.php
+++ b/tests/Unit/Server/Session/FileSessionStoreTest.php
@@ -62,6 +62,28 @@ class FileSessionStoreTest extends TestCase
         $this->assertSame('payload', $store->read($id));
     }
 
+    #[TestDox('gc() only deletes expired session files, never foreign files in the directory')]
+    public function testGcLeavesForeignFilesAlone(): void
+    {
+        $store = new FileSessionStore($this->directory, ttl: 60);
+        $id = new UuidV4();
+        $store->write($id, 'payload');
+
+        $foreign = $this->directory.'/important.lock';
+        file_put_contents($foreign, 'not a session');
+
+        // Make everything stale
+        $expired = time() - 120;
+        touch($this->directory.'/'.$id->toRfc4122(), $expired);
+        touch($foreign, $expired);
+
+        $deleted = $store->gc();
+
+        $this->assertEquals([$id], $deleted);
+        $this->assertFileDoesNotExist($this->directory.'/'.$id->toRfc4122());
+        $this->assertFileExists($foreign);
+    }
+
     #[TestDox('rejects an unwritable directory with the SDK\'s own exception')]
     public function testUnwritableDirectoryThrowsPackageException(): void
     {


### PR DESCRIPTION
`gc()` unlinked any stale file in the session directory and only then checked whether the name was a UUID — pointing the store at a shared directory could delete unrelated files. Now the filename is validated as an RFC 4122 UUID before any unlink, so `gc()` only touches files the store owns.

Fork issue: chr-hertel/php-sdk#24
