### PR TITLE
[Capability] Suppress list-changed events during the initial registry load

### DIFF
--- a/src/Capability/Registry.php
+++ b/src/Capability/Registry.php
@@ -390,12 +390,7 @@ final class Registry implements RegistryInterface
         return $this->prompts[$name] ?? throw new PromptNotFoundException($name);
     }
 
-    /**
-     * List-changed events announce a change to a list a client may have already seen. The deferred
-     * load populates the initial state before any read returns, so nothing observable changes —
-     * dispatching there would publish one spurious frame per element onto a configured notification
-     * bus. Suppressed while the loader runs, dispatched as usual for runtime (un)registrations.
-     */
+    /** Suppressed while the deferred loader runs, since it only sets up initial state. */
     private function dispatch(object $event): void
     {
         if ($this->loading) {

--- a/src/Capability/Registry.php
+++ b/src/Capability/Registry.php
@@ -108,7 +108,7 @@ final class Registry implements RegistryInterface
         $reference = new ToolReference($tool, $handler);
         $this->tools[$tool->name] = $reference;
 
-        $this->eventDispatcher?->dispatch(new ToolListChangedEvent());
+        $this->dispatch(new ToolListChangedEvent());
 
         return $reference;
     }
@@ -118,7 +118,7 @@ final class Registry implements RegistryInterface
         $reference = new ResourceReference($resource, $handler);
         $this->resources[$resource->uri] = $reference;
 
-        $this->eventDispatcher?->dispatch(new ResourceListChangedEvent());
+        $this->dispatch(new ResourceListChangedEvent());
 
         return $reference;
     }
@@ -131,7 +131,7 @@ final class Registry implements RegistryInterface
         $reference = new ResourceTemplateReference($template, $handler, $completionProviders);
         $this->resourceTemplates[$template->uriTemplate] = $reference;
 
-        $this->eventDispatcher?->dispatch(new ResourceTemplateListChangedEvent());
+        $this->dispatch(new ResourceTemplateListChangedEvent());
 
         return $reference;
     }
@@ -144,7 +144,7 @@ final class Registry implements RegistryInterface
         $reference = new PromptReference($prompt, $handler, $completionProviders);
         $this->prompts[$prompt->name] = $reference;
 
-        $this->eventDispatcher?->dispatch(new PromptListChangedEvent());
+        $this->dispatch(new PromptListChangedEvent());
 
         return $reference;
     }
@@ -157,7 +157,7 @@ final class Registry implements RegistryInterface
 
         unset($this->tools[$name]);
 
-        $this->eventDispatcher?->dispatch(new ToolListChangedEvent());
+        $this->dispatch(new ToolListChangedEvent());
     }
 
     public function unregisterResource(string $uri): void
@@ -168,7 +168,7 @@ final class Registry implements RegistryInterface
 
         unset($this->resources[$uri]);
 
-        $this->eventDispatcher?->dispatch(new ResourceListChangedEvent());
+        $this->dispatch(new ResourceListChangedEvent());
     }
 
     public function unregisterResourceTemplate(string $uriTemplate): void
@@ -179,7 +179,7 @@ final class Registry implements RegistryInterface
 
         unset($this->resourceTemplates[$uriTemplate]);
 
-        $this->eventDispatcher?->dispatch(new ResourceTemplateListChangedEvent());
+        $this->dispatch(new ResourceTemplateListChangedEvent());
     }
 
     public function unregisterPrompt(string $name): void
@@ -190,7 +190,7 @@ final class Registry implements RegistryInterface
 
         unset($this->prompts[$name]);
 
-        $this->eventDispatcher?->dispatch(new PromptListChangedEvent());
+        $this->dispatch(new PromptListChangedEvent());
     }
 
     public function hasTool(string $name): bool
@@ -388,6 +388,21 @@ final class Registry implements RegistryInterface
         $this->load();
 
         return $this->prompts[$name] ?? throw new PromptNotFoundException($name);
+    }
+
+    /**
+     * List-changed events announce a change to a list a client may have already seen. The deferred
+     * load populates the initial state before any read returns, so nothing observable changes —
+     * dispatching there would publish one spurious frame per element onto a configured notification
+     * bus. Suppressed while the loader runs, dispatched as usual for runtime (un)registrations.
+     */
+    private function dispatch(object $event): void
+    {
+        if ($this->loading) {
+            return;
+        }
+
+        $this->eventDispatcher?->dispatch($event);
     }
 
     /**

--- a/src/Capability/Registry.php
+++ b/src/Capability/Registry.php
@@ -390,7 +390,9 @@ final class Registry implements RegistryInterface
         return $this->prompts[$name] ?? throw new PromptNotFoundException($name);
     }
 
-    /** Suppressed while the deferred loader runs, since it only sets up initial state. */
+    /**
+     * Suppressed while the deferred loader runs, since it only sets up initial state.
+     */
     private function dispatch(object $event): void
     {
         if ($this->loading) {

--- a/tests/Unit/Capability/RegistryTest.php
+++ b/tests/Unit/Capability/RegistryTest.php
@@ -19,6 +19,7 @@ use Mcp\Capability\Registry\ResourceReference;
 use Mcp\Capability\Registry\ResourceTemplateReference;
 use Mcp\Capability\Registry\ToolReference;
 use Mcp\Capability\RegistryInterface;
+use Mcp\Event\ToolListChangedEvent;
 use Mcp\Exception\PromptNotFoundException;
 use Mcp\Exception\ResourceNotFoundException;
 use Mcp\Exception\ToolNotFoundException;
@@ -31,6 +32,7 @@ use Mcp\Schema\ResourceTemplate;
 use Mcp\Schema\Tool;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 
 class RegistryTest extends TestCase
@@ -720,6 +722,50 @@ class RegistryTest extends TestCase
         }
 
         $this->assertArrayHasKey('loaded', $registry->getTools()->references);
+    }
+
+    public function testListChangedEventsAreSuppressedDuringTheDeferredLoad(): void
+    {
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->never())->method('dispatch');
+
+        $loader = new class($this->createValidTool('loaded'), $this->createValidResource('file:///loaded'), $this->createValidResourceTemplate('file:///loaded/{id}'), $this->createValidPrompt('loaded_prompt')) implements LoaderInterface {
+            public function __construct(
+                private readonly Tool $tool,
+                private readonly ResourceDefinition $resource,
+                private readonly ResourceTemplate $template,
+                private readonly Prompt $prompt,
+            ) {
+            }
+
+            public function load(RegistryInterface $registry): void
+            {
+                $registry->registerTool($this->tool, 'handler');
+                $registry->registerResource($this->resource, 'handler');
+                $registry->registerResourceTemplate($this->template, 'handler');
+                $registry->registerPrompt($this->prompt, 'handler');
+            }
+        };
+
+        $registry = new Registry($eventDispatcher, $this->logger, loader: $loader);
+
+        $this->assertTrue($registry->hasTools());
+        $this->assertTrue($registry->hasPrompts());
+    }
+
+    public function testListChangedEventsAreStillDispatchedForRuntimeRegistrations(): void
+    {
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(ToolListChangedEvent::class))
+            ->willReturnArgument(0);
+
+        $loader = $this->toolLoader($this->createValidTool('loaded'));
+        $registry = new Registry($eventDispatcher, $this->logger, loader: $loader);
+        $registry->load();
+
+        $registry->registerTool($this->createValidTool('runtime'), 'handler');
     }
 
     public function testLoadRunsTheConfiguredLoaderEagerly(): void


### PR DESCRIPTION
`Registry` dispatched a list-changed event per element while the deferred loader ran, publishing spurious frames onto a configured notification bus before any client had observed a list. Registrations now route through a helper that skips dispatch while `loading` is set — the load establishes the initial state before the first read returns, so no change is observable and no end-of-load event is needed.

Fork issue: chr-hertel/php-sdk#26
