### PR TITLE
[Docs] Add blank line before lists so they render

### DIFF
--- a/docs/advanced/events.md
+++ b/docs/advanced/events.md
@@ -35,6 +35,7 @@ The SDK dispatches 4 broad event types at the protocol level, allowing you to ob
 **Dispatched**: When any request is received from the client, before it's processed by handlers.
 
 **Properties**:
+
 - `getRequest(): Request` - The incoming request
 - `setRequest(Request $request): void` - Modify the request before processing
 - `getSession(): SessionInterface` - The current session
@@ -45,6 +46,7 @@ The SDK dispatches 4 broad event types at the protocol level, allowing you to ob
 **Dispatched**: When a successful response is ready to be sent to the client, after handler execution.
 
 **Properties**:
+
 - `getResponse(): Response` - The response being sent
 - `setResponse(Response $response): void` - Modify the response before sending
 - `getRequest(): Request` - The original request
@@ -56,6 +58,7 @@ The SDK dispatches 4 broad event types at the protocol level, allowing you to ob
 **Dispatched**: When an error occurs during request processing.
 
 **Properties**:
+
 - `getError(): Error` - The error being sent
 - `setError(Error $error): void` - Modify the error before sending
 - `getRequest(): Request` - The original request. Messages that fail to parse are rejected before this event, so a listener never sees them.
@@ -67,6 +70,7 @@ The SDK dispatches 4 broad event types at the protocol level, allowing you to ob
 **Dispatched**: When a notification is received from the client, before it's processed by handlers.
 
 **Properties**:
+
 - `getNotification(): Notification` - The incoming notification
 - `setNotification(Notification $notification): void` - Modify the notification before processing
 - `getSession(): SessionInterface` - The current session

--- a/docs/client/connecting.md
+++ b/docs/client/connecting.md
@@ -169,6 +169,7 @@ $client->connect($transport);
 ```
 
 The `connect()` method performs the MCP initialization handshake:
+
 1. Opens the transport connection
 2. Sends InitializeRequest with client capabilities
 3. Waits for InitializeResult from server

--- a/docs/client/transports.md
+++ b/docs/client/transports.md
@@ -18,6 +18,7 @@ $transport = new StdioTransport(
 ```
 
 **Parameters:**
+
 - `command` (string): The command to execute
 - `args` (array): Command arguments
 - `cwd` (string|null): Working directory for the process
@@ -39,6 +40,7 @@ $transport = new HttpTransport(
 ```
 
 **Parameters:**
+
 - `endpoint` (string): The MCP server URL
 - `headers` (array): Additional HTTP headers
 - `httpClient` (ClientInterface|null): PSR-18 HTTP client (auto-discovered)
@@ -50,6 +52,7 @@ $transport = new HttpTransport(
 **PSR-18 Auto-Discovery:**
 
 The transport automatically discovers PSR-18 HTTP clients from:
+
 - `php-http/guzzle7-adapter`
 - `php-http/curl-client`
 - `symfony/http-client`

--- a/docs/run/server-builder.md
+++ b/docs/run/server-builder.md
@@ -54,6 +54,7 @@ $server = Server::builder()
 ```
 
 **Parameters:**
+
 - `$name` (string): The server name
 - `$version` (string): Version string (semantic versioning recommended)
 - `$description` (string|null): Optional description
@@ -152,6 +153,7 @@ $server = Server::builder()
 ```
 
 **Parameters:**
+
 - `$basePath` (string): Base directory for discovery (typically `__DIR__`)
 - `$scanDirs` (array): Directories to recursively scan for `#[McpTool]`, `#[McpResource]`, etc. All subdirectories are included. (default: `['.', 'src']`)
 - `$excludeDirs` (array): Directory names to exclude **within** the scanned directories during recursive scanning
@@ -189,6 +191,7 @@ $server = Server::builder()
 ```
 
 **How `excludeDirs` works:**
+
 - If scanning `src/` and there's `src/vendor/`, it will be excluded
 - If scanning `lib/` and there's `lib/tests/`, it will be excluded
 - But if `vendor/` and `tests/` are at the same level as `src/`, they're not scanned anyway (not in `scanDirs`)
@@ -217,6 +220,7 @@ $server = Server::builder()
 ```
 
 **Basic Container Features:**
+
 - Supports constructor auto-wiring for classes with parameterless constructors
 - Resolves dependencies where all parameters are type-hinted classes/interfaces known to the container
 - Supports parameters with default values

--- a/docs/run/sessions.md
+++ b/docs/run/sessions.md
@@ -74,6 +74,7 @@ $server = Server::builder()
 ```
 
 **Parameters:**
+
 - `$gcProbability` (int): The numerator of the GC probability fraction (default: `1`). Set to `0` to disable GC.
 - `$gcDivisor` (int): The denominator of the GC probability fraction (default: `100`). Must be >= 1.
 
@@ -81,6 +82,7 @@ $server = Server::builder()
 > the `gcProbability` and `gcDivisor` settings are ignored — you control GC behavior in your own implementation.
 
 **Available Session Stores:**
+
 - `InMemorySessionStore`: Fast in-memory storage (default)
 - `FileSessionStore`: Persistent file-based storage
 - `Psr16SessionStore`: PSR-16 compliant cache-based storage

--- a/docs/servers/completions.md
+++ b/docs/servers/completions.md
@@ -87,6 +87,7 @@ public function getUserProfile(
 ```
 
 **Provider Resolution:**
+
 - **Class strings** (`Provider::class`) → Resolved from PSR-11 container
 - **Instances** (`new Provider()`) → Used directly
 - **Values** (`['a', 'b']`) → Wrapped in `ListCompletionProvider`

--- a/docs/servers/prompts.md
+++ b/docs/servers/prompts.md
@@ -100,6 +100,7 @@ makes the prompt handler throw.
 ### Error Handling
 
 Prompt handlers can throw any exception, but the type determines how it's handled:
+
 - **`PromptGetException`**: Converted to JSON-RPC error response with the actual exception message
 - **Any other exception**: Converted to JSON-RPC error response, but with a generic error message
 

--- a/docs/servers/registration.md
+++ b/docs/servers/registration.md
@@ -6,6 +6,7 @@ registry somehow. There are three ways to get it there, and they mix freely.
 ## Attribute-Based Discovery
 
 **Advantages:**
+
 - Declarative and readable
 - Automatic parameter inference
 - DocBlock integration
@@ -25,6 +26,7 @@ Register MCP elements programmatically without using attributes. The handler is 
 any PHP callable.
 
 **Advantages:**
+
 - Fine-grained control
 - Runtime configuration
 - Conditional registration


### PR DESCRIPTION
With `sane_lists` enabled, a list can't interrupt a paragraph — so lists directly following a `**Bold:**` intro line rendered as flat text (e.g. Parameters / Available Session Stores on the Sessions page). Adds the required blank line in 18 spots across 8 pages.