### PR TITLE
[Server][Capability] Defer loading into a custom registry

### DIFF
--- a/src/Capability/Registry.php
+++ b/src/Capability/Registry.php
@@ -11,6 +11,7 @@
 
 namespace Mcp\Capability;
 
+use Mcp\Capability\Registry\Loader\ChainLoader;
 use Mcp\Capability\Registry\Loader\LoaderInterface;
 use Mcp\Capability\Registry\PromptReference;
 use Mcp\Capability\Registry\ResourceReference;
@@ -69,7 +70,7 @@ final class Registry implements RegistryInterface
         private readonly ?EventDispatcherInterface $eventDispatcher = null,
         private readonly LoggerInterface $logger = new NullLogger(),
         private readonly NameValidator $nameValidator = new NameValidator(),
-        private readonly ?LoaderInterface $loader = null,
+        private ?LoaderInterface $loader = null,
     ) {
     }
 
@@ -112,6 +113,28 @@ final class Registry implements RegistryInterface
         } finally {
             $this->loading = false;
         }
+    }
+
+    /**
+     * Adopts $loader for the deferred load, so a registry the caller constructed can still load at
+     * first read instead of at build time. Chains behind a loader the constructor already took,
+     * but only when that loader is still owed its run: once it has already run, chaining would run
+     * it a second time — discovery would rescan — so $loader replaces it instead. Resetting $loaded
+     * is what makes the adopted loader actually run on the next read.
+     */
+    public function deferLoadingFrom(LoaderInterface $loader): void
+    {
+        $this->loader = null === $this->loader || $this->loaded ? $loader : new ChainLoader([$this->loader, $loader]);
+        $this->loaded = false;
+    }
+
+    /**
+     * True when nothing is registered yet. Reads the backing arrays directly, so unlike has*() it
+     * never triggers the loader.
+     */
+    public function isEmpty(): bool
+    {
+        return [] === $this->tools && [] === $this->resources && [] === $this->resourceTemplates && [] === $this->prompts;
     }
 
     public function registerTool(Tool $tool, callable|array|string $handler): ToolReference

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -522,8 +522,9 @@ final class Builder
      *
      * Lazy (the default) defers loading to the first registry read so a persistent runtime does not
      * freeze the registry to a source not yet ready at build time. Disable to load eagerly at build.
-     * A registry supplied via setRegistry() is always loaded eagerly; its own constructor loader,
-     * if it has one, still runs on the first read.
+     * A registry supplied via setRegistry() is deferred the same way, whatever it already holds is
+     * still advertised by capability detection. Either way its own constructor loader, if it has
+     * one, still runs on the first read.
      */
     public function setLazyLoading(bool $lazyLoading = true): self
     {
@@ -1043,17 +1044,25 @@ final class Builder
         }
 
         $chainLoader = new ChainLoader($loaders);
+        $hasPreloadedElements = false;
 
         if ($this->hasCustomRegistry) {
-            // Builder can't inject the loader into an already-constructed instance, so load it eagerly.
-            // Via loadFrom(), which suppresses the change events the load would otherwise dispatch.
             $registry = $this->registry;
-            if ($registry instanceof Registry) {
-                $registry->loadFrom($chainLoader);
+
+            if ($this->lazyLoading && $registry instanceof Registry) {
+                $hasPreloadedElements = !$registry->isEmpty();
+                $registry->deferLoadingFrom($chainLoader);
+                $eagerlyLoaded = false;
             } else {
-                $chainLoader->load($registry);
+                // A foreign RegistryInterface cannot be deferred into, so it is loaded eagerly here.
+                // loadFrom() suppresses the change events the load would otherwise dispatch.
+                if ($registry instanceof Registry) {
+                    $registry->loadFrom($chainLoader);
+                } else {
+                    $chainLoader->load($registry);
+                }
+                $eagerlyLoaded = true;
             }
-            $eagerlyLoaded = true;
         } else {
             $registry = new Registry($eventDispatcher, $logger, loader: $chainLoader);
             if (!$this->lazyLoading) {
@@ -1064,7 +1073,7 @@ final class Builder
 
         $messageFactory = MessageFactory::make(additional: $this->extensionMessages);
 
-        $capabilities = $this->serverCapabilities ?? $this->detectCapabilities($registry, $eagerlyLoaded, $eventDispatcher);
+        $capabilities = $this->serverCapabilities ?? $this->detectCapabilities($registry, $eagerlyLoaded, $eventDispatcher, $hasPreloadedElements);
 
         // Extensions enabled via enableExtension() are folded into caller-supplied
         // capabilities too, so setCapabilities() does not silently drop them.
@@ -1118,9 +1127,11 @@ final class Builder
     /**
      * When loaded, capabilities are read from the registry. When deferred, reading it would force
      * the load, so they are advertised from the configured sources instead — opaque sources (custom
-     * loaders, discovery) advertise all kinds, and over-advertising is harmless per MCP semantics.
+     * loaders, discovery) advertise all kinds, and over-advertising is harmless per MCP semantics. A
+     * custom registry deferred while already holding elements ($hasPreloadedElements) counts as an
+     * opaque source too, for the same reason: reading it would force the load it is deferred to avoid.
      */
-    private function detectCapabilities(RegistryInterface $registry, bool $eagerlyLoaded, ?EventDispatcherInterface $eventDispatcher): ServerCapabilities
+    private function detectCapabilities(RegistryInterface $registry, bool $eagerlyLoaded, ?EventDispatcherInterface $eventDispatcher, bool $hasPreloadedElements): ServerCapabilities
     {
         // Without a dispatcher the registry announces nothing, so there is no
         // list-changed notification to advertise.
@@ -1143,7 +1154,7 @@ final class Builder
             );
         }
 
-        $hasOpaqueSources = [] !== $this->loaders || null !== $this->discoveryBasePath;
+        $hasOpaqueSources = [] !== $this->loaders || null !== $this->discoveryBasePath || $hasPreloadedElements;
         $hasResources = [] !== $this->resources || [] !== $this->explicitResources || [] !== $this->resourceTemplates || [] !== $this->explicitResourceTemplates || $hasOpaqueSources;
 
         return new ServerCapabilities(

--- a/tests/Unit/Capability/RegistryTest.php
+++ b/tests/Unit/Capability/RegistryTest.php
@@ -853,6 +853,104 @@ class RegistryTest extends TestCase
         $this->assertFalse($registry->hasTools());
     }
 
+    public function testDeferLoadingFromDoesNotRunUntilFirstRead(): void
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader->expects($this->never())->method('load');
+
+        $registry = new Registry(null, $this->logger);
+        $registry->deferLoadingFrom($loader);
+    }
+
+    public function testDeferLoadingFromRunsOnFirstReadAndPopulatesTheRegistry(): void
+    {
+        $registry = new Registry(null, $this->logger);
+        $registry->deferLoadingFrom($this->toolLoader($this->createValidTool('deferred')));
+
+        $this->assertTrue($registry->hasTools());
+        $this->assertArrayHasKey('deferred', $registry->getTools()->references);
+    }
+
+    public function testDeferLoadingFromRunsTheLoaderExactlyOnceAcrossManyReads(): void
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader->expects($this->once())->method('load');
+
+        $registry = new Registry(null, $this->logger);
+        $registry->deferLoadingFrom($loader);
+
+        $registry->hasTools();
+        $registry->getTools();
+        $registry->hasResources();
+    }
+
+    public function testDeferLoadingFromChainsBehindTheConstructorLoader(): void
+    {
+        // Both register 'shared'; last-write-wins proves the run order, since
+        // ChainLoader lets the later loader overwrite the earlier one's registration.
+        $constructorLoader = $this->toolLoader($this->createValidTool('shared', null, 'from constructor'));
+        $deferredLoader = $this->toolLoader($this->createValidTool('shared', null, 'from deferred'));
+
+        $registry = new Registry(null, $this->logger, loader: $constructorLoader);
+        $registry->deferLoadingFrom($deferredLoader);
+
+        $tools = $registry->getTools()->references;
+
+        $this->assertArrayHasKey('shared', $tools);
+        $this->assertSame('from deferred', $tools['shared']->description);
+    }
+
+    public function testDeferLoadingFromRunsTheAdoptedLoaderAfterTheConstructorLoaderAlreadyRan(): void
+    {
+        // A read before deferLoadingFrom() runs the constructor loader and sets $loaded, the bug
+        // this covers: the adopted loader was then stored but never run because load() returned on
+        // $loaded before consulting it.
+        $constructorLoader = new class implements LoaderInterface {
+            public int $calls = 0;
+
+            public function load(RegistryInterface $registry): void
+            {
+                ++$this->calls;
+            }
+        };
+        $adoptedLoader = new class implements LoaderInterface {
+            public int $calls = 0;
+
+            public function load(RegistryInterface $registry): void
+            {
+                ++$this->calls;
+            }
+        };
+
+        $registry = new Registry(null, $this->logger, loader: $constructorLoader);
+        $registry->hasTools();
+
+        $registry->deferLoadingFrom($adoptedLoader);
+        $registry->hasTools();
+        $registry->hasResources();
+
+        $this->assertSame(1, $constructorLoader->calls);
+        $this->assertSame(1, $adoptedLoader->calls);
+    }
+
+    public function testIsEmptyIsTrueForAFreshRegistryAndDoesNotTriggerTheLoader(): void
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader->expects($this->never())->method('load');
+
+        $registry = new Registry(null, $this->logger, loader: $loader);
+
+        $this->assertTrue($registry->isEmpty());
+    }
+
+    public function testIsEmptyIsFalseAfterRegisterTool(): void
+    {
+        $registry = new Registry(null, $this->logger);
+        $registry->registerTool($this->createValidTool('registered'), 'handler');
+
+        $this->assertFalse($registry->isEmpty());
+    }
+
     private function toolLoader(Tool $tool): LoaderInterface
     {
         return new class($tool) implements LoaderInterface {
@@ -907,7 +1005,7 @@ class RegistryTest extends TestCase
         $this->assertNull($toolRef->extractStructuredContent($result, ProtocolVersion::V2025_11_25));
     }
 
-    private function createValidTool(string $name, ?array $outputSchema = null): Tool
+    private function createValidTool(string $name, ?array $outputSchema = null, ?string $description = null): Tool
     {
         return new Tool(
             name: $name,
@@ -919,7 +1017,7 @@ class RegistryTest extends TestCase
                 ],
                 'required' => null,
             ],
-            description: "Test tool: {$name}",
+            description: $description ?? "Test tool: {$name}",
             annotations: null,
             icons: null,
             meta: null,

--- a/tests/Unit/Server/BuilderTest.php
+++ b/tests/Unit/Server/BuilderTest.php
@@ -443,6 +443,92 @@ final class BuilderTest extends TestCase
             ->addTool(static fn (): string => 'ok', 'alpha')
             ->build();
     }
+
+    #[TestDox('An empty custom registry with lazy loading defers its configured loader past build(), running it on the first registry read')]
+    public function testEmptyCustomRegistryDefersLoaderPastBuild(): void
+    {
+        $loader = new class implements LoaderInterface {
+            public int $calls = 0;
+
+            public function load(RegistryInterface $registry): void
+            {
+                ++$this->calls;
+            }
+        };
+
+        $registry = new Registry();
+
+        Server::builder()
+            ->setRegistry($registry)
+            ->addLoader($loader)
+            ->build();
+
+        $this->assertSame(0, $loader->calls);
+
+        $registry->hasTools();
+
+        $this->assertSame(1, $loader->calls);
+    }
+
+    #[TestDox('An empty custom registry with lazy loading advertises tools from the configured loader without forcing a load')]
+    public function testEmptyCustomRegistryAdvertisesToolsFromConfiguredLoaderWithoutLoading(): void
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader->expects($this->never())->method('load');
+
+        $registry = new Registry();
+
+        $server = Server::builder()
+            ->setServerInfo('test', '1.0.0')
+            ->setRegistry($registry)
+            ->addLoader($loader)
+            ->build();
+
+        $capabilities = $this->extractServerCapabilities($server);
+
+        $this->assertTrue($capabilities->tools);
+    }
+
+    #[TestDox('setLazyLoading(false) with an empty custom registry loads it eagerly during build()')]
+    public function testSetLazyLoadingFalseWithEmptyCustomRegistryLoadsEagerly(): void
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader->expects($this->once())->method('load');
+
+        $registry = new Registry();
+
+        Server::builder()
+            ->setRegistry($registry)
+            ->setLazyLoading(false)
+            ->addLoader($loader)
+            ->build();
+    }
+
+    #[TestDox('A pre-populated custom registry with lazy loading also defers its configured loader past build(), instead of the old isEmpty() gate loading it eagerly')]
+    public function testPreloadedCustomRegistryDefersLoaderPastBuild(): void
+    {
+        $loader = new class implements LoaderInterface {
+            public int $calls = 0;
+
+            public function load(RegistryInterface $registry): void
+            {
+                ++$this->calls;
+            }
+        };
+
+        $registry = new Registry();
+        $registry->registerTool(
+            new Tool(name: 'preloaded_tool', title: null, inputSchema: ['type' => 'object', 'properties' => [], 'required' => null], description: 'A preloaded tool', annotations: null),
+            static fn (): string => 'result',
+        );
+
+        Server::builder()
+            ->setRegistry($registry)
+            ->addLoader($loader)
+            ->build();
+
+        $this->assertSame(0, $loader->calls);
+    }
 }
 
 /**


### PR DESCRIPTION
Follow-up to #389, which made loading lazy for the registry the builder constructs. This does the same for one the caller supplies.

### The gap

`setLazyLoading()` defaults to `true`, but it never applied to a registry passed through `setRegistry()`. `resolve()` ran the chain loader itself and set `$eagerlyLoaded = true`, because the builder could not hand a loader to an instance it did not construct.

Two consequences under a persistent runtime (FrankenPHP worker mode, Laravel Octane):

1. The loaders run once, at build. If a source is not ready yet — a cold metadata cache — the registry is frozen empty for the whole process and `tools/list` keeps returning `[]`.
2. `detectCapabilities()` takes the `$eagerlyLoaded === true` branch and reads `hasTools()` off that cold registry, so the server can advertise `tools: false`. A client that respects capabilities then never calls `tools/list` at all, which the first point alone would not cause.

Not hypothetical: `symfony/mcp-bundle` registers its registry as a `Registry` service and calls `setRegistry()` on it, and API Platform does the same on its Laravel side. Every consumer that supplies its own registry service is affected, and API Platform carried a custom `tools/list` handler purely to work around it.

### The change

`Registry::deferLoadingFrom()` adopts a loader after construction, so the builder can defer instead of loading eagerly and report `$eagerlyLoaded = false`.

It chains behind a loader the constructor took while that one is still owed its run, and **replaces** it once it has already run — chaining there would run it twice and discovery would rescan. Resetting `loaded` is what lets the adopted loader run on the next read; without it a registry that was read before `build()` (a warmup, a debug command, a health check) would keep the deferred loader forever unrun, which is the same cold-source bug this PR exists to fix.

Deferral is deliberately **not** conditional on the registry being empty. Gating it that way would mean a caller who hand-registers a single element before `setRegistry()` silently falls back to eager loading and gets the bug back. Instead `Registry::isEmpty()` — which reads the element arrays directly and so does not trigger the loader while answering — tells `detectCapabilities()` that a deferred registry already holds elements, and it advertises them as one more opaque source.

That over-advertises a registry holding only one kind. Per the doctrine already stated in `detectCapabilities()`'s docblock, over-advertising is harmless under MCP semantics, and it is already how custom loaders and discovery are treated.

Two guards remain:

- `$this->lazyLoading` — `setLazyLoading(false)` must still mean eager for a supplied registry.
- `$registry instanceof Registry` — a foreign `RegistryInterface` cannot be deferred into and keeps the eager path, as `testAThirdPartyRegistryIsStillLoadedThroughThePlainLoader` pins.

### Notes

- `RegistryInterface` is untouched. Both new methods live on `Registry`, which is what the builder already type-checks for `loadFrom()`; adding them to the interface would break third-party implementations.
- Event suppression from #490 is preserved — the deferred path runs through `load()`, which delegates to `loadFrom()`.
- `$loader` loses `readonly` (still private) so it can be replaced.
- No `CHANGELOG.md` entry, matching #490.

### Tests

`RegistryTest`: `deferLoadingFrom()` does not run until the first read, runs exactly once across many reads, chains behind a constructor loader, and — the regression guard for the `loaded` reset — runs the adopted loader even when the constructor loader had already run. `isEmpty()` is true for a fresh registry without triggering a configured loader, and false after `registerTool()`.

`BuilderTest`: an empty custom registry defers its loader past `build()` and runs it on the first read; a pre-populated one defers too; the deferred setup advertises `tools: true` while the loader is asserted never to run; `setLazyLoading(false)` still loads eagerly. `testBuildAdvertisesToolsForPreloadedCustomRegistry` passes unchanged.
