### PR TITLE
[Schema] Fix _meta guard key in Request and Notification jsonSerialize()

### DIFF
--- a/src/Schema/JsonRpc/Notification.php
+++ b/src/Schema/JsonRpc/Notification.php
@@ -74,7 +74,7 @@ abstract class Notification implements HasMethodInterface, MessageInterface
             $array['params'] = $params;
         }
 
-        if (null !== $this->meta && !isset($params['meta'])) {
+        if (null !== $this->meta && !isset($params['_meta'])) {
             $array['params']['_meta'] = $this->meta;
         }
 

--- a/src/Schema/JsonRpc/Request.php
+++ b/src/Schema/JsonRpc/Request.php
@@ -122,7 +122,7 @@ abstract class Request implements HasMethodInterface, MessageInterface
             $array['params'] = $params;
         }
 
-        if (null !== $this->meta && !isset($params['meta'])) {
+        if (null !== $this->meta && !isset($params['_meta'])) {
             $array['params']['_meta'] = $this->meta;
         }
 

--- a/tests/Unit/Schema/JsonRpc/NotificationTest.php
+++ b/tests/Unit/Schema/JsonRpc/NotificationTest.php
@@ -53,4 +53,44 @@ final class NotificationTest extends TestCase
 
         $this->assertSame($expectedMeta, $notification->jsonSerialize());
     }
+
+    public function testMetaDoesNotOverrideMetaFromParams(): void
+    {
+        $notificationImplementation = new class extends Notification {
+            public static function getMethod(): string
+            {
+                return 'notifications/dummy';
+            }
+
+            public static function fromParams(?array $params): self
+            {
+                return new self();
+            }
+
+            protected function getParams(): array
+            {
+                return [
+                    '_meta' => ['key' => 'from-params'],
+                ];
+            }
+        };
+
+        $notification = $notificationImplementation::fromArray([
+            'jsonrpc' => '2.0',
+            'method' => 'notifications/dummy',
+            'params' => [
+                '_meta' => ['key' => 'from-meta'],
+            ],
+        ]);
+
+        $expected = [
+            'jsonrpc' => '2.0',
+            'method' => 'notifications/dummy',
+            'params' => [
+                '_meta' => ['key' => 'from-params'],
+            ],
+        ];
+
+        $this->assertSame($expected, $notification->jsonSerialize());
+    }
 }

--- a/tests/Unit/Schema/JsonRpc/RequestTest.php
+++ b/tests/Unit/Schema/JsonRpc/RequestTest.php
@@ -55,4 +55,41 @@ final class RequestTest extends TestCase
 
         $this->assertSame($expectedMeta, $notification->jsonSerialize());
     }
+
+    public function testMetaDoesNotOverrideMetaFromParams(): void
+    {
+        $requestImplementation = new class extends Request {
+            public static function getMethod(): string
+            {
+                return 'foo/bar';
+            }
+
+            public static function fromParams(?array $params): static
+            {
+                return new self();
+            }
+
+            protected function getParams(): array
+            {
+                return [
+                    '_meta' => ['key' => 'from-params'],
+                ];
+            }
+        };
+
+        $request = $requestImplementation::fromParams(null)
+            ->withId('12345')
+            ->withMeta(['key' => 'from-meta']);
+
+        $expected = [
+            'jsonrpc' => '2.0',
+            'id' => '12345',
+            'method' => 'foo/bar',
+            'params' => [
+                '_meta' => ['key' => 'from-params'],
+            ],
+        ];
+
+        $this->assertSame($expected, $request->jsonSerialize());
+    }
 }


### PR DESCRIPTION
The guard in `Request::jsonSerialize()` checked `$params['meta']` while the write targets `$params['_meta']`, so a `_meta` provided by the message class was silently overwritten by `withMeta()`.

Fixes the key in both `Request` and `Notification`, with a regression test each.
