### PR TITLE
[Docs] Add wordpress-mcp to PHP Libraries Using the MCP SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The full documentation is published at **[php.sdk.modelcontextprotocol.io](https
 - [api-platform/mcp](https://github.com/api-platform/mcp) — MCP integration for API Platform
 - [bnomei/kirby-mcp](https://github.com/bnomei/kirby-mcp) — MCP server for the Kirby CMS
 - [drupal/mcp_server](https://www.drupal.org/project/mcp_server) — MCP server for Drupal exposing configuration and entities as MCP elements
+- [Faneraiy14/wordpress-mcp](https://github.com/Faneraiy14/wordpress-mcp) — MCP server for WordPress, exposing site health, posts, and plugins as tools
 - [josbeir/cakephp-synapse](https://github.com/josbeir/cakephp-synapse) — CakePHP plugin exposing application functionality over MCP
 - [nette/mcp-inspector](https://github.com/nette/mcp-inspector) — MCP server for introspecting Nette applications
 - [symfony/ai-mate](https://github.com/symfony/ai-mate) — AI development assistant MCP server for Symfony projects


### PR DESCRIPTION
## Summary

Adds [Faneraiy14/wordpress-mcp](https://github.com/Faneraiy14/wordpress-mcp) to the "PHP Libraries Using the MCP SDK" list.

It's an MCP server for WordPress, built on `mcp/sdk` (^0.8), running as a WordPress plugin and serving MCP over the REST API at `/wp-json/wordpress-mcp/v1/mcp` - same pattern as the existing Drupal/CakePHP/Kirby entries in the list (native to its target CMS rather than a standalone server).

Four tools currently, all live-verified against a real WordPress install rather than mocked:

- `get_site_health` - runs WordPress's own Site Health checks, returns a critical/recommended/good summary
- `list_posts(limit, status)` - recent posts
- `update_post(post_id, title?, content?, status?)` - the one write tool, gated per-post by `current_user_can('edit_post', ...)`
- `list_plugins()` - installed plugins with active/inactive status

## Test plan

- [x] `composer install` + `vendor/bin/phpunit` - 7/7 passing (the pure formatter/summarizer logic; the WP-runtime glue itself needs a running WordPress to exercise)
- [x] Live-tested the full MCP handshake (`initialize` → session → `tools/call`) against a real local WordPress install with a real authenticated request, for all four tools