### PR TITLE
[Server] Stop Session::forget() from creating missing segments

### DIFF
--- a/src/Server/Session/Session.php
+++ b/src/Server/Session/Session.php
@@ -110,15 +110,12 @@ class Session implements SessionInterface
         while (\count($segments) > 1) {
             $segment = array_shift($segments);
             if (!isset($data[$segment]) || !\is_array($data[$segment])) {
-                $data[$segment] = [];
+                return;
             }
             $data = &$data[$segment];
         }
 
-        $lastKey = array_shift($segments);
-        if (isset($data[$lastKey])) {
-            unset($data[$lastKey]);
-        }
+        unset($data[array_shift($segments)]);
     }
 
     public function clear(): void

--- a/tests/Unit/Server/Session/SessionTest.php
+++ b/tests/Unit/Server/Session/SessionTest.php
@@ -245,6 +245,21 @@ class SessionTest extends TestCase
         $this->assertFalse($this->session->has('nonexistent'));
     }
 
+    public function testForgetDoesNotCreateIntermediateSegments(): void
+    {
+        $this->session->forget('a.b');
+
+        $this->assertSame([], $this->session->all());
+    }
+
+    public function testForgetDoesNotOverwriteNonArrayIntermediateValue(): void
+    {
+        $this->session->set('key', 'string_value');
+        $this->session->forget('key.nested');
+
+        $this->assertSame('string_value', $this->session->get('key'));
+    }
+
     public function testSessionCanStoreVariousDataTypes(): void
     {
         $this->session->set('string', 'value');


### PR DESCRIPTION
`Session::forget()` reused `set()`'s loop body, so deleting a nested key vivified missing intermediate segments: `forget('a.b')` left `a => []` behind, and a non-array intermediate got clobbered into an array. It now returns early when the path doesn't exist.

Regression tests included.
