### PR TITLE
[README] Show conformance badges in a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,9 @@
 # MCP PHP SDK
 
-<div align="center">
-
 [![Latest Version](https://img.shields.io/packagist/v/mcp/sdk.svg)](https://packagist.org/packages/mcp/sdk)
 [![CI](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/pipeline.yaml/badge.svg)](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/pipeline.yaml)
 [![PHP Version](https://img.shields.io/packagist/php-v/mcp/sdk.svg)](https://packagist.org/packages/mcp/sdk)
 [![License](https://img.shields.io/packagist/l/mcp/sdk.svg)](LICENSE)
-
-[![Server Conformance 2025-11-25](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/modelcontextprotocol/php-sdk/badges/server-conformance-2025-11-25.json)](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/conformance-weekly.yaml)
-[![Client Conformance 2025-11-25](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/modelcontextprotocol/php-sdk/badges/client-conformance-2025-11-25.json)](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/conformance-weekly.yaml)
-[![Server Conformance 2026-07-28](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/modelcontextprotocol/php-sdk/badges/server-conformance-2026-07-28.json)](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/conformance-weekly.yaml)
-[![Client Conformance 2026-07-28](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/modelcontextprotocol/php-sdk/badges/client-conformance-2026-07-28.json)](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/conformance-weekly.yaml)
-
-</div>
 
 The official PHP SDK for the Model Context Protocol (MCP). It provides a framework-agnostic API for implementing MCP
 servers and clients in PHP — tools, resources, prompts, STDIO and HTTP transports, sessions, authorization, and both
@@ -24,6 +15,17 @@ development practices and standards from the Symfony project, including [Coding 
 
 Until the first major release, this SDK is considered [experimental](https://symfony.com/doc/current/contributing/code/experimental.html), please see the [roadmap](./ROADMAP.md) for
 planned next steps and features.
+
+## Protocol Conformance
+
+Measured weekly against the [MCP Conformance Test Framework](https://github.com/modelcontextprotocol/conformance),
+as passing checks out of total. The `2026-07-28` scores run against the framework's `alpha` releases, so they move as
+upstream publishes new scenarios.
+
+| Revision | Server | Client |
+|:--------:|:------:|:------:|
+| `2026-07-28` | [![Server conformance 2026-07-28](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/modelcontextprotocol/php-sdk/badges/server-conformance-2026-07-28.json)](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/conformance-weekly.yaml) | [![Client conformance 2026-07-28](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/modelcontextprotocol/php-sdk/badges/client-conformance-2026-07-28.json)](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/conformance-weekly.yaml) |
+| `2025-11-25` | [![Server conformance 2025-11-25](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/modelcontextprotocol/php-sdk/badges/server-conformance-2025-11-25.json)](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/conformance-weekly.yaml) | [![Client conformance 2025-11-25](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/modelcontextprotocol/php-sdk/badges/client-conformance-2025-11-25.json)](https://github.com/modelcontextprotocol/php-sdk/actions/workflows/conformance-weekly.yaml) |
 
 ## Installation
 

--- a/tests/Conformance/score.php
+++ b/tests/Conformance/score.php
@@ -16,11 +16,12 @@
  *   php score.php <server|client> <spec-version> [results-dir]
  *
  * The conformance CLI writes one `checks.json` per scenario into
- * `[results-dir]` (default `results`), relative to this file. A scenario
- * counts as passing when none of its checks has a FAILURE status; the badge
- * message is "<passed>/<total> (<pct>%)" and is written to
+ * `[results-dir]` (default `results`), relative to this file. Every check with
+ * a SUCCESS or FAILURE status counts towards the score; the badge message is
+ * "<passed>/<total> (<pct>%)" and is written to
  * `<suite>-conformance-<spec-version>.json`, so each revision gets its own
- * badge.
+ * badge. The badge is labelled "checks" only: the README renders the badges in
+ * a table whose row and column headers already name the revision and suite.
  */
 
 use Symfony\Component\Console\Command\Command;
@@ -92,7 +93,7 @@ require_once dirname(__DIR__, 2).'/vendor/autoload.php';
 
         $badge = [
             'schemaVersion' => 1,
-            'label' => sprintf('%s %s', $suite, $specVersion),
+            'label' => 'checks',
             'message' => $total > 0 ? sprintf('%d/%d (%d%%)', $passed, $total, $pct) : 'no data',
             'color' => match (true) {
                 0 === $total => 'lightgrey',
@@ -116,7 +117,7 @@ require_once dirname(__DIR__, 2).'/vendor/autoload.php';
             $io->listing($failures);
         }
 
-        $io->success(sprintf('%s: %s', $badge['label'], $badge['message']));
+        $io->success(sprintf('%s %s: %s', $suite, $specVersion, $badge['message']));
 
         return Command::SUCCESS;
     })


### PR DESCRIPTION
Replaces the stacked conformance badges with a `Revision | Server | Client` table in its own section above Installation, and drops the now-redundant label from the badge JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfxeUzTUQqih5iSZa81Vdv